### PR TITLE
tidy(profiler): inline single-use NodeProfile setters into build_node

### DIFF
--- a/crates/flowlog-build/src/profiler/mod.rs
+++ b/crates/flowlog-build/src/profiler/mod.rs
@@ -42,8 +42,8 @@ pub(crate) fn with_profiler<F>(profiler: &mut Option<Profiler>, f: F)
 where
     F: FnOnce(&mut Profiler),
 {
-    if let Some(profiler) = profiler.as_mut() {
-        f(profiler);
+    if let Some(p) = profiler.as_mut() {
+        f(p);
     }
 }
 
@@ -52,8 +52,8 @@ pub fn with_profiler_ref<F, E>(profiler: &Option<Profiler>, f: F) -> Result<(), 
 where
     F: FnOnce(&Profiler) -> Result<(), E>,
 {
-    if let Some(profiler) = profiler.as_ref() {
-        f(profiler)
+    if let Some(p) = profiler.as_ref() {
+        f(p)
     } else {
         Ok(())
     }

--- a/crates/flowlog-build/src/profiler/node.rs
+++ b/crates/flowlog-build/src/profiler/node.rs
@@ -24,43 +24,6 @@ pub(super) struct NodeProfile {
     parents: Vec<usize>,
 }
 
-impl NodeProfile {
-    /// Update the node id.
-    fn update_id(&mut self, new_id: usize) {
-        self.id = new_id;
-    }
-
-    /// Update the node name.
-    fn update_name(&mut self, new_name: String) {
-        self.name = new_name;
-    }
-
-    /// Update the block label.
-    fn update_block(&mut self, new_block: String) {
-        self.block = new_block;
-    }
-
-    /// Set the fingerprint from a raw u64 value.
-    fn update_fingerprint(&mut self, fingerprint: u64) {
-        self.fingerprint = Some(format!("0x{:016x}", fingerprint));
-    }
-
-    /// Add a tag to the node.
-    fn add_tag(&mut self, tag: String) {
-        self.tags.push(tag);
-    }
-
-    /// Append operator addresses.
-    fn add_operators(&mut self, operator_addrs: Vec<Addr>) {
-        self.operators.extend(operator_addrs);
-    }
-
-    /// Append parent node ids.
-    fn add_parents(&mut self, parent_ids: Vec<usize>) {
-        self.parents.extend(parent_ids);
-    }
-}
-
 /// Internal nodes manager that tracks ids, scope addresses, and dependencies.
 #[derive(Debug, Clone, Default)]
 pub(super) struct NodeManager {
@@ -112,22 +75,20 @@ impl NodeManager {
         operator_steps: u32,
         fingerprint: Option<u64>,
     ) -> NodeProfile {
-        let mut node = NodeProfile::default();
-
-        let parent_ids = input_variable_names
+        let parent_ids: Vec<usize> = input_variable_names
             .iter()
             .filter_map(|variable_name| self.node_map.get(variable_name).copied())
             .collect();
 
-        node.update_id(self.id_cnt);
-        node.update_name(name);
-        node.update_block(self.block.clone());
-        if let Some(fingerprint) = fingerprint {
-            node.update_fingerprint(fingerprint);
-        }
-        node.add_tag(tag.to_string());
-        node.add_operators(self.addr_cnt.advance(operator_steps));
-        node.add_parents(parent_ids);
+        let node = NodeProfile {
+            id: self.id_cnt,
+            name,
+            block: self.block.clone(),
+            fingerprint: fingerprint.map(|fp| format!("0x{:016x}", fp)),
+            tags: vec![tag.to_string()],
+            operators: self.addr_cnt.advance(operator_steps),
+            parents: parent_ids,
+        };
 
         if let Some(output_variable_name) = output_variable_name {
             self.node_map.insert(output_variable_name, self.id_cnt);


### PR DESCRIPTION
## Summary

`NodeProfile` had 7 single-use setter methods — `update_id`, `update_name`, `update_block`, `update_fingerprint`, `add_tag`, `add_operators`, `add_parents` — each called *exactly once* from `NodeManager::build_node`. They added no encapsulation (fields are `pub(super)`, no validation, no invariants), and the imperative *"default + 7 setter calls"* pattern made the construction sequence harder to scan than a struct literal.

This PR:

- Drops all 7 setters from `NodeProfile`.
- Rewrites `build_node` to construct `NodeProfile` with a struct literal, pushing `fingerprint.map(|fp| format!("0x{:016x}", fp))` and `vec![tag.to_string()]` into the literal directly.
- Tightens `parent_ids: Vec<usize>` typing (was inferred via `collect`).
- Renames `if let Some(profiler) = profiler.as_mut()` → `if let Some(p) = ...` in `with_profiler{,_ref}` to avoid shadowing the outer binding.

Net `+14 / -53`.

## Why this is *safer*, not just shorter

With the setters, adding a new field to `NodeProfile` would require remembering to call a new `update_x` from `build_node` — silently buggy if forgotten. With the struct literal, omitting a field is a compile error.

## Validation

- `cargo check --workspace --tests` — clean
- Smoke benchmark (galen reasoning) within 1.5% of base
- All `NodeProfile` setters were single-use (`rg 'update_(id|name|block|fingerprint)\\|add_(tag|operators|parents)'` confirms only `build_node` was using them)
- No public API touched

## Provenance

Generated by an internal agentic readability loop (`minimalist`, trial-2, iter 2 of 3). Diff was hand-reviewed before opening this PR. Sister PR for parser readability changes from the same trial run is filed separately.
