### PR TITLE
cleanups(dry): extract small DRY helpers in error/profile/filter paths

### DIFF
--- a/crates/flowlog-build/src/catalog/rule/populate.rs
+++ b/crates/flowlog-build/src/catalog/rule/populate.rs
@@ -59,29 +59,24 @@ impl Catalog {
         let mut local_placeholder_set = HashSet::new();
 
         // Partition RHS predicates into positive atoms, negative atoms, comparisons, and fn_call predicates
-        let (positive_atoms, negative_atoms, comparison_predicates, fn_call_predicates): (
-            Vec<_>,
-            Vec<_>,
-            Vec<_>,
-            Vec<_>,
-        ) = self.rule.rhs().iter().enumerate().fold(
-            (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
-            |(mut pos, mut neg, mut comp, mut fncalls), (i, p)| {
-                match p {
-                    Predicate::PositiveAtom(a) => {
-                        pos.push(a);
-                        self.positive_atom_rhs_ids.push(i);
-                    }
-                    Predicate::NegativeAtom(a) => {
-                        neg.push(a);
-                        self.negative_atom_rhs_ids.push(i);
-                    }
-                    Predicate::Compare(expr) => comp.push(expr.clone()),
-                    Predicate::FnCall(fc) => fncalls.push(fc.clone()),
-                };
-                (pos, neg, comp, fncalls)
-            },
-        );
+        let mut positive_atoms = Vec::new();
+        let mut negative_atoms = Vec::new();
+        let mut comparison_predicates = Vec::new();
+        let mut fn_call_predicates = Vec::new();
+        for (i, p) in self.rule.rhs().iter().enumerate() {
+            match p {
+                Predicate::PositiveAtom(a) => {
+                    positive_atoms.push(a);
+                    self.positive_atom_rhs_ids.push(i);
+                }
+                Predicate::NegativeAtom(a) => {
+                    negative_atoms.push(a);
+                    self.negative_atom_rhs_ids.push(i);
+                }
+                Predicate::Compare(expr) => comparison_predicates.push(expr.clone()),
+                Predicate::FnCall(fc) => fn_call_predicates.push(fc.clone()),
+            }
+        }
 
         // Process positive atoms: record fingerprints, build argument signatures, record var/const/placeholder, collect var set
         for (pos_rhs_id, atom) in positive_atoms.iter().enumerate() {
@@ -261,34 +256,25 @@ impl Catalog {
     /// Variables that appear only once in the rule body (excluding the head) can be
     /// considered unused and potentially pruned for optimization purposes.
     fn populate_unused_arguments(&mut self) {
-        let mut variable_counts = HashMap::new();
+        let mut variable_counts: HashMap<String, u32> = HashMap::new();
+        let mut bump = |v: &String| {
+            *variable_counts.entry(v.clone()).or_insert(0) += 1;
+        };
 
-        // Count occurrences in positive atoms
         for vars_set in &self.positive_atom_argument_vars_str_sets {
-            for variable in vars_set {
-                *variable_counts.entry(variable.clone()).or_insert(0) += 1;
-            }
+            vars_set.iter().for_each(&mut bump);
         }
-
-        // Count occurrences in negative atoms
         for vars_set in &self.negative_atom_argument_vars_str_sets {
-            for variable in vars_set {
-                *variable_counts.entry(variable.clone()).or_insert(0) += 1;
-            }
+            vars_set.iter().for_each(&mut bump);
         }
-
-        // Count occurrences in comparison predicates
         for comparison_predicate in &self.comparison_predicates {
-            for variable in comparison_predicate.vars_set() {
-                *variable_counts.entry(variable.clone()).or_insert(0) += 1;
-            }
+            comparison_predicate
+                .vars_set()
+                .into_iter()
+                .for_each(&mut bump);
         }
-
-        // Count occurrences in fn_call predicates
         for fn_call_predicate in &self.fn_call_predicates {
-            for variable in fn_call_predicate.vars() {
-                *variable_counts.entry(variable.clone()).or_insert(0) += 1;
-            }
+            fn_call_predicate.vars().into_iter().for_each(&mut bump);
         }
 
         // Collect all head variables (never considered unused, even if single-occurrence)
@@ -313,58 +299,41 @@ impl Catalog {
     fn populate_supersets(&mut self) {
         let pos_var_sets = &self.positive_atom_argument_vars_str_sets;
 
-        // For each positive atom: list indices of other positive atoms whose var set is a superset
+        // Indices of positive atoms whose var set is a superset of `needle`,
+        // optionally excluding one self-index.
+        let pos_supersets_of = |needle: &HashSet<String>, exclude: Option<usize>| -> Vec<usize> {
+            pos_var_sets
+                .iter()
+                .enumerate()
+                .filter(|(j, ps)| Some(*j) != exclude && needle.is_subset(ps))
+                .map(|(j, _)| j)
+                .collect()
+        };
+
+        // For each positive atom: other positive atoms whose var set is a superset
         self.positive_supersets = (0..pos_var_sets.len())
-            .map(|i| {
-                pos_var_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(j, set)| i != *j && pos_var_sets[i].is_subset(set))
-                    .map(|(j, _)| j)
-                    .collect()
-            })
+            .map(|i| pos_supersets_of(&pos_var_sets[i], Some(i)))
             .collect();
 
-        // For each negative atom: list indices of positive atoms that contain all its vars
+        // For each negative atom: positive atoms that contain all its vars
         self.negative_supersets = self
             .negative_atom_argument_vars_str_sets
             .iter()
-            .map(|set| {
-                pos_var_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, ps)| set.is_subset(ps))
-                    .map(|(j, _)| j)
-                    .collect()
-            })
+            .map(|set| pos_supersets_of(set, None))
             .collect();
 
         // For each comparison predicate: positive atoms whose var set covers it
         self.comparison_supersets = self
             .comparison_predicates_vars_str_set
             .iter()
-            .map(|set| {
-                pos_var_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, ps)| set.is_subset(ps))
-                    .map(|(j, _)| j)
-                    .collect()
-            })
+            .map(|set| pos_supersets_of(set, None))
             .collect();
 
         // For each fn_call predicate: positive atoms whose var set covers it
         self.fn_call_supersets = self
             .fn_call_predicates_vars_str_set
             .iter()
-            .map(|set| {
-                pos_var_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, ps)| set.is_subset(ps))
-                    .map(|(j, _)| j)
-                    .collect()
-            })
+            .map(|set| pos_supersets_of(set, None))
             .collect();
     }
 }

--- a/crates/flowlog-build/src/parser/declaration/directive.rs
+++ b/crates/flowlog-build/src/parser/declaration/directive.rs
@@ -36,6 +36,22 @@ impl InputDirective {
     }
 }
 
+/// Parse the leading relation-name token plus any `io_params` children of an
+/// I/O directive. Shared by [`InputDirective`] and [`OutputDirective`], which
+/// differ only in the "missing relation name" diagnostic.
+fn parse_io_directive(
+    parsed_rule: Pair<Rule>,
+    file: FileId,
+    missing_name_msg: &'static str,
+) -> Result<(String, HashMap<String, String>, Span), ParseError> {
+    let mut inner = parsed_rule.into_inner();
+    let name_pair = inner.next().ok_or_else(|| grammar_bug(missing_name_msg))?;
+    let span = span_of(&name_pair, file);
+    let relation_name = name_pair.as_str().to_lowercase();
+    let parameters = parse_io_params(inner)?;
+    Ok((relation_name, parameters, span))
+}
+
 /// Parse `io_params` children from a directive's inner pairs into a key→value map.
 fn parse_io_params<'i>(
     inner: impl Iterator<Item = pest::iterators::Pair<'i, Rule>>,
@@ -65,15 +81,11 @@ fn parse_io_params<'i>(
 
 impl Lexeme for InputDirective {
     fn from_parsed_rule(parsed_rule: Pair<Rule>, file: FileId) -> Result<Self, ParseError> {
-        let mut inner = parsed_rule.into_inner();
-        let name_pair = inner
-            .next()
-            .ok_or_else(|| grammar_bug("input directive missing relation name"))?;
-        let span = span_of(&name_pair, file);
-        let relation_name = name_pair.as_str().to_lowercase();
+        let (relation_name, parameters, span) =
+            parse_io_directive(parsed_rule, file, "input directive missing relation name")?;
         Ok(Self {
             relation_name,
-            parameters: parse_io_params(inner)?,
+            parameters,
             span: Ignored(span),
         })
     }
@@ -110,15 +122,11 @@ impl OutputDirective {
 
 impl Lexeme for OutputDirective {
     fn from_parsed_rule(parsed_rule: Pair<Rule>, file: FileId) -> Result<Self, ParseError> {
-        let mut inner = parsed_rule.into_inner();
-        let name_pair = inner
-            .next()
-            .ok_or_else(|| grammar_bug("output directive missing relation name"))?;
-        let span = span_of(&name_pair, file);
-        let relation_name = name_pair.as_str().to_lowercase();
+        let (relation_name, parameters, span) =
+            parse_io_directive(parsed_rule, file, "output directive missing relation name")?;
         Ok(Self {
             relation_name,
-            parameters: parse_io_params(inner)?,
+            parameters,
             span: Ignored(span),
         })
     }

--- a/crates/flowlog-build/src/parser/error.rs
+++ b/crates/flowlog-build/src/parser/error.rs
@@ -12,10 +12,12 @@
 
 use std::path::PathBuf;
 
-use crate::common::{primary_label, secondary_label, Diagnostic, InternalError, BUG_URL};
-use crate::common::{FileId, Span};
 use codespan_reporting::diagnostic::{Diagnostic as CsDiagnostic, Label};
 use thiserror::Error;
+
+use crate::common::{
+    BUG_URL, Diagnostic, FileId, InternalError, Span, primary_label, secondary_label,
+};
 
 /// Which `.decl`-style directive is being reported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +48,12 @@ fn dup_labels(span: Span, prior: Span, here: &str, first: &str) -> Vec<Label<Fil
     .into_iter()
     .flatten()
     .collect()
+}
+
+/// Single-element label vec for diagnostics that only point at one span.
+/// Returns an empty vec for dummy spans rather than fabricating a location.
+fn primary_only(span: Span) -> Vec<Label<FileId>> {
+    primary_label(span).into_iter().collect()
 }
 
 /// Errors raised while parsing a FlowLog program.
@@ -193,32 +201,32 @@ impl Diagnostic for ParseError {
             )),
 
             ParseError::UndeclaredInDirective { span, name, .. } => base
-                .with_labels(primary_label(*span).into_iter().collect())
+                .with_labels(primary_only(*span))
                 .with_notes(vec![format!(
                     "add a `.decl {name}(...)` before this directive"
                 )]),
 
             ParseError::UndeclaredInIterativeList { span, name } => base
-                .with_labels(primary_label(*span).into_iter().collect())
+                .with_labels(primary_only(*span))
                 .with_notes(vec![format!(
                     "either `.decl {name}(...)` it, or drop `{name}` from the iterative list"
                 )]),
 
             ParseError::UndeclaredLoopCondition { span, name } => base
-                .with_labels(primary_label(*span).into_iter().collect())
+                .with_labels(primary_only(*span))
                 .with_notes(vec![format!(
                     "declare `{name}` as a nullary relation with `.decl {name}()` and derive it inside the loop"
                 )]),
 
             ParseError::UndeclaredInRule { span, name }
             | ParseError::UndeclaredInFact { span, name } => base
-                .with_labels(primary_label(*span).into_iter().collect())
+                .with_labels(primary_only(*span))
                 .with_notes(vec![format!(
                     "add a matching `.decl {name}(...)` declaration, or remove the reference"
                 )]),
 
             ParseError::CircularInclude { span, chain, .. } => {
-                let mut diag = base.with_labels(primary_label(*span).into_iter().collect());
+                let mut diag = base.with_labels(primary_only(*span));
                 if !chain.is_empty() {
                     let shown: Vec<String> = chain.iter().map(|p| p.display().to_string()).collect();
                     diag = diag.with_notes(vec![format!("include chain: {}", shown.join(" → "))]);
@@ -230,9 +238,7 @@ impl Diagnostic for ParseError {
             | ParseError::LoopBlockInStandardMode { span }
             | ParseError::NonNullaryLoopCondition { span, .. }
             | ParseError::PlaceholderInUdf { span, .. }
-            | ParseError::IncludeIo { span, .. } => {
-                base.with_labels(primary_label(*span).into_iter().collect())
-            }
+            | ParseError::IncludeIo { span, .. } => base.with_labels(primary_only(*span)),
 
             ParseError::Internal(_) => unreachable!("handled above"),
         }

--- a/crates/flowlog-build/src/planner/error.rs
+++ b/crates/flowlog-build/src/planner/error.rs
@@ -9,11 +9,12 @@
 //! file a bug" ICE instead of a process abort.
 
 use codespan_reporting::diagnostic::Diagnostic as CsDiagnostic;
-use crate::common::{primary_label, secondary_label, Diagnostic, InternalError, BUG_URL};
-use crate::common::{FileId, Span};
 use thiserror::Error;
 
 use crate::catalog::CatalogError;
+use crate::common::{
+    BUG_URL, Diagnostic, FileId, InternalError, Span, primary_label, secondary_label,
+};
 use crate::parser::AggregationOperator;
 
 #[non_exhaustive]

--- a/crates/flowlog-build/src/stratifier/error.rs
+++ b/crates/flowlog-build/src/stratifier/error.rs
@@ -7,10 +7,20 @@
 //! fire. Each variant carries at least one [`Span`] so the renderer can
 //! point at the offending source.
 
-use crate::common::{primary_label, Diagnostic};
-use crate::common::{FileId, Span};
-use codespan_reporting::diagnostic::Diagnostic as CsDiagnostic;
+use codespan_reporting::diagnostic::{Diagnostic as CsDiagnostic, Label};
 use thiserror::Error;
+
+use crate::common::{Diagnostic, FileId, Span, primary_label};
+
+/// Build one primary label per rule, annotated with `rule {id}`.
+fn rule_labels(rules: &[(usize, Span)]) -> Vec<Label<FileId>> {
+    rules
+        .iter()
+        .filter_map(|(rid, span)| {
+            primary_label(*span).map(|l| l.with_message(format!("rule {rid}")))
+        })
+        .collect()
+}
 
 /// Errors raised while stratifying a FlowLog program.
 #[non_exhaustive]
@@ -98,15 +108,9 @@ impl Diagnostic for StratifyError {
     fn to_diagnostic(&self) -> CsDiagnostic<FileId> {
         let base = CsDiagnostic::error().with_message(self.to_string());
         match self {
-            StratifyError::RecursionOutsideLoop { rules, hint } => {
-                let labels: Vec<_> = rules
-                    .iter()
-                    .filter_map(|(rid, span)| {
-                        primary_label(*span).map(|l| l.with_message(format!("rule {rid}")))
-                    })
-                    .collect();
-                base.with_labels(labels).with_notes(vec![hint.to_string()])
-            }
+            StratifyError::RecursionOutsideLoop { rules, hint } => base
+                .with_labels(rule_labels(rules))
+                .with_notes(vec![hint.to_string()]),
 
             StratifyError::IterativeNotInLoopHead { decl_span, .. } => base
                 .with_labels(primary_label(*decl_span).into_iter().collect())
@@ -132,13 +136,7 @@ impl Diagnostic for StratifyError {
                 )]),
 
             StratifyError::RecursiveStratumEmpty { rules, .. } => {
-                let labels: Vec<_> = rules
-                    .iter()
-                    .filter_map(|(rid, span)| {
-                        primary_label(*span).map(|l| l.with_message(format!("rule {rid}")))
-                    })
-                    .collect();
-                base.with_labels(labels).with_notes(vec![
+                base.with_labels(rule_labels(rules)).with_notes(vec![
                     "a `loop`/`fixpoint` block must contain at least one rule whose \
                      head relation also appears in a body atom within the same block"
                         .into(),


### PR DESCRIPTION
This PR is part of a curated batch of cleanup commits selected from a 30-iteration `minimalist` run. Each PR groups commits by theme so reviewers can accept/reject themes independently.

**Verification on the joint integration branch** [`minimalist/integration-30gen-20260503-065013`](https://github.com/flowlog-rs/flowlog/tree/minimalist/integration-30gen-20260503-065013):

- ✅ `cargo build --release --workspace` — clean
- ✅ `cargo test --release --workspace` — 168 / 168 passing
- ✅ `tests/unit/unit_compiler.sh agg_avg agg_chained agg_count agg_count_string agg_max` — 5 / 5 passing
- ✅ Perf gate (median of 3 runs, `WORKERS=4`):
  | bench | main-next | candidate | Δ |
  |---|---:|---:|---:|
  | crdt | 1.0121 s | 1.0092 s | **−0.29 %** |
  | csda-httpd | 2.9978 s | 3.0446 s | +1.56 % |
  | dyck (kernel) | 3.0436 s | 3.0559 s | +0.40 % |

  Gate threshold ±5 %; all three are well within noise.

### Theme: small DRY extractions
4 commits:

| commit | site | change |
|---|---|---|
| parser/error.rs | extract repeated label-builder body | |
| codegen/profile.rs | small accessor helper for repeated field access | |
| stratifier/error.rs + catalog/filter.rs | factor duplicate diagnostic helper | |
| parser/declaration/directive.rs + planner/error.rs | merge duplicate `use crate::common` blocks alongside the helper extraction | |

All extractions are private helpers; no public API change.