### PR TITLE
tidy(parser): extract IO directive helper + idiomatic fn_call rewrite

### DIFF
--- a/crates/flowlog-build/src/parser/declaration/directive.rs
+++ b/crates/flowlog-build/src/parser/declaration/directive.rs
@@ -63,18 +63,30 @@ fn parse_io_params<'i>(
     Ok(parameters)
 }
 
+/// Parse an IO directive: extract relation name and parameters.
+fn parse_io_directive_parts(
+    parsed_rule: Pair<Rule>,
+    file: FileId,
+    error_context: &str,
+) -> Result<(String, HashMap<String, String>, Ignored<Span>), ParseError> {
+    let mut inner = parsed_rule.into_inner();
+    let name_pair = inner
+        .next()
+        .ok_or_else(|| grammar_bug(format!("{error_context} missing relation name")))?;
+    let span = span_of(&name_pair, file);
+    let relation_name = name_pair.as_str().to_lowercase();
+    let parameters = parse_io_params(inner)?;
+    Ok((relation_name, parameters, Ignored(span)))
+}
+
 impl Lexeme for InputDirective {
     fn from_parsed_rule(parsed_rule: Pair<Rule>, file: FileId) -> Result<Self, ParseError> {
-        let mut inner = parsed_rule.into_inner();
-        let name_pair = inner
-            .next()
-            .ok_or_else(|| grammar_bug("input directive missing relation name"))?;
-        let span = span_of(&name_pair, file);
-        let relation_name = name_pair.as_str().to_lowercase();
+        let (relation_name, parameters, span) =
+            parse_io_directive_parts(parsed_rule, file, "input directive")?;
         Ok(Self {
             relation_name,
-            parameters: parse_io_params(inner)?,
-            span: Ignored(span),
+            parameters,
+            span,
         })
     }
 }
@@ -110,16 +122,12 @@ impl OutputDirective {
 
 impl Lexeme for OutputDirective {
     fn from_parsed_rule(parsed_rule: Pair<Rule>, file: FileId) -> Result<Self, ParseError> {
-        let mut inner = parsed_rule.into_inner();
-        let name_pair = inner
-            .next()
-            .ok_or_else(|| grammar_bug("output directive missing relation name"))?;
-        let span = span_of(&name_pair, file);
-        let relation_name = name_pair.as_str().to_lowercase();
+        let (relation_name, parameters, span) =
+            parse_io_directive_parts(parsed_rule, file, "output directive")?;
         Ok(Self {
             relation_name,
-            parameters: parse_io_params(inner)?,
-            span: Ignored(span),
+            parameters,
+            span,
         })
     }
 }

--- a/crates/flowlog-build/src/parser/logic/fn_call.rs
+++ b/crates/flowlog-build/src/parser/logic/fn_call.rs
@@ -103,17 +103,14 @@ impl Lexeme for FnCall {
     fn from_parsed_rule(parsed_rule: Pair<Rule>, file: FileId) -> Result<Self, ParseError> {
         let span = span_of(&parsed_rule, file);
         let mut children = parsed_rule.into_inner();
-        let fn_name = children
-            .next()
-            .ok_or_else(|| grammar_bug("fn_call_expr missing function name"))?
-            .as_str()
-            .to_string();
-        let mut args = Vec::new();
-        for p in children {
-            if p.as_rule() == Rule::arithmetic_expr {
-                args.push(Arithmetic::from_parsed_rule(p, file)?);
-            }
-        }
+        let Some(name_pair) = children.next() else {
+            return Err(grammar_bug("fn_call_expr missing function name"));
+        };
+        let fn_name = name_pair.as_str().to_string();
+        let args = children
+            .filter(|p| p.as_rule() == Rule::arithmetic_expr)
+            .map(|p| Arithmetic::from_parsed_rule(p, file))
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             name: fn_name,
             args,


### PR DESCRIPTION
## Summary

Two small, behaviour-preserving readability tidies in `flowlog-build` parser code paths.

### 1. `parser/declaration/directive.rs` — extract shared IO directive helper

`InputDirective::from_parsed_rule` and `OutputDirective::from_parsed_rule` had ~5 lines of identical *"pull name pair, capture span, lowercase relation name, parse params"* logic. Hoisted into a private `parse_io_directive_parts(rule, file, error_context)` helper; the only differing line (the `grammar_bug` message) is threaded as `error_context: &str`.

### 2. `parser/logic/fn_call.rs` — `let-else` + `filter_map`

`FnCall::from_parsed_rule` used `next().ok_or_else(...)?` and a manual `for p in children { if … { args.push(...?); } }`. Replaced with `let-else` for the missing-name branch and `filter().map().collect::<Result<Vec<_>, _>>()?` for the args. The `collect::<Result<_>>` short-circuits on the first error identically to the manual `?`.

## Validation

- `cargo check --workspace --tests` — clean
- `bash tools/benchmark/bench_one.sh example/knowledge_reasoning/crdt.dl facts/crdt` — within 1.5% of base (well under the 10% smoke gate)
- No public API touched, no trait/impl signatures changed
- No new dependencies

## Provenance

Generated by an internal agentic readability loop (`minimalist`, trial-2 — a 3-iteration run gated on `cargo check --tests` and a smoke perf bench). Each commit corresponds to one accepted iteration. Diffs were reviewed by hand and grouped into this PR by area (parser). The profiler cleanup from the same trial run is filed in a sister PR.
