### PR TITLE
Add CFL-reachability program analyses (aa, civf, pa, taint, vf)

### DIFF
--- a/example/program_analysis/aa.dl
+++ b/example/program_analysis/aa.dl
@@ -1,0 +1,59 @@
+// Alias analysis (CFL-reachability formulation)
+//
+// Indexed-label encoding: each edge is (src, dst, label_index). EDB relations
+// `a`/`ra` (assign and reverse-assign), `new`/`rnew` (allocation and reverse),
+// `load_i`/`rload_i` (load and reverse-load with label index), and
+// `store_i`/`rstore_i` (store and reverse-store with label index) are loaded
+// from per-label CSV files produced from a CFL graph (see
+// `tools/transfer_facts.py` style preprocessing).
+
+.decl a(x: int32, y: int32, i: int32)
+.input a(IO="file", filename="a.csv", delimiter=",")
+.decl ra(x: int32, y: int32, i: int32)
+.input ra(IO="file", filename="ra.csv", delimiter=",")
+
+.decl new(x: int32, y: int32, i: int32)
+.input new(IO="file", filename="new.csv", delimiter=",")
+.decl rnew(x: int32, y: int32, i: int32)
+.input rnew(IO="file", filename="rnew.csv", delimiter=",")
+
+.decl load_i(x: int32, y: int32, i: int32)
+.input load_i(IO="file", filename="load_i.csv", delimiter=",")
+.decl rload_i(x: int32, y: int32, i: int32)
+.input rload_i(IO="file", filename="rload_i.csv", delimiter=",")
+
+.decl store_i(x: int32, y: int32, i: int32)
+.input store_i(IO="file", filename="store_i.csv", delimiter=",")
+.decl rstore_i(x: int32, y: int32, i: int32)
+.input rstore_i(IO="file", filename="rstore_i.csv", delimiter=",")
+
+.decl FlowsTo(x: int32, y: int32, i: int32)
+.decl RFlowsTo(x: int32, y: int32, i: int32)
+
+.decl Assign(x: int32, y: int32, i: int32)
+.decl RAssign(x: int32, y: int32, i: int32)
+
+.decl Alias(x: int32, y: int32, i: int32)
+
+.decl SA_i(x: int32, y: int32, i: int32)
+.decl RSA_i(x: int32, y: int32, i: int32)
+
+FlowsTo(x, y, 0) :- new(x, y, _).
+RFlowsTo(x, y, 0) :- rnew(x, y, _).
+
+FlowsTo(x, y, 0) :- FlowsTo(x, z, _), Assign(z, y, _).
+RFlowsTo(x, y, 0) :- RAssign(x, z, _), RFlowsTo(z, y, _).
+
+Assign(x, y, 0) :- a(x, y, _).
+RAssign(x, y, 0) :- ra(x, y, _).
+
+SA_i(x, y, i) :- store_i(x, z, i), Alias(z, y, _).
+Assign(x, y, 0) :- SA_i(x, z, i), load_i(z, y, i).
+
+RSA_i(x, y, i) :- Alias(x, z, _), rstore_i(z, y, i).
+RAssign(x, y, 0) :- rload_i(x, z, i), RSA_i(z, y, i).
+
+Alias(x, y, 0) :- RFlowsTo(x, z, _), FlowsTo(z, y, _).
+
+.printsize Alias
+.printsize FlowsTo

--- a/example/program_analysis/civf.dl
+++ b/example/program_analysis/civf.dl
@@ -1,0 +1,31 @@
+// Context-insensitive value-flow analysis (CFL-reachability formulation)
+//
+// Indexed-label encoding: assignment edges `a` and indexed call/return edges
+// `call_i`/`ret_i`. Computes the symmetric closure `MatchA` over assignments and
+// call/return matching is collapsed (context-insensitive).
+
+.decl a(x: int32, y: int32, i: int32)
+.input a(IO="file", filename="a.csv", delimiter=",")
+
+.decl call_i(x: int32, y: int32, i: int32)
+.input call_i(IO="file", filename="call_i.csv", delimiter=",")
+
+.decl ret_i(x: int32, y: int32, i: int32)
+.input ret_i(IO="file", filename="ret_i.csv", delimiter=",")
+
+.decl ids(x: int32)
+.decl MatchA(x: int32, y: int32, i: int32)
+
+ids(x) :- a(x, _, 0).
+ids(x) :- a(_, x, 0).
+ids(x) :- call_i(x, _, _).
+ids(x) :- call_i(_, x, _).
+ids(x) :- ret_i(x, _, _).
+ids(x) :- ret_i(_, x, _).
+
+MatchA(x, x, 0) :- ids(x).
+MatchA(x, y, 0) :- MatchA(x, z, _), call_i(z, y, _).
+MatchA(x, y, 0) :- MatchA(x, z, _), ret_i(z, y, _).
+MatchA(x, y, 0) :- MatchA(x, z, _), a(z, y, _).
+
+.printsize MatchA

--- a/example/program_analysis/pa.dl
+++ b/example/program_analysis/pa.dl
@@ -1,0 +1,46 @@
+// Points-to analysis for Java (CFL-reachability formulation)
+//
+// Indexed-label encoding: assignments `a`, indexed calls `call_i` and indexed
+// returns `ret_i`. Computes the matched-parenthesis closure `MatchA` together with
+// auxiliary relations `B`, `S`, `P`, and `CA_i` (calls matched with returns).
+
+.decl a(x: int32, y: int32, i: int32)
+.input a(IO="file", filename="a.csv", delimiter=",")
+
+.decl call_i(x: int32, y: int32, i: int32)
+.input call_i(IO="file", filename="call_i.csv", delimiter=",")
+
+.decl ret_i(x: int32, y: int32, i: int32)
+.input ret_i(IO="file", filename="ret_i.csv", delimiter=",")
+
+.decl ids(x: int32)
+
+.decl MatchA(x: int32, y: int32, i: int32)
+.decl B(x: int32, y: int32, i: int32)
+.decl S(x: int32, y: int32, i: int32)
+.decl P(x: int32, y: int32, i: int32)
+.decl CA_i(x: int32, y: int32, i: int32)
+
+ids(x) :- a(x, _, 0).
+ids(x) :- a(_, x, 0).
+ids(x) :- call_i(x, _, _).
+ids(x) :- call_i(_, x, _).
+ids(x) :- ret_i(x, _, _).
+ids(x) :- ret_i(_, x, _).
+
+MatchA(x, x, 0) :- ids(x).
+MatchA(x, y, 0) :- MatchA(x, z, _), MatchA(z, y, _).
+MatchA(x, y, 0) :- a(x, y, _).
+MatchA(x, y, 0) :- CA_i(x, m, i), ret_i(m, y, i).
+CA_i(x, y, i) :- call_i(x, m, i), MatchA(m, y, _).
+
+P(x, x, 0) :- ids(x).
+P(x, y, 0) :- MatchA(x, z, _), P(z, y, _).
+P(x, y, 0) :- ret_i(x, z, _), P(z, y, _).
+
+S(x, y, 0) :- P(x, y, _).
+S(x, y, 0) :- S(x, z, _), MatchA(z, y, _).
+S(x, y, 0) :- S(x, z, _), call_i(z, y, _).
+
+.printsize MatchA
+.printsize S

--- a/example/program_analysis/taint.dl
+++ b/example/program_analysis/taint.dl
@@ -1,0 +1,37 @@
+// Taint analysis (CFL-reachability formulation)
+//
+// Indexed-label encoding: assignments `a` and indexed calls/returns
+// `call_i`/`ret_i`. Computes the matched closure `MatchA` using auxiliary `B` and
+// `CA_i` (calls matched with returns).
+
+.decl a(x: int32, y: int32, i: int32)
+.input a(IO="file", filename="a.csv", delimiter=",")
+
+.decl call_i(x: int32, y: int32, i: int32)
+.input call_i(IO="file", filename="call_i.csv", delimiter=",")
+
+.decl ret_i(x: int32, y: int32, i: int32)
+.input ret_i(IO="file", filename="ret_i.csv", delimiter=",")
+
+.decl ids(x: int32)
+
+.decl MatchA(x: int32, y: int32, i: int32)
+.decl B(x: int32, y: int32, i: int32)
+.decl CA_i(x: int32, y: int32, i: int32)
+
+ids(x) :- a(x, _, 0).
+ids(x) :- a(_, x, 0).
+ids(x) :- call_i(x, _, _).
+ids(x) :- call_i(_, x, _).
+ids(x) :- ret_i(x, _, _).
+ids(x) :- ret_i(_, x, _).
+
+MatchA(x, x, 0) :- ids(x).
+MatchA(x, y, 0) :- MatchA(x, z, _), B(z, y, _).
+MatchA(x, y, 0) :- MatchA(x, z, _), a(z, y, _).
+B(x, y, 0) :- a(x, y, _).
+
+B(x, y, 0) :- CA_i(x, m, i), ret_i(m, y, i).
+CA_i(x, y, i) :- call_i(x, m, i), MatchA(m, y, _).
+
+.printsize MatchA

--- a/example/program_analysis/vf.dl
+++ b/example/program_analysis/vf.dl
@@ -1,0 +1,54 @@
+// Value-flow analysis (CFL-reachability formulation)
+//
+// Indexed-label encoding: forward/reverse assignments `a`/`abar`, indexed
+// dereferences `d`/`dbar`, and indexed field accesses `f_i`/`fbar_i`.
+// Computes value-flow `V`, alias-derived `MatchA`/`MatchAbar`, and field-aliased
+// auxiliaries `FV_i`, `M`, `DV`.
+
+.decl a(x: int32, y: int32, i: int32)
+.input a(IO="file", filename="a.csv", delimiter=",")
+.decl abar(x: int32, y: int32, i: int32)
+.input abar(IO="file", filename="abar.csv", delimiter=",")
+.decl d(x: int32, y: int32, i: int32)
+.input d(IO="file", filename="d.csv", delimiter=",")
+.decl dbar(x: int32, y: int32, i: int32)
+.input dbar(IO="file", filename="dbar.csv", delimiter=",")
+.decl f_i(x: int32, y: int32, i: int32)
+.input f_i(IO="file", filename="f_i.csv", delimiter=",")
+.decl fbar_i(x: int32, y: int32, i: int32)
+.input fbar_i(IO="file", filename="fbar_i.csv", delimiter=",")
+
+.decl M(x: int32, y: int32, i: int32)
+.decl V(x: int32, y: int32, i: int32)
+.decl MatchA(x: int32, y: int32, i: int32)
+.decl MatchAbar(x: int32, y: int32, i: int32)
+.decl FV_i(x: int32, y: int32, i: int32)
+.decl DV(x: int32, y: int32, i: int32)
+
+.decl ids(x: int32)
+
+ids(x) :- a(x, _, _).
+ids(x) :- abar(x, _, _).
+ids(x) :- d(x, _, _).
+ids(x) :- dbar(x, _, _).
+ids(x) :- f_i(x, _, _).
+ids(x) :- fbar_i(x, _, _).
+
+DV(x, y, 0) :- dbar(x, w, _), V(w, y, _).
+M(x, y, 0) :- DV(x, z, _), d(z, y, _).
+
+FV_i(x, y, i) :- fbar_i(x, z, i), V(z, y, _).
+V(x, y, 0) :- FV_i(x, z, i), f_i(z, y, i).
+V(x, x, 0) :- ids(x).
+V(x, y, 0) :- M(x, y, _).
+V(x, y, 0) :- MatchAbar(x, z, _), V(z, y, _).
+V(x, y, 0) :- V(x, z, _), MatchA(z, y, _).
+
+MatchA(x, y, 0) :- a(x, z, _), M(z, y, _).
+MatchA(x, y, 0) :- a(x, y, _).
+
+MatchAbar(x, y, 0) :- M(x, z, _), abar(z, y, _).
+MatchAbar(x, y, 0) :- abar(x, y, _).
+
+.printsize V
+.printsize M


### PR DESCRIPTION
Adds five Datalog programs that encode CFL-reachability program
analyses to `example/program_analysis/`, joining the existing
`cspa.dl` and `csda.dl` benchmarks already in this directory:

- `aa.dl`    — Alias analysis for C/C++
- `civf.dl`  — Context-insensitive value-flow analysis
- `pa.dl`    — Points-to analysis for Java
- `taint.dl` — Taint analysis
- `vf.dl`    — Value-flow analysis

Each program uses arity-3 `(src, dst, label_index)` tuples with
`int32` columns and `.input`/`.printsize` directives matching the
existing FlowLog example convention. Sources are adapted from the
souffle-experiments artifact.

Notes:
- The auxiliary relation traditionally named `A`/`Abar` is renamed to
  `MatchA`/`MatchAbar` to avoid collision with the lowercase EDB `a`
  under FlowLog's case-insensitive identifier resolution.
- Front-end compilation (parse, stratify, plan) is verified for all
  five programs via `flowlog-compiler`. End-to-end runs require
  per-label CSV facts produced from a CFL graph (see the
  souffle-experiments `transfer_facts.py` preprocessing).