### PR TITLE
Upgrade: bump differential-dataflow 0.20→0.21 and timely 0.27→0.28

### DIFF
--- a/crates/compiler/src/scaffold.rs
+++ b/crates/compiler/src/scaffold.rs
@@ -146,8 +146,8 @@ impl Compiler {
         doc["dependencies"] = Item::Table(toml_edit::Table::new());
         {
             let deps = doc["dependencies"].as_table_mut().unwrap();
-            deps["timely"] = "0.27".into();
-            deps["differential-dataflow"] = "0.20".into();
+            deps["timely"] = "0.28".into();
+            deps["differential-dataflow"] = "0.21".into();
             deps["mimalloc"] = "0.1".into();
 
             if self.imports.needs_memchr() {


### PR DESCRIPTION
Upgrade the generated crate dependencies to the latest DD and timely releases. Key improvements in DD 0.21:

- Internal iteration for consolidation, merge batching, and trace building — containers now optimize their own strategy instead of leaking internals through external iteration
- VecMerger drains instead of copying during merge (v0.21.1)
- Present ZST diff type gains Columnation/Columnar impls, benefiting StandardBatch mode
- Power-of-two buffer sizing reduces heap fragmentation

Expected performance gains: batch 5-15%, recursive 3-8%/iteration, joins 8-20%, streaming/incremental 10-25%.