### PR TITLE
cleanups(parser): fix lying transformation comments + flatten Relation::output_limit

### DIFF
--- a/crates/flowlog-build/src/parser/declaration/relation.rs
+++ b/crates/flowlog-build/src/parser/declaration/relation.rs
@@ -1,16 +1,16 @@
 //! Relation declaration types for FlowLog Datalog programs.
 
-use super::Attribute;
-use crate::parser::error::{grammar_bug, ParseError};
-use crate::parser::primitive::DataType;
-use crate::parser::{span_of, Lexeme, Rule};
-use pest::iterators::Pair;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
-use crate::common::compute_fp;
-use crate::common::{FileId, Ignored, Span};
+use pest::iterators::Pair;
+
+use super::Attribute;
+use crate::common::{FileId, Ignored, Span, compute_fp};
+use crate::parser::error::{ParseError, grammar_bug};
+use crate::parser::primitive::DataType;
+use crate::parser::{Lexeme, Rule, span_of};
 
 /// A relation schema with input/output annotations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -200,29 +200,20 @@ impl Relation {
     /// Get the output row limit, if specified.
     #[must_use]
     pub(crate) fn output_limit(&self) -> Option<usize> {
-        let limit = self
-            .output_params
-            .as_ref()
-            .and_then(|m| m.get("limit"))
-            .map(|v| {
-                v.parse::<usize>().unwrap_or_else(|_| {
-                    panic!(
-                        "Parser error: invalid limit '{}' for relation '{}', expected a non-negative integer",
-                        v, self.name
-                    )
-                })
-            });
-        if limit.is_some() {
-            assert!(
-                self.output_params
-                    .as_ref()
-                    .and_then(|m| m.get("order_by"))
-                    .is_some(),
-                "Parser error: limit requires order_by for relation '{}'",
-                self.name
-            );
-        }
-        limit
+        let params = self.output_params.as_ref()?;
+        let raw = params.get("limit")?;
+        let limit = raw.parse::<usize>().unwrap_or_else(|_| {
+            panic!(
+                "Parser error: invalid limit '{}' for relation '{}', expected a non-negative integer",
+                raw, self.name
+            )
+        });
+        assert!(
+            params.contains_key("order_by"),
+            "Parser error: limit requires order_by for relation '{}'",
+            self.name
+        );
+        Some(limit)
     }
 
     /// Get the output ordering specification, if specified.

--- a/crates/flowlog-build/src/planner/transformation.rs
+++ b/crates/flowlog-build/src/planner/transformation.rs
@@ -213,11 +213,10 @@ impl Transformation {
 // Constructors
 // ========================
 impl Transformation {
-    /// Creates a key-value to key-value transformation.
+    /// Creates a unary transformation between row/key-value layouts.
     ///
     /// This method analyzes the input and output layouts to determine the specific
-    /// transformation type needed (RowToRow, RowToK, RowToKv, KvToKv, KvToK, or KvToRow).
-    /// It automatically detects whether the transformation is a no-op optimization.
+    /// transformation type needed (`RowToRow`, `RowToKv`, `KvToRow`, or `KvToKv`).
     ///
     /// # Arguments
     ///
@@ -225,13 +224,11 @@ impl Transformation {
     ///
     /// # Returns
     ///
-    /// A Transformation variant appropriate for the input/output layout combination:
+    /// A unary Transformation variant appropriate for the input/output layout combination:
     /// - `RowToRow`: Row input → Row output (filtering/projection)
-    /// - `RowToK`: Row input → Key-only output (key extraction)
     /// - `RowToKv`: Row input → Key-value output (structuring)
-    /// - `KvToKv`: Key-value input → Key-value output (transformation)
-    /// - `KvToK`: Key-value input → Key-only output (key extraction)
     /// - `KvToRow`: Key-value input → Row output (flattening)
+    /// - `KvToKv`: Key-value input → Key-value output (transformation)
     pub(crate) fn kv_to_kv(info: &TransformationInfo) -> Self {
         trace!("Creating kv_to_kv transformation with info:\n{}", info);
         // Create the transformation flow that defines how data moves through the operation
@@ -265,13 +262,13 @@ impl Transformation {
                 output,
                 flow,
             },
-            // Row input -> Key-only output: extract keys from row data
+            // Row input -> Key-value output: structure row data into key-value pairs
             (true, false) => Self::RowToKv {
                 input,
                 output,
                 flow,
             },
-            // Row input -> Key-value output: structure row data into key-value pairs
+            // Key-value input -> Row output: flatten key-value pairs back into rows
             (false, true) => Self::KvToRow {
                 input,
                 output,
@@ -298,12 +295,9 @@ impl Transformation {
     ///
     /// # Returns
     ///
-    /// A binary Transformation variant based on the input collection types:
-    /// - `JnKK`: Key-only ⋈ Key-only join
-    /// - `JnKKv`: Key-only ⋈ Key-value join (right has values)
-    /// - `JnKvK`: Key-value ⋈ Key-only join (left has values)
-    /// - `JnKvKv`: Key-value ⋈ Key-value join (both have values)
-    /// - `Cartesian`: Cartesian product (no join keys)
+    /// A binary Transformation variant based on the output collection type:
+    /// - `JnToRow`: Key-value ⋈ Key-value join with Row output
+    /// - `JnToKv`: Key-value ⋈ Key-value join with Key-value output
     pub(crate) fn join(info: &TransformationInfo) -> Self {
         // Create transformation flow that defines how the join operation processes data
         let flow = TransformationFlow::join_to_kv(
@@ -367,8 +361,8 @@ impl Transformation {
     /// # Returns
     ///
     /// A binary antijoin Transformation variant:
-    /// - `NjKK`: Key-only ¬⋈ Key-only antijoin
-    /// - `NjKvK`: Key-value ¬⋈ Key-only antijoin
+    /// - `NJnToRow`: Key-only ¬⋈ Key-value antijoin with Row output
+    /// - `NJnToKv`: Key-only ¬⋈ Key-value antijoin with Key-value output
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Two parser/planner readability fixes: corrects misleading match-arm comments + doc bullets in `planner::transformation`, and flattens `Relation::output_limit` from compute-then-recheck to early-return.

## What changed

### `planner::transformation` — fix lying comments + non-existent variant references

The match-arm comments in `Transformation::kv_to_kv` had each been pasted into the wrong arm:

```diff
-            // Row input -> Key-only output: extract keys from row data
+            // Row input -> Key-value output: structure row data into key-value pairs
             (true, false) => Self::RowToKv {
                 ...
             },
-            // Row input -> Key-value output: structure row data into key-value pairs
+            // Key-value input -> Row output: flatten key-value pairs back into rows
             (false, true) => Self::KvToRow {
```

The doc-bullets on `kv_to_kv` and `join` / `antijoin` constructors named enum variants that don't exist in the current `Transformation` definition (`RowToK`, `KvToK`, `JnKK`, `JnKKv`, `JnKvK`, `JnKvKv`, `Cartesian`, `NjKK`, `NjKvK`). Updated to match what the code actually constructs (`RowToRow`, `RowToKv`, `KvToRow`, `KvToKv`, `JnToRow`, `JnToKv`, `NJnToRow`, `NJnToKv`).

No code change in this file — only doc/comment fixes.

### `parser::declaration::Relation::output_limit` — flatten control flow

```rust
// Before: compute the Option, then re-fetch output_params to do an assertion.
let limit = self.output_params.as_ref().and_then(|m| m.get("limit")).map(|v| {
    v.parse::<usize>().unwrap_or_else(|_| panic!("…"))
});
if limit.is_some() {
    assert!(self.output_params.as_ref().and_then(|m| m.get("order_by")).is_some(), "…");
}
limit

// After: read top-to-bottom with early returns; assert only on the limit path.
let params = self.output_params.as_ref()?;
let raw = params.get("limit")?;
let limit = raw.parse::<usize>().unwrap_or_else(|_| panic!("…"));
assert!(params.contains_key("order_by"), "…");
Some(limit)
```

Same observable behavior:
- Returns `None` if `output_params` is `None` or doesn't contain `"limit"`.
- Panics with the same message on a non-integer `limit`.
- Asserts (with the same message) that `"order_by"` is present whenever `"limit"` is.

But now reads in source order — the value is bound, validated, asserted, and returned without re-traversing the option chain.

## Verification

- `cargo test --release --workspace` — all 13 test groups pass.
- `cargo build --release --workspace` — clean, no new warnings.
- Perf gate on the source branch: no regression on any of 3 rotating benchmarks across 25 iterations.

## Notes for review

The doc-comment fixes are arguably the most valuable hunk here — readers (and AI assistants) navigating `Transformation` would have been actively misled by the stale variant names. One of four PRs splitting an automated cleanup batch by topic. Companion PRs:
- `cleanups/perf-hoists` — hoists out of inner loops.
- `cleanups/dry-refactors` — helper extractions and match-arm dedup.
- `cleanups/profiler-build_node` — inline trivial NodeProfile setters into a struct literal.
