### PR TITLE
cleanups(profiler): inline NodeProfile setters into struct literal in build_node

### DIFF
--- a/crates/flowlog-build/src/profiler/node.rs
+++ b/crates/flowlog-build/src/profiler/node.rs
@@ -24,43 +24,6 @@ pub(super) struct NodeProfile {
     parents: Vec<usize>,
 }
 
-impl NodeProfile {
-    /// Update the node id.
-    fn update_id(&mut self, new_id: usize) {
-        self.id = new_id;
-    }
-
-    /// Update the node name.
-    fn update_name(&mut self, new_name: String) {
-        self.name = new_name;
-    }
-
-    /// Update the block label.
-    fn update_block(&mut self, new_block: String) {
-        self.block = new_block;
-    }
-
-    /// Set the fingerprint from a raw u64 value.
-    fn update_fingerprint(&mut self, fingerprint: u64) {
-        self.fingerprint = Some(format!("0x{:016x}", fingerprint));
-    }
-
-    /// Add a tag to the node.
-    fn add_tag(&mut self, tag: String) {
-        self.tags.push(tag);
-    }
-
-    /// Append operator addresses.
-    fn add_operators(&mut self, operator_addrs: Vec<Addr>) {
-        self.operators.extend(operator_addrs);
-    }
-
-    /// Append parent node ids.
-    fn add_parents(&mut self, parent_ids: Vec<usize>) {
-        self.parents.extend(parent_ids);
-    }
-}
-
 /// Internal nodes manager that tracks ids, scope addresses, and dependencies.
 #[derive(Debug, Clone, Default)]
 pub(super) struct NodeManager {
@@ -112,25 +75,24 @@ impl NodeManager {
         operator_steps: u32,
         fingerprint: Option<u64>,
     ) -> NodeProfile {
-        let mut node = NodeProfile::default();
-
-        let parent_ids = input_variable_names
+        let id = self.id_cnt;
+        let parents = input_variable_names
             .iter()
             .filter_map(|variable_name| self.node_map.get(variable_name).copied())
             .collect();
 
-        node.update_id(self.id_cnt);
-        node.update_name(name);
-        node.update_block(self.block.clone());
-        if let Some(fingerprint) = fingerprint {
-            node.update_fingerprint(fingerprint);
-        }
-        node.add_tag(tag.to_string());
-        node.add_operators(self.addr_cnt.advance(operator_steps));
-        node.add_parents(parent_ids);
+        let node = NodeProfile {
+            id,
+            name,
+            block: self.block.clone(),
+            fingerprint: fingerprint.map(|fp| format!("0x{fp:016x}")),
+            tags: vec![tag.to_string()],
+            operators: self.addr_cnt.advance(operator_steps),
+            parents,
+        };
 
         if let Some(output_variable_name) = output_variable_name {
-            self.node_map.insert(output_variable_name, self.id_cnt);
+            self.node_map.insert(output_variable_name, id);
         }
         self.id_cnt += 1;
 


### PR DESCRIPTION
Inline `NodeProfile`'s seven trivial single-call setter methods into `NodeManager::build_node` via a single struct-literal construction. Net `-38` lines.

## Why

`NodeProfile` had seven `update_*` / `add_*` setter methods, each with exactly one caller (`NodeManager::build_node`) inside the same module:

```rust
fn update_id(&mut self, new_id: usize) { self.id = new_id; }
fn update_name(&mut self, new_name: String) { self.name = new_name; }
fn update_block(&mut self, new_block: String) { self.block = new_block; }
fn update_fingerprint(&mut self, fingerprint: u64) { self.fingerprint = Some(format!("0x{:016x}", fingerprint)); }
fn add_tag(&mut self, tag: String) { self.tags.push(tag); }
fn add_operators(&mut self, operator_addrs: Vec<Addr>) { self.operators.extend(operator_addrs); }
fn add_parents(&mut self, parent_ids: Vec<usize>) { self.parents.extend(parent_ids); }
```

Build-site:

```rust
let mut node = NodeProfile::default();
let parent_ids = input_variable_names.iter()…collect();
node.update_id(self.id_cnt);
node.update_name(name);
node.update_block(self.block.clone());
if let Some(fingerprint) = fingerprint { node.update_fingerprint(fingerprint); }
node.add_tag(tag.to_string());
node.add_operators(self.addr_cnt.advance(operator_steps));
node.add_parents(parent_ids);
```

Each setter is a single field assignment (or `push` / `extend` on an empty vec from `Default`). They add no validation, no logging, no invariant — pure indirection.

## After

```rust
let id = self.id_cnt;
let parents = input_variable_names.iter()…collect();
let node = NodeProfile {
    id,
    name,
    block: self.block.clone(),
    fingerprint: fingerprint.map(|fp| format!("0x{fp:016x}")),
    tags: vec![tag.to_string()],
    operators: self.addr_cnt.advance(operator_steps),
    parents,
};
```

The construction now reads top-to-bottom in one place, the field initialization order matches the struct definition, and the local `id` is also reused for the `node_map` insert (avoiding a second field read).

## Behavior preservation

- `parents` is computed from `input_variable_names` *before* `output_variable_name` is inserted into `self.node_map` — same order as before.
- `fingerprint` is formatted with the same `0x{:016x}` width and zero-padding (using `fingerprint.map(|fp| format!(…))` instead of `if let Some(fp) = … { update_fingerprint(fp); }`).
- `addr_cnt.advance(operator_steps)` is called exactly once, in the same position.
- `id_cnt` is incremented exactly once at the end (unchanged code below the replaced block).
- The `output_variable_name` insert uses the same id value as `node.id`.

## Verification

- `cargo test --release --workspace` — all 13 test groups pass.
- `cargo build --release --workspace` — clean, no new warnings.
- Perf gate on the source branch: no regression on any of 3 rotating benchmarks across 25 iterations.

## Notes for review

This is one of four PRs splitting an automated cleanup batch by topic. Companion PRs:
- `cleanups/perf-hoists` — hoists out of inner loops.
- `cleanups/dry-refactors` — helper extractions and match-arm dedup.
- `cleanups/parser-readability` — doc/comment fixes + `output_limit` flatten.
