### PR TITLE
cleanups(docs): fix doc comment in aggregation parser

### DIFF
--- a/crates/flowlog-build/src/codegen/features.rs
+++ b/crates/flowlog-build/src/codegen/features.rs
@@ -4,9 +4,9 @@
 //! compilation unit so that downstream passes (imports, scaffold, type
 //! declarations) emit only what is required.
 
-use crate::parser::{AggregationOperator, DataType};
-
 use std::collections::HashSet;
+
+use crate::parser::{AggregationOperator, DataType};
 
 // =========================================================================
 // AggSemiringNeeds

--- a/crates/flowlog-build/src/parser/logic/aggregation.rs
+++ b/crates/flowlog-build/src/parser/logic/aggregation.rs
@@ -12,9 +12,9 @@ use std::fmt;
 
 /// Supported aggregation operators.
 ///
-/// Declared `pub` because `Features::agg_semirings()` returns
-/// `&[(AggregationOperator, DataType)]` which `flowlog-compiler` iterates
-/// over and calls [`Self::semiring_mod`] / [`Self::semiring_prefix`] on.
+/// Declared `pub` because `Features::agg_semirings()` exposes an
+/// `AggSemiringNeeds` whose entries `flowlog-compiler` iterates over,
+/// calling [`Self::semiring_mod`] / [`Self::semiring_prefix`] on each.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AggregationOperator {
     Min,


### PR DESCRIPTION
This PR is part of a curated batch of cleanup commits selected from a 30-iteration `minimalist` run. Each PR groups commits by theme so reviewers can accept/reject themes independently.

**Verification on the joint integration branch** [`minimalist/integration-30gen-20260503-065013`](https://github.com/flowlog-rs/flowlog/tree/minimalist/integration-30gen-20260503-065013):

- ✅ `cargo build --release --workspace` — clean
- ✅ `cargo test --release --workspace` — 168 / 168 passing
- ✅ `tests/unit/unit_compiler.sh agg_avg agg_chained agg_count agg_count_string agg_max` — 5 / 5 passing
- ✅ Perf gate (median of 3 runs, `WORKERS=4`):
  | bench | main-next | candidate | Δ |
  |---|---:|---:|---:|
  | crdt | 1.0121 s | 1.0092 s | **−0.29 %** |
  | csda-httpd | 2.9978 s | 3.0446 s | +1.56 % |
  | dyck (kernel) | 3.0436 s | 3.0559 s | +0.40 % |

  Gate threshold ±5 %; all three are well within noise.

### Theme: documentation only
1 commit. Fixes a stale/typo doc comment in `parser/logic/aggregation.rs` and tidies a related pair of imports in `codegen/features.rs`.

Pure documentation; zero impact on compiled output.