### PR TITLE
cleanups: hoist deps get_mut and global_fp_to_ident clone out of inner loops

### DIFF
--- a/crates/flowlog-build/src/catalog/error.rs
+++ b/crates/flowlog-build/src/catalog/error.rs
@@ -2,9 +2,10 @@
 
 use std::fmt;
 
+use crate::common::{
+    BUG_URL, Diagnostic, FileId, InternalError, Span, primary_label, secondary_label,
+};
 use codespan_reporting::diagnostic::Diagnostic as CsDiagnostic;
-use crate::common::{primary_label, secondary_label, Diagnostic, InternalError, BUG_URL};
-use crate::common::{FileId, Span};
 use thiserror::Error;
 
 /// Which body predicate carried an unsafe variable. Only affects the

--- a/crates/flowlog-build/src/catalog/rule/modify.rs
+++ b/crates/flowlog-build/src/catalog/rule/modify.rs
@@ -17,7 +17,7 @@ use crate::parser::{Atom, AtomArg, FlowLogRule, Predicate};
 /// Public API for modifying rules and updating catalog metadata accordingly.
 impl Catalog {
     /// Map an EDB atom to a required key/value layout.
-    /// This function do not change the arity of the atom.
+    /// This function does not change the arity of the atom.
     /// Only premap of an original atom should use this function.
     pub(crate) fn map_modify(
         &mut self,

--- a/crates/flowlog-build/src/codegen/flow/non_recursive.rs
+++ b/crates/flowlog-build/src/codegen/flow/non_recursive.rs
@@ -13,17 +13,15 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use tracing::trace;
 
-use crate::parser::AggregationOperator;
-use crate::planner::StratumPlanner;
-use crate::profiler::{with_profiler, Profiler};
-
 use crate::codegen::aggregation::{
     aggregation_avg_optimize, aggregation_count_optimize, aggregation_max_optimize,
     aggregation_merge_kv, aggregation_min_optimize, aggregation_reduce_stmt, aggregation_row_chop,
     aggregation_sum_optimize,
 };
-use crate::codegen::CodegenError;
-use crate::codegen::CodeGen;
+use crate::codegen::{CodeGen, CodegenError};
+use crate::parser::AggregationOperator;
+use crate::planner::StratumPlanner;
+use crate::profiler::{Profiler, with_profiler};
 
 // =========================================================================
 // Non-Recursive Flow Generation
@@ -39,9 +37,10 @@ impl CodeGen {
         let mut flows = Vec::new();
         // Stratum-scoped cache of arrangements; emit arrange_by_key just before first use.
         let mut non_recursive_arranged_map: HashMap<u64, Ident> = HashMap::new();
+        // Snapshot the global ident map once; `gen_transformation` does not mutate it.
+        let global_fp_to_ident = self.global_fp_to_ident.clone();
 
         for transformation in stratum.non_recursive_transformations() {
-            let global_fp_to_ident = self.global_fp_to_ident.clone();
             flows.push(self.gen_transformation(
                 &global_fp_to_ident,
                 transformation,

--- a/crates/flowlog-build/src/stratifier/dependency_graph.rs
+++ b/crates/flowlog-build/src/stratifier/dependency_graph.rs
@@ -46,18 +46,20 @@ impl DependencyGraph {
         let mut negative_edges: BTreeSet<(usize, usize)> = BTreeSet::new();
 
         for (rule_id, rule) in rules.iter().enumerate() {
+            let deps = dependency_map.get_mut(&rule_id).unwrap();
             for predicate in rule.rhs() {
                 let (atom_name, is_negative) = match predicate {
                     Predicate::PositiveAtom(atom) => (atom.name(), false),
                     Predicate::NegativeAtom(atom) => (atom.name(), true),
                     _ => continue,
                 };
-                if let Some(dep_ids) = head_to_rule_map.get(atom_name) {
-                    for &dep_id in dep_ids {
-                        dependency_map.get_mut(&rule_id).unwrap().insert(dep_id);
-                        if is_negative {
-                            negative_edges.insert((rule_id, dep_id));
-                        }
+                let Some(dep_ids) = head_to_rule_map.get(atom_name) else {
+                    continue;
+                };
+                for &dep_id in dep_ids {
+                    deps.insert(dep_id);
+                    if is_negative {
+                        negative_edges.insert((rule_id, dep_id));
                     }
                 }
             }
@@ -70,7 +72,7 @@ impl DependencyGraph {
     }
 
     fn build_head_to_rule_map(rules: &[FlowLogRule]) -> HashMap<String, Vec<usize>> {
-        let mut map: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut map: HashMap<String, Vec<usize>> = HashMap::with_capacity(rules.len());
         for (id, rule) in rules.iter().enumerate() {
             map.entry(rule.head().name().to_string())
                 .or_default()


### PR DESCRIPTION
Two small, behavior-preserving hoists out of inner loops, plus an `with_capacity` hint. Found by an automated multi-iteration cleanup pass; each hunk was independently judged and validated against the full Rust workspace test suite (`cargo test --release --workspace`) and a 3-benchmark perf gate (crdt, csda-httpd, dyck/kernel) on every iteration.

## What changed

### `stratifier::DependencyGraph::new`

```diff
 for (rule_id, rule) in rules.iter().enumerate() {
+    let deps = dependency_map.get_mut(&rule_id).unwrap();
     for predicate in rule.rhs() {
         let (atom_name, is_negative) = match predicate {
             Predicate::PositiveAtom(atom) => (atom.name(), false),
             Predicate::NegativeAtom(atom) => (atom.name(), true),
             _ => continue,
         };
-        if let Some(dep_ids) = head_to_rule_map.get(atom_name) {
-            for &dep_id in dep_ids {
-                dependency_map.get_mut(&rule_id).unwrap().insert(dep_id);
-                if is_negative {
-                    negative_edges.insert((rule_id, dep_id));
-                }
-            }
-        }
+        let Some(dep_ids) = head_to_rule_map.get(atom_name) else {
+            continue;
+        };
+        for &dep_id in dep_ids {
+            deps.insert(dep_id);
+            ...
+        }
     }
 }
```

The inner loop body never mutates `dependency_map` for any other key, so it's safe to hold the mutable borrow across the entire RHS scan. Also pre-sizes `head_to_rule_map` with `with_capacity(rules.len())` since each rule contributes exactly one head entry.

### `codegen::flow::non_recursive::gen_non_recursive_core_flows`

```diff
 let mut non_recursive_arranged_map: HashMap<u64, Ident> = HashMap::new();
+// Snapshot the global ident map once; `gen_transformation` does not mutate it.
+let global_fp_to_ident = self.global_fp_to_ident.clone();

 for transformation in stratum.non_recursive_transformations() {
-    let global_fp_to_ident = self.global_fp_to_ident.clone();
     flows.push(self.gen_transformation(
```

The clone is now done once per stratum instead of once per transformation. The accompanying comment documents the (already-true) invariant that `gen_transformation` does not mutate the global ident map.

### Bundled side-cleanups

Each commit also bundled minor neighboring tweaks the cleanup pass made on the same files:
- `catalog/error.rs` — merged two adjacent `crate::common::{...}` use lines into one group.
- `catalog/rule/modify.rs` — fixed a `do not change` → `does not change` doc-comment grammar slip.
- `codegen/flow/non_recursive.rs` — regrouped the file's `use` statements into the standard std/external/crate order.

## Verification

- `cargo test --release --workspace` — all 13 test groups pass.
- `cargo build --release --workspace` — clean, no new warnings.
- Perf gate on the source branch saw no regression on any of the 3 rotating benchmarks across 25 iterations; final cumulative sweep: crdt −0.57%, csda +0.27%, dyck/kernel +1.18% (all well within the 5% cap and within typical jitter).

## Notes for review

These hoists are the "real" perf-leaning items separated out from a larger style/cleanup batch. Two related PRs cover the rest:
- `cleanups/dry-refactors` — DRY helper extractions (no behavior change).
- `cleanups/profiler-build_node` — inline trivial NodeProfile setters into a struct literal.
- `cleanups/parser-readability` — doc/comment fixes + `output_limit` flatten.
