### PR TITLE
refactor: unify aggregation optimize and pre_leave pipelines

### DIFF
--- a/crates/compiler/src/aggregation/avg.rs
+++ b/crates/compiler/src/aggregation/avg.rs
@@ -9,7 +9,10 @@ use parser::DataType;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use super::common::{key_from_row, key_pattern, row_pattern, tuple};
+use super::common::{
+    aggregation_optimize_pipeline, aggregation_pre_leave_pipeline, key_pattern, row_pattern, tuple,
+    ThresholdCmp,
+};
 
 /// `Avg{I32,I64}::new(x<agg_pos>)` expression.
 fn avg_new(agg_pos: usize, agg_type: DataType) -> TokenStream {
@@ -50,52 +53,19 @@ fn avg_result_from_key(arity: usize, agg_pos: usize) -> TokenStream {
 
 /// Generates the Avg-semiring optimized aggregation pipeline.
 pub fn aggregation_avg_optimize(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = row_pattern(arity);
-    let key_expr = key_from_row(arity, agg_pos);
-    let avg_expr = avg_new(agg_pos, agg_type);
-    let key_pat = key_pattern(arity);
-    let result = avg_result_from_key(arity, agg_pos);
-
-    quote! {
-        // Phase 1: (row, time, _) → (key, time, Avg::new(value))
-        .inner
-        .map(move |(#row_pat, t, _)| {
-            let key = #key_expr;
-            (key, t, #avg_expr)
-        })
-        .as_collection()
-
-        // Phase 2: threshold_semigroup with Avg semiring
-        .threshold_semigroup(|_k, &new_avg, current_avg| {
-            match current_avg {
-                Some(current) if new_avg != *current => Some(new_avg),
-                Some(_) => None,
-                None if !new_avg.is_zero() => Some(new_avg),
-                None => None,
-            }
-        })
-
-        // Phase 3: (key, time, Avg{sum, count}) → (full_row, time, SEMIRING_ONE)
-        .inner
-        .map(move |(#key_pat, t, agg_val)| {
-            let row = #result;
-            (row, t, SEMIRING_ONE)
-        })
-        .as_collection()
-    }
+    aggregation_optimize_pipeline(
+        arity,
+        agg_pos,
+        row_pattern(arity),
+        avg_new(agg_pos, agg_type),
+        ThresholdCmp::Ne,
+        avg_result_from_key(arity, agg_pos),
+    )
 }
 
 /// Generates the pre-leave conversion for avg-aggregated recursive relations.
 pub fn aggregation_avg_pre_leave(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = row_pattern(arity);
-    let key_expr = key_from_row(arity, agg_pos);
-    let avg_expr = avg_new(agg_pos, agg_type);
-
-    quote! {
-        .inner
-        .map(move |(#row_pat, t, _)| ((#key_expr), t, #avg_expr))
-        .as_collection()
-    }
+    aggregation_pre_leave_pipeline(arity, agg_pos, row_pattern(arity), avg_new(agg_pos, agg_type))
 }
 
 /// Post-leave conversion for avg-aggregated recursive relations.

--- a/crates/compiler/src/aggregation/common.rs
+++ b/crates/compiler/src/aggregation/common.rs
@@ -83,6 +83,114 @@ pub(super) fn result_from_key(arity: usize, agg_pos: usize) -> TokenStream {
 }
 
 // =============================================================================
+// Shared semiring-optimised pipeline helpers
+// =============================================================================
+
+/// Threshold comparison strategy for the semiring optimisation pipeline.
+///
+/// Determines when a consolidated semiring value is re-emitted.
+pub(super) enum ThresholdCmp {
+    /// Emit when the new value is strictly less than the current (`min`).
+    Lt,
+    /// Emit when the new value is strictly greater than the current (`max`).
+    Gt,
+    /// Emit when the new value differs from the current (`sum`, `count`, `avg`).
+    Ne,
+}
+
+/// Generates the 3-phase semiring-optimised aggregation pipeline.
+///
+/// 1. **Phase 1** – Rewrite each `(row, time, _diff)` into `(key, time, Semiring::new(value))`
+/// 2. **Phase 2** – `threshold_semigroup` with the semiring; emits only when the
+///    consolidated value satisfies the comparison predicate.
+/// 3. **Phase 3** – Convert back: `(key, time, SemiringVal)` → `(full_row, time, SEMIRING_ONE)`
+///
+/// `phase3_result` controls how the aggregated value is extracted:
+/// use `result_from_key` (`.value`) for min/max/sum/count, or
+/// `avg_result_from_key` (`.avg()`) for avg.
+pub(super) fn aggregation_optimize_pipeline(
+    arity: usize,
+    agg_pos: usize,
+    row_pat: TokenStream,
+    semiring_expr: TokenStream,
+    cmp: ThresholdCmp,
+    phase3_result: TokenStream,
+) -> TokenStream {
+    let key_expr = key_from_row(arity, agg_pos);
+    let key_pat = key_pattern(arity);
+
+    let threshold = match cmp {
+        ThresholdCmp::Lt => quote! {
+            .threshold_semigroup(|_k, &new_val, current_val| {
+                match current_val {
+                    Some(current) if new_val < *current => Some(new_val),
+                    Some(_) => None,
+                    None if !new_val.is_zero() => Some(new_val),
+                    None => None,
+                }
+            })
+        },
+        ThresholdCmp::Gt => quote! {
+            .threshold_semigroup(|_k, &new_val, current_val| {
+                match current_val {
+                    Some(current) if new_val > *current => Some(new_val),
+                    Some(_) => None,
+                    None if !new_val.is_zero() => Some(new_val),
+                    None => None,
+                }
+            })
+        },
+        ThresholdCmp::Ne => quote! {
+            .threshold_semigroup(|_k, &new_val, current_val| {
+                match current_val {
+                    Some(current) if new_val != *current => Some(new_val),
+                    Some(_) => None,
+                    None if !new_val.is_zero() => Some(new_val),
+                    None => None,
+                }
+            })
+        },
+    };
+
+    quote! {
+        .inner
+        .map(move |(#row_pat, t, _)| {
+            let key = #key_expr;
+            (key, t, #semiring_expr)
+        })
+        .as_collection()
+
+        #threshold
+
+        .inner
+        .map(move |(#key_pat, t, agg_val)| {
+            let row = #phase3_result;
+            (row, t, SEMIRING_ONE)
+        })
+        .as_collection()
+    }
+}
+
+/// Generates the pre-leave conversion for semiring-optimised recursive relations.
+///
+/// Converts `(row, time, Present)` → `((key,), time, Semiring::new(value))` so
+/// that `leave()` carries semiring diffs across iterations.
+pub(super) fn aggregation_pre_leave_pipeline(
+    arity: usize,
+    agg_pos: usize,
+    row_pat: TokenStream,
+    semiring_expr: TokenStream,
+) -> TokenStream {
+    let key_expr = key_from_row(arity, agg_pos);
+
+    quote! {
+        .inner
+        .map(move |(#row_pat, t, _)| ((#key_expr), t, #semiring_expr))
+        .as_collection()
+    }
+}
+
+// =============================================================================
 // Semiring-optimised post-leave (shared by min / max / sum / avg)
 // =============================================================================
 

--- a/crates/compiler/src/aggregation/count.rs
+++ b/crates/compiler/src/aggregation/count.rs
@@ -9,7 +9,9 @@ use parser::DataType;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use super::common::{key_from_row, key_pattern, result_from_key};
+use super::common::{
+    aggregation_optimize_pipeline, aggregation_pre_leave_pipeline, result_from_key, ThresholdCmp,
+};
 
 /// Row destructuring pattern with `_` at the aggregated position (count ignores the value).
 fn count_row_pattern(arity: usize, agg_pos: usize) -> TokenStream {
@@ -49,61 +51,27 @@ fn count_one(agg_type: DataType) -> TokenStream {
 }
 
 /// Generates the Count-semiring optimized aggregation pipeline.
-///
-/// Same structure as sum, but Phase 1 maps every tuple to `Sum::new(1)` instead
-/// of extracting a field value.
 pub fn aggregation_count_optimize(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = count_row_pattern(arity, agg_pos);
-    let key_expr = key_from_row(arity, agg_pos);
-    let one_expr = count_one(agg_type);
-    let key_pat = key_pattern(arity);
-    let result = result_from_key(arity, agg_pos);
-
-    quote! {
-        // Phase 1: (row, time, _) → (key, time, Sum::new(1))
-        .inner
-        .map(move |(#row_pat, t, _)| {
-            let key = #key_expr;
-            (key, t, #one_expr)
-        })
-        .as_collection()
-
-        // Phase 2: threshold_semigroup — emits when count changes
-        .threshold_semigroup(|_k, &new_count, current_count| {
-            match current_count {
-                Some(current) if new_count != *current => Some(new_count),
-                Some(_) => None,
-                None if !new_count.is_zero() => Some(new_count),
-                None => None,
-            }
-        })
-
-        // Phase 3: (key, time, Sum{value}) → (full_row, time, SEMIRING_ONE)
-        .inner
-        .map(move |(#key_pat, t, agg_val)| {
-            let row = #result;
-            (row, t, SEMIRING_ONE)
-        })
-        .as_collection()
-    }
+    aggregation_optimize_pipeline(
+        arity,
+        agg_pos,
+        count_row_pattern(arity, agg_pos),
+        count_one(agg_type),
+        ThresholdCmp::Ne,
+        result_from_key(arity, agg_pos),
+    )
 }
 
 /// Generates the pre-leave conversion for count-aggregated recursive relations.
-///
-/// Converts `(row, time, Present)` → `((key,), time, Sum::new(1))` so that
-/// `leave()` carries count diffs, enabling cross-iteration count via consolidation.
 pub fn aggregation_count_pre_leave(
     arity: usize,
     agg_pos: usize,
     agg_type: DataType,
 ) -> TokenStream {
-    let row_pat = count_row_pattern(arity, agg_pos);
-    let key_expr = key_from_row(arity, agg_pos);
-    let one_expr = count_one(agg_type);
-
-    quote! {
-        .inner
-        .map(move |(#row_pat, t, _)| ((#key_expr), t, #one_expr))
-        .as_collection()
-    }
+    aggregation_pre_leave_pipeline(
+        arity,
+        agg_pos,
+        count_row_pattern(arity, agg_pos),
+        count_one(agg_type),
+    )
 }

--- a/crates/compiler/src/aggregation/max.rs
+++ b/crates/compiler/src/aggregation/max.rs
@@ -10,7 +10,10 @@ use parser::DataType;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use super::common::{key_from_row, key_pattern, result_from_key, row_pattern};
+use super::common::{
+    aggregation_optimize_pipeline, aggregation_pre_leave_pipeline, result_from_key, row_pattern,
+    ThresholdCmp,
+};
 
 /// `Max{I32,I64}::new(x<agg_pos>)` expression.
 fn max_new(agg_pos: usize, agg_type: DataType) -> TokenStream {
@@ -31,57 +34,18 @@ fn max_new(agg_pos: usize, agg_type: DataType) -> TokenStream {
 }
 
 /// Generates the Max-semiring optimized aggregation pipeline.
-///
-/// Identical structure to `aggregation_min_optimize` but the threshold compares
-/// with `>` (emits when the running maximum increases).
 pub fn aggregation_max_optimize(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = row_pattern(arity);
-    let key_expr = key_from_row(arity, agg_pos);
-    let max_expr = max_new(agg_pos, agg_type);
-    let key_pat = key_pattern(arity);
-    let result = result_from_key(arity, agg_pos);
-
-    quote! {
-        // Phase 1: (row, time, _) → (key, time, Max::new(value))
-        .inner
-        .map(move |(#row_pat, t, _)| {
-            let key = #key_expr;
-            (key, t, #max_expr)
-        })
-        .as_collection()
-
-        // Phase 2: threshold_semigroup with Max semiring
-        .threshold_semigroup(|_k, &new_max, current_max| {
-            match current_max {
-                Some(current) if new_max > *current => Some(new_max),
-                Some(_) => None,
-                None if !new_max.is_zero() => Some(new_max),
-                None => None,
-            }
-        })
-
-        // Phase 3: (key, time, Max{value}) → (full_row, time, SEMIRING_ONE)
-        .inner
-        .map(move |(#key_pat, t, agg_val)| {
-            let row = #result;
-            (row, t, SEMIRING_ONE)
-        })
-        .as_collection()
-    }
+    aggregation_optimize_pipeline(
+        arity,
+        agg_pos,
+        row_pattern(arity),
+        max_new(agg_pos, agg_type),
+        ThresholdCmp::Gt,
+        result_from_key(arity, agg_pos),
+    )
 }
 
 /// Generates the pre-leave conversion for max-aggregated recursive relations.
-///
-/// Converts `(row, time, Present)` → `((key,), time, Max::new(value))` so that
-/// `leave()` carries MaxI32 diffs, enabling cross-iteration max via consolidation.
 pub fn aggregation_max_pre_leave(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = row_pattern(arity);
-    let key_expr = key_from_row(arity, agg_pos);
-    let max_expr = max_new(agg_pos, agg_type);
-
-    quote! {
-        .inner
-        .map(move |(#row_pat, t, _)| ((#key_expr), t, #max_expr))
-        .as_collection()
-    }
+    aggregation_pre_leave_pipeline(arity, agg_pos, row_pattern(arity), max_new(agg_pos, agg_type))
 }

--- a/crates/compiler/src/aggregation/min.rs
+++ b/crates/compiler/src/aggregation/min.rs
@@ -8,7 +8,10 @@ use parser::DataType;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use super::common::{key_from_row, key_pattern, result_from_key, row_pattern};
+use super::common::{
+    aggregation_optimize_pipeline, aggregation_pre_leave_pipeline, result_from_key, row_pattern,
+    ThresholdCmp,
+};
 
 /// `Min{I32,I64}::new(x<agg_pos>)` expression.
 fn min_new(agg_pos: usize, agg_type: DataType) -> TokenStream {
@@ -28,65 +31,19 @@ fn min_new(agg_pos: usize, agg_type: DataType) -> TokenStream {
     }
 }
 
-/// Generates the Min-semiring optimized aggregation pipeline as a single `TokenStream`.
-///
-/// Instead of `map(row_chop) → reduce_core(min) → as_collection(merge_kv)`,
-/// this produces a 3-phase pipeline that encodes `min` in the diff position:
-///
-/// 1. **Phase 1** – Rewrite each `(row, time, _diff)` into `(key, time, Min::new(value))`
-/// 2. **Phase 2** – `threshold_semigroup` with the `Min` semigroup; consolidation
-///    computes the running minimum, and the threshold only emits when it decreases.
-/// 3. **Phase 3** – Convert back: `(key, time, Min{value})` → `(full_row, time, SEMIRING_ONE)`
-///
-/// This replaces two arrangements (threshold + reduce_core) with one (threshold only).
+/// Generates the Min-semiring optimized aggregation pipeline.
 pub fn aggregation_min_optimize(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = row_pattern(arity);
-    let key_expr = key_from_row(arity, agg_pos);
-    let min_expr = min_new(agg_pos, agg_type);
-    let key_pat = key_pattern(arity);
-    let result = result_from_key(arity, agg_pos);
-
-    quote! {
-        // Phase 1: (row, time, _) → (key, time, Min::new(value))
-        .inner
-        .map(move |(#row_pat, t, _)| {
-            let key = #key_expr;
-            (key, t, #min_expr)
-        })
-        .as_collection()
-
-        // Phase 2: threshold_semigroup with Min semiring
-        .threshold_semigroup(|_k, &new_min, current_min| {
-            match current_min {
-                Some(current) if new_min < *current => Some(new_min),
-                Some(_) => None,
-                None if !new_min.is_zero() => Some(new_min),
-                None => None,
-            }
-        })
-
-        // Phase 3: (key, time, Min{value}) → (full_row, time, SEMIRING_ONE)
-        .inner
-        .map(move |(#key_pat, t, agg_val)| {
-            let row = #result;
-            (row, t, SEMIRING_ONE)
-        })
-        .as_collection()
-    }
+    aggregation_optimize_pipeline(
+        arity,
+        agg_pos,
+        row_pattern(arity),
+        min_new(agg_pos, agg_type),
+        ThresholdCmp::Lt,
+        result_from_key(arity, agg_pos),
+    )
 }
 
 /// Generates the pre-leave conversion for min-aggregated recursive relations.
-///
-/// Converts `(row, time, Present)` → `((key,), time, Min::new(value))` so that
-/// `leave()` carries MinI32 diffs, enabling cross-iteration min via consolidation.
 pub fn aggregation_min_pre_leave(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = row_pattern(arity);
-    let key_expr = key_from_row(arity, agg_pos);
-    let min_expr = min_new(agg_pos, agg_type);
-
-    quote! {
-        .inner
-        .map(move |(#row_pat, t, _)| ((#key_expr), t, #min_expr))
-        .as_collection()
-    }
+    aggregation_pre_leave_pipeline(arity, agg_pos, row_pattern(arity), min_new(agg_pos, agg_type))
 }

--- a/crates/compiler/src/aggregation/sum.rs
+++ b/crates/compiler/src/aggregation/sum.rs
@@ -11,7 +11,10 @@ use parser::DataType;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use super::common::{key_from_row, key_pattern, result_from_key, row_pattern};
+use super::common::{
+    aggregation_optimize_pipeline, aggregation_pre_leave_pipeline, result_from_key, row_pattern,
+    ThresholdCmp,
+};
 
 /// `Sum{I32,I64}::new(x<agg_pos>)` expression.
 fn sum_new(agg_pos: usize, agg_type: DataType) -> TokenStream {
@@ -32,57 +35,18 @@ fn sum_new(agg_pos: usize, agg_type: DataType) -> TokenStream {
 }
 
 /// Generates the Sum-semiring optimized aggregation pipeline.
-///
-/// Identical structure to `aggregation_min_optimize` / `aggregation_max_optimize`
-/// but the threshold emits whenever the accumulated sum changes (any non-equal update).
 pub fn aggregation_sum_optimize(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = row_pattern(arity);
-    let key_expr = key_from_row(arity, agg_pos);
-    let sum_expr = sum_new(agg_pos, agg_type);
-    let key_pat = key_pattern(arity);
-    let result = result_from_key(arity, agg_pos);
-
-    quote! {
-        // Phase 1: (row, time, _) → (key, time, Sum::new(value))
-        .inner
-        .map(move |(#row_pat, t, _)| {
-            let key = #key_expr;
-            (key, t, #sum_expr)
-        })
-        .as_collection()
-
-        // Phase 2: threshold_semigroup with Sum semiring
-        .threshold_semigroup(|_k, &new_sum, current_sum| {
-            match current_sum {
-                Some(current) if new_sum != *current => Some(new_sum),
-                Some(_) => None,
-                None if !new_sum.is_zero() => Some(new_sum),
-                None => None,
-            }
-        })
-
-        // Phase 3: (key, time, Sum{value}) → (full_row, time, SEMIRING_ONE)
-        .inner
-        .map(move |(#key_pat, t, agg_val)| {
-            let row = #result;
-            (row, t, SEMIRING_ONE)
-        })
-        .as_collection()
-    }
+    aggregation_optimize_pipeline(
+        arity,
+        agg_pos,
+        row_pattern(arity),
+        sum_new(agg_pos, agg_type),
+        ThresholdCmp::Ne,
+        result_from_key(arity, agg_pos),
+    )
 }
 
 /// Generates the pre-leave conversion for sum-aggregated recursive relations.
-///
-/// Converts `(row, time, Present)` → `((key,), time, Sum::new(value))` so that
-/// `leave()` carries SumI32/SumI64 diffs, enabling cross-iteration sum via consolidation.
 pub fn aggregation_sum_pre_leave(arity: usize, agg_pos: usize, agg_type: DataType) -> TokenStream {
-    let row_pat = row_pattern(arity);
-    let key_expr = key_from_row(arity, agg_pos);
-    let sum_expr = sum_new(agg_pos, agg_type);
-
-    quote! {
-        .inner
-        .map(move |(#row_pat, t, _)| ((#key_expr), t, #sum_expr))
-        .as_collection()
-    }
+    aggregation_pre_leave_pipeline(arity, agg_pos, row_pattern(arity), sum_new(agg_pos, agg_type))
 }


### PR DESCRIPTION
## Summary

Extract the shared 3-phase pipeline structure from the five aggregation `*_optimize()` and `*_pre_leave()` functions into two reusable helpers in `common.rs`:

- **`aggregation_optimize_pipeline()`** — parameterized by row pattern, semiring constructor, threshold comparison (`Lt`/`Gt`/`Ne`), and Phase 3 result expression
- **`aggregation_pre_leave_pipeline()`** — parameterized by row pattern and semiring constructor

Each aggregation file (`min`, `max`, `sum`, `count`, `avg`) is now a thin wrapper providing its specific parameters. The pipeline structure (Phase 1: map to semiring → Phase 2: threshold_semigroup → Phase 3: map back) is written once instead of five times.

## Changes

| File | Change |
|------|--------|
| `common.rs` | Add `ThresholdCmp` enum, `aggregation_optimize_pipeline()`, `aggregation_pre_leave_pipeline()` |
| `min.rs` | Replace inline pipeline with `aggregation_optimize_pipeline(..., ThresholdCmp::Lt, ...)` |
| `max.rs` | Replace inline pipeline with `aggregation_optimize_pipeline(..., ThresholdCmp::Gt, ...)` |
| `sum.rs` | Replace inline pipeline with `aggregation_optimize_pipeline(..., ThresholdCmp::Ne, ...)` |
| `count.rs` | Replace inline pipeline with `aggregation_optimize_pipeline(..., ThresholdCmp::Ne, ...)` |
| `avg.rs` | Replace inline pipeline with `aggregation_optimize_pipeline(..., ThresholdCmp::Ne, ...)` |

**Net: +178 / -247 lines** (69 lines removed)

## Safety

- No runtime performance impact — compiler-internal refactoring only
- Clean `cargo build --release`