### PR TITLE
cleanup: dedupe and sort imports across crates

### DIFF
--- a/crates/flowlog-build/src/build/pipeline.rs
+++ b/crates/flowlog-build/src/build/pipeline.rs
@@ -12,16 +12,14 @@ use std::path::{Path, PathBuf};
 
 use proc_macro2::TokenStream;
 
-use crate::common::BoxError;
-use crate::common::{Config, SourceMap};
+use crate::build::relation::gen_input_module;
+use crate::codegen::Features;
+use crate::common::{BoxError, Config, SourceMap};
 use crate::optimizer::Optimizer;
 use crate::parser::Program;
 use crate::planner::StratumPlanner;
 use crate::profiler::Profiler;
 use crate::stratifier::Stratifier;
-
-use crate::build::relation::gen_input_module;
-use crate::codegen::Features;
 use crate::{BuildError, Builder, CodeGen, CodeParts};
 
 /// Artifacts produced by one compilation, consumed by library-mode assembly.

--- a/crates/flowlog-build/src/build/relation/handler.rs
+++ b/crates/flowlog-build/src/build/relation/handler.rs
@@ -13,9 +13,7 @@ use quote::quote;
 use crate::common::Span;
 use crate::parser::{ConstType, Relation};
 
-use crate::codegen::const_to_token;
-use crate::codegen::CodegenError;
-use crate::codegen::tuple_tokens;
+use crate::codegen::{CodegenError, const_to_token, tuple_tokens};
 use crate::data_type_tokens;
 
 use super::input_struct_ident;

--- a/crates/flowlog-build/src/build/relation/mod.rs
+++ b/crates/flowlog-build/src/build/relation/mod.rs
@@ -15,10 +15,8 @@ pub(crate) mod user;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 
+use crate::codegen::{CodegenError, Features};
 use crate::parser::{Program, Relation};
-
-use crate::codegen::CodegenError;
-use crate::codegen::Features;
 
 /// Emit the body of the library-mode `relops` module — EDB input handlers
 /// + the `Inputs` container — plus the `use` lines they depend on.

--- a/crates/flowlog-build/src/catalog/error.rs
+++ b/crates/flowlog-build/src/catalog/error.rs
@@ -3,9 +3,11 @@
 use std::fmt;
 
 use codespan_reporting::diagnostic::Diagnostic as CsDiagnostic;
-use crate::common::{primary_label, secondary_label, Diagnostic, InternalError, BUG_URL};
-use crate::common::{FileId, Span};
 use thiserror::Error;
+
+use crate::common::{
+    BUG_URL, Diagnostic, FileId, InternalError, Span, primary_label, secondary_label,
+};
 
 /// Which body predicate carried an unsafe variable. Only affects the
 /// rendered wording; all three kinds share the same range-restriction rule.
@@ -62,17 +64,17 @@ impl Diagnostic for CatalogError {
                 var,
                 ..
             } => {
-                let mut label_vec = Vec::new();
+                let mut labels = Vec::new();
                 if let Some(l) = primary_label(*predicate_span) {
-                    label_vec
+                    labels
                         .push(l.with_message(format!("`{var}` is never bound in a positive atom")));
                 }
                 if let Some(l) = secondary_label(*rule_span) {
-                    label_vec.push(l.with_message("in this rule"));
+                    labels.push(l.with_message("in this rule"));
                 }
                 CsDiagnostic::error()
                     .with_message(self.to_string())
-                    .with_labels(label_vec)
+                    .with_labels(labels)
                     .with_notes(vec![
                         "every variable in a body predicate must also appear in a \
                          positive atom, so the set of tuples it ranges over is finite"

--- a/crates/flowlog-build/src/codegen/aggregation/common.rs
+++ b/crates/flowlog-build/src/codegen/aggregation/common.rs
@@ -10,8 +10,7 @@ use quote::{format_ident, quote};
 
 use crate::parser::{AggregationOperator, DataType};
 
-use crate::codegen::tuple_tokens;
-use crate::codegen::CodegenError;
+use crate::codegen::{CodegenError, tuple_tokens};
 
 // ==================================================
 // Semiring constructor helpers

--- a/crates/flowlog-build/src/codegen/code_parts.rs
+++ b/crates/flowlog-build/src/codegen/code_parts.rs
@@ -1,16 +1,15 @@
 //! Bundles per-pass fragments into [`CodeParts`].
 
-use proc_macro2::TokenStream;
-use quote::quote;
 use std::collections::HashSet;
 
-use crate::planner::StratumPlanner;
-use crate::profiler::{with_profiler, Profiler};
+use proc_macro2::TokenStream;
+use quote::quote;
 
 use crate::codegen::idb_buffers::InspectorCodegen;
 use crate::codegen::profile::render_profile_ops_const;
-use crate::codegen::CodeGen;
-use crate::codegen::CodegenError;
+use crate::codegen::{CodeGen, CodegenError};
+use crate::planner::StratumPlanner;
+use crate::profiler::{Profiler, with_profiler};
 
 /// Token-stream fragments and rendered source files produced by
 /// [`CodeGen::generate`]. All fields are `pub` so consumers can

--- a/crates/flowlog-build/src/codegen/flow/transformation.rs
+++ b/crates/flowlog-build/src/codegen/flow/transformation.rs
@@ -4,31 +4,28 @@
 //! such as Row-to-Row, Row-to-KV, KV-to-KV, KV-to-Row, Joins, and Antijoins
 //! in the differential dataflow pipelines.
 
-use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote};
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::profiler::{with_profiler, Profiler};
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
 
 use crate::codegen::arg::{
     build_kv_constraints_predicate, build_row_constraints_predicate, combine_predicates,
     compute_join_param_tokens, compute_kv_param_tokens, kv_use_counts, row_pattern_and_fields,
     row_use_counts,
 };
-use crate::codegen::data_type_tokens;
 use crate::codegen::ident::find_local_ident;
-use crate::codegen::CodeGen;
-use crate::codegen::CodegenError;
-
+use crate::codegen::{CodeGen, CodegenError, data_type_tokens};
 use crate::planner::{StratumPlanner, Transformation};
+use crate::profiler::{Profiler, with_profiler};
 
-/// Generate differential dataflow pipelines for a single transformation.
-///
-/// For non-recursive transformations, we use the global fingerprint-to-ident map.
-/// For recursive transformations, we use the local fingerprint-to-ident map.
-/// This function accepts the map as `local_fp_to_ident` to keep the interface unified.
 impl CodeGen {
+    /// Generate differential dataflow pipelines for a single transformation.
+    ///
+    /// For non-recursive transformations, we use the global fingerprint-to-ident map.
+    /// For recursive transformations, we use the local fingerprint-to-ident map.
+    /// This function accepts the map as `local_fp_to_ident` to keep the interface unified.
     pub(super) fn gen_transformation(
         &mut self,
         local_fp_to_ident: &HashMap<u64, Ident>,

--- a/crates/flowlog-build/src/codegen/idb_buffers.rs
+++ b/crates/flowlog-build/src/codegen/idb_buffers.rs
@@ -6,15 +6,14 @@
 //! Buffers store `(data, time, diff)` triples. Batch mode hardcodes
 //! `diff = 1` (DD uses `Present`, not `i32`). Sort operates on data only.
 
-use crate::codegen::ty::tuple_type;
-use crate::codegen::CodeGen;
-
-use crate::parser::{DataType, Relation};
-use crate::profiler::{with_profiler, Profiler};
-
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::Index;
+
+use crate::codegen::CodeGen;
+use crate::codegen::ty::tuple_type;
+use crate::parser::{DataType, Relation};
+use crate::profiler::{Profiler, with_profiler};
 
 // =========================================================================
 // Output struct
@@ -78,9 +77,7 @@ impl CodeGen {
 
                 self.features.mark_output_buffers();
 
-                let to_stdout = self.config.output_to_stdout();
-
-                if to_stdout {
+                if self.config.output_to_stdout() {
                     with_profiler(profiler, |p| {
                         p.inspect_content_terminal_operator(name.to_string(), name.to_string());
                     });

--- a/crates/flowlog-build/src/codegen/ty/data.rs
+++ b/crates/flowlog-build/src/codegen/ty/data.rs
@@ -14,8 +14,7 @@ use crate::planner::{
     ArithmeticArgument, FactorArgument, StratumPlanner, TransformationArgument, TransformationFlow,
 };
 
-use crate::codegen::CodeGen;
-use crate::codegen::CodegenError;
+use crate::codegen::{CodeGen, CodegenError};
 
 /// `(key_types, value_types)` — a relation's shape in key++value form.
 pub(crate) type KvTypes = (Vec<DataType>, Vec<DataType>);

--- a/crates/flowlog-build/src/parser/logic/atom.rs
+++ b/crates/flowlog-build/src/parser/logic/atom.rs
@@ -3,14 +3,14 @@
 //! - [`AtomArg`]: variable / constant / placeholder (`_`)
 //! - [`Atom`]: `name(arg1, ..., argN)`
 
-use crate::parser::error::{grammar_bug, ParseError};
-use crate::parser::primitive::ConstType;
-use crate::parser::{span_of, Lexeme, Rule};
-use pest::iterators::Pair;
 use std::fmt;
 
-use crate::common::compute_fp;
-use crate::common::{FileId, Ignored, Span};
+use pest::iterators::Pair;
+
+use crate::common::{FileId, Ignored, Span, compute_fp};
+use crate::parser::error::{ParseError, grammar_bug};
+use crate::parser::primitive::ConstType;
+use crate::parser::{Lexeme, Rule, span_of};
 
 /// An argument to an atom: variable, constant, or `_`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/flowlog-build/src/parser/logic/fn_call.rs
+++ b/crates/flowlog-build/src/parser/logic/fn_call.rs
@@ -3,13 +3,14 @@
 //! A [`FnCall`] represents a user-defined function applied to arguments
 //! in a rule head or as a boolean predicate (e.g., `my_udf(x, y + 1)`).
 
-use super::Arithmetic;
-use crate::parser::error::{grammar_bug, ParseError};
-use crate::parser::{span_of, Lexeme, Rule};
-
-use crate::common::{FileId, Ignored, Span};
-use pest::iterators::Pair;
 use std::fmt;
+
+use pest::iterators::Pair;
+
+use super::Arithmetic;
+use crate::common::{FileId, Ignored, Span};
+use crate::parser::error::{ParseError, grammar_bug};
+use crate::parser::{Lexeme, Rule, span_of};
 
 /// A user-defined function call in a rule head or body predicates.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/flowlog-build/src/parser/logic/predicate.rs
+++ b/crates/flowlog-build/src/parser/logic/predicate.rs
@@ -6,12 +6,15 @@
 //!
 //! Predicates form the antecedent of rules: `head(...) :- p1, !p2, X > Y.`
 
-use super::{Atom, ComparisonExpr, FnCall};
+use std::fmt;
+
+use pest::iterators::Pair;
+
 use crate::common::FileId;
 use crate::parser::error::{grammar_bug, ParseError};
 use crate::parser::{Lexeme, Rule};
-use pest::iterators::Pair;
-use std::fmt;
+
+use super::{Atom, ComparisonExpr, FnCall};
 
 /// A predicate in a rule body.
 #[derive(Clone, PartialEq, Eq, Hash)]

--- a/crates/flowlog-build/src/profiler/mod.rs
+++ b/crates/flowlog-build/src/profiler/mod.rs
@@ -18,11 +18,13 @@ mod operators;
 mod rule;
 mod steps;
 
+use std::io;
+
+use serde::{Deserialize, Serialize};
+
 use crate::common::ExecutionMode;
 use crate::profiler::node::{NodeManager, NodeProfile};
 use crate::profiler::rule::RuleProfile;
-use serde::{Deserialize, Serialize};
-use std::io;
 
 /// Profiler that records the operator plan graph during compilation.
 #[derive(Serialize, Deserialize, Debug, Default)]


### PR DESCRIPTION
This PR normalizes and deduplicates `use` blocks across 13 files.
It is import hygiene only and does not change behavior.

## Scope

| Touches | What changed |
|---|---|
| 13 files | Merge duplicate `use` lines and normalize order: `std` → external crates → `crate`/`super` |

**Diffstat:** `+57 / -64`

## Notable non-import nits

| File | Change |
|---|---|
| `codegen/flow/transformation.rs` | local `label_vec` → `labels` |
| `profiler/mod.rs` | remove dead `to_stdout` binding |

## Verification

| Gate | Result |
|---|---|
| `cargo build --release --workspace` | ✅ |
| `cargo test --workspace` | ✅ 168 / 168 |
| `cargo clippy --all-targets -- -D warnings` | ✅ |
| `tests/unit/unit_compiler.sh` | ✅ 95 / 95 |
| `tests/unit/unit_lib.sh` | ✅ 95 / 95 |
| `tests/complex` integer config | ✅ 19 / 19 |

## Supersedes

Replaces #89 and #93.
