### PR TITLE
cleanups(idiomatic v2): small idiomatic-Rust rewrites in planner/parser/stratifier

### DIFF
--- a/crates/flowlog-build/src/common/config.rs
+++ b/crates/flowlog-build/src/common/config.rs
@@ -1,8 +1,9 @@
 //! Command line argument parsing for FlowLog tools.
 
-use clap::{Parser, ValueEnum};
 use std::path::{Path, PathBuf};
 use std::{fs, process};
+
+use clap::{Parser, ValueEnum};
 
 /// Execution strategy for FlowLog workflows
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum, Default)]
@@ -107,8 +108,8 @@ impl Config {
         Path::new(&self.program)
             .file_stem()
             .and_then(|stem| stem.to_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "unknown_program".into())
+            .unwrap_or("unknown_program")
+            .to_string()
     }
 
     pub fn fact_dir(&self) -> Option<&str> {

--- a/crates/flowlog-build/src/parser/primitive/data_type.rs
+++ b/crates/flowlog-build/src/parser/primitive/data_type.rs
@@ -51,19 +51,7 @@ pub enum DataType {
 impl DataType {
     /// Returns `true` for all integer and floating-point types.
     pub(crate) fn is_numeric(&self) -> bool {
-        matches!(
-            self,
-            Self::Int8
-                | Self::Int16
-                | Self::Int32
-                | Self::Int64
-                | Self::UInt8
-                | Self::UInt16
-                | Self::UInt32
-                | Self::UInt64
-                | Self::Float32
-                | Self::Float64
-        )
+        self.is_integer() || self.is_float()
     }
 
     /// Returns `true` for integer types only (excludes floats, strings, bools).

--- a/crates/flowlog-build/src/planner/arithmetic.rs
+++ b/crates/flowlog-build/src/planner/arithmetic.rs
@@ -75,9 +75,9 @@ impl ArithmeticArgument {
         ) -> FactorArgument {
             match factor {
                 FactorPos::Var(_) => {
-                    let var_signature = &var_arguments[*var_id];
+                    let var = var_arguments[*var_id];
                     *var_id += 1;
-                    FactorArgument::Var(*var_signature)
+                    FactorArgument::Var(var)
                 }
                 FactorPos::Const(constant) => FactorArgument::Const(constant.clone()),
                 FactorPos::FnCall { name, args } => {

--- a/crates/flowlog-build/src/planner/rule_planner/fuse.rs
+++ b/crates/flowlog-build/src/planner/rule_planner/fuse.rs
@@ -196,10 +196,7 @@ impl RulePlanner {
 
         for tx_fp in tx_fps {
             // Copy out the producer index and current consumers (if any), then mutate
-            let Some((producer_indices, consumers)) = self
-                .producer_consumer
-                .get(&tx_fp)
-                .map(|(p, c)| (p.clone(), c.clone()))
+            let Some((producer_indices, consumers)) = self.producer_consumer.get(&tx_fp).cloned()
             else {
                 // No producer found - likely an original atom; ignore
                 continue;
@@ -307,16 +304,11 @@ impl RulePlanner {
     // Collect all output positions (keys + values) from an upstream transformation.
     #[inline]
     fn collect_output_positions(&self, producer_idx: usize) -> Vec<ArithmeticPos> {
-        self.transformation_infos[producer_idx]
-            .output_kv_layout()
+        let layout = self.transformation_infos[producer_idx].output_kv_layout();
+        layout
             .key()
             .iter()
-            .chain(
-                self.transformation_infos[producer_idx]
-                    .output_kv_layout()
-                    .value()
-                    .iter(),
-            )
+            .chain(layout.value().iter())
             .cloned()
             .collect()
     }
@@ -499,12 +491,7 @@ impl RulePlanner {
 
         // Second pass: register all consumers for each input fingerprint
         for index in 0..count {
-            let (left_fp, right_fp_opt) = {
-                let tx = &self.transformation_infos[index];
-                let (left_fp, right_fp_opt) = tx.input_info_fp();
-                (left_fp, right_fp_opt)
-            };
-
+            let (left_fp, right_fp_opt) = self.transformation_infos[index].input_info_fp();
             for input_fp in [Some(left_fp), right_fp_opt].into_iter().flatten() {
                 self.insert_consumer(original_atom_fp, input_fp, index)?;
             }

--- a/crates/flowlog-build/src/stratifier/dependency_graph.rs
+++ b/crates/flowlog-build/src/stratifier/dependency_graph.rs
@@ -46,18 +46,21 @@ impl DependencyGraph {
         let mut negative_edges: BTreeSet<(usize, usize)> = BTreeSet::new();
 
         for (rule_id, rule) in rules.iter().enumerate() {
+            // Pre-populated above, so the entry is guaranteed to exist.
+            let deps = dependency_map.get_mut(&rule_id).unwrap();
             for predicate in rule.rhs() {
                 let (atom_name, is_negative) = match predicate {
                     Predicate::PositiveAtom(atom) => (atom.name(), false),
                     Predicate::NegativeAtom(atom) => (atom.name(), true),
                     _ => continue,
                 };
-                if let Some(dep_ids) = head_to_rule_map.get(atom_name) {
-                    for &dep_id in dep_ids {
-                        dependency_map.get_mut(&rule_id).unwrap().insert(dep_id);
-                        if is_negative {
-                            negative_edges.insert((rule_id, dep_id));
-                        }
+                let Some(dep_ids) = head_to_rule_map.get(atom_name) else {
+                    continue;
+                };
+                for &dep_id in dep_ids {
+                    deps.insert(dep_id);
+                    if is_negative {
+                        negative_edges.insert((rule_id, dep_id));
                     }
                 }
             }


### PR DESCRIPTION
This PR is part of a curated cleanup batch from a 100-iteration `minimalist` run on top of [PRs #89–92]. Themes are split so each PR can be accepted/rejected on its own merits and reviewed in isolation.

**Verification on integration branch** [`cleanups/batch2-integration`](https://github.com/hdz284/flowlog/tree/cleanups/batch2-integration) (this PR + the 3 sibling cleanup PRs merged together on top of `main-next`):

- ✅ `cargo build --release --workspace` — clean in 9.7 s
- ✅ `cargo test --release --workspace` — 125 + 14 + 6 + 3 + 3 + 15 unit tests pass; doctests green
- ✅ `tests/unit/unit_compiler.sh agg_avg agg_chained agg_count agg_count_string agg_max` — 5 / 5 passing
- ✅ Cleanly cherry-picks onto `main-next` (5 conflict-free commits)
- ✅ Zero file overlap with PRs #89, #90, #91, #92 or with the sibling batch-2 PRs

### Theme: idiomatic Rust rewrites
5 commits. Each is small and contained:

| commit | site | change |
|---|---|---|
| 79b8b24 | `common/config.rs` | grouped `use` block + collapsed `.map(\|s\| s.to_string()).unwrap_or_else(\|\| "…".into())` into `.unwrap_or("…").to_string()` |
| a136703 | `stratifier/dependency_graph.rs` | hoisted the dependency-map `get_mut` out of the inner loop (one lookup per outer key instead of per inner iteration) |
| 494b052 | `planner/arithmetic.rs` | simplified the `Va…` variant pattern |
| a897dfc | `parser/primitive/data_type.rs` | `is_numeric` now reads `self.is_integer() \|\| self.is_float()` instead of duplicating the variant list (−13 lines, single source of truth for the numeric-set definition) |
| 8cae035 | `planner/rule_planner/fuse.rs` | flattened nested `if let` |

No behavioural change in any commit; `cargo test` and the unit-compiler smoke test confirm.
