### PR TITLE
cleanup: modernize idiomatic Rust patterns

### DIFF
--- a/crates/flowlog-build/src/catalog/arithmetic.rs
+++ b/crates/flowlog-build/src/catalog/arithmetic.rs
@@ -53,12 +53,12 @@ impl FactorPos {
 impl fmt::Display for FactorPos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            FactorPos::Var(sig) => write!(f, "{}", sig),
-            FactorPos::Const(c) => write!(f, "{}", c),
+            FactorPos::Var(sig) => write!(f, "{sig}"),
+            FactorPos::Const(c) => write!(f, "{c}"),
             FactorPos::FnCall { name, args } => {
                 let args_str = args
                     .iter()
-                    .map(|a| a.to_string())
+                    .map(ArithmeticPos::to_string)
                     .collect::<Vec<_>>()
                     .join(", ");
                 write!(f, "{name}({args_str})")
@@ -176,7 +176,7 @@ impl fmt::Display for ArithmeticPos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.init)?;
         for (op, factor) in &self.rest {
-            write!(f, " {} {}", op, factor)?;
+            write!(f, " {op} {factor}")?;
         }
         Ok(())
     }

--- a/crates/flowlog-build/src/catalog/rule/modify.rs
+++ b/crates/flowlog-build/src/catalog/rule/modify.rs
@@ -426,12 +426,9 @@ impl Catalog {
     ) -> Result<(), CatalogError> {
         let mut new_rhs = self.rule.rhs().to_vec();
 
-        global_rhs_indices_to_update
-            .iter()
-            .enumerate()
-            .for_each(|(i, idx)| {
-                new_rhs[*idx] = new_predicates[i].clone();
-            });
+        for (idx, pred) in global_rhs_indices_to_update.into_iter().zip(new_predicates) {
+            new_rhs[idx] = pred;
+        }
         new_rhs.remove(global_rhs_index_to_remove);
 
         let new_rule = FlowLogRule::new(self.rule.head().clone(), new_rhs);

--- a/crates/flowlog-build/src/codegen/edb_handles.rs
+++ b/crates/flowlog-build/src/codegen/edb_handles.rs
@@ -4,7 +4,6 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::codegen::CodeGen;
-
 use crate::parser::DataType;
 use crate::profiler::{with_profiler, Profiler};
 
@@ -33,8 +32,8 @@ impl CodeGen {
         }
 
         if edbs.iter().any(|rel| {
-            rel.data_type().contains(&DataType::Float32)
-                || rel.data_type().contains(&DataType::Float64)
+            let dt = rel.data_type();
+            dt.contains(&DataType::Float32) || dt.contains(&DataType::Float64)
         }) {
             self.features.mark_ordered_float();
         }

--- a/crates/flowlog-build/src/codegen/flow/recursive.rs
+++ b/crates/flowlog-build/src/codegen/flow/recursive.rs
@@ -197,9 +197,8 @@ impl CodeGen {
             });
 
             // Preserve arranged bindings for recursive paths.
-            if non_recursive_arranged_map.contains_key(fp) {
-                let entered_arr =
-                    format_ident!("in_{}", non_recursive_arranged_map.get(fp).unwrap());
+            if let Some(arranged) = non_recursive_arranged_map.get(fp) {
+                let entered_arr = format_ident!("in_{}", arranged);
                 recursive_arranged.insert(*fp, entered_arr);
             }
         }
@@ -260,23 +259,15 @@ impl CodeGen {
 
             with_profiler(profiler, |profiler| {
                 let output_name = self.find_global_ident(*idb_fp).to_string();
-                if sources.len() > 1 {
-                    profiler.concat_dedup_operator(
-                        output_name,
-                        sources.iter().map(|id| id.to_string()).collect(),
-                        next_ident.to_string(),
-                        sources.len() as u32 - 1,
-                        true,
-                    );
-                } else {
-                    profiler.concat_dedup_operator(
-                        output_name,
-                        vec![sources[0].to_string()],
-                        next_ident.to_string(),
-                        0,
-                        true,
-                    );
-                }
+                let source_names: Vec<String> = sources.iter().map(|id| id.to_string()).collect();
+                let concat_count = (sources.len() as u32).saturating_sub(1);
+                profiler.concat_dedup_operator(
+                    output_name,
+                    source_names,
+                    next_ident.to_string(),
+                    concat_count,
+                    true,
+                );
             });
 
             // ----------------------------------------------------------------

--- a/crates/flowlog-build/src/codegen/semiring.rs
+++ b/crates/flowlog-build/src/codegen/semiring.rs
@@ -53,7 +53,7 @@ impl CodeGen {
             return Vec::new();
         }
 
-        let s = self.features.agg_semirings();
+        let semirings = self.features.agg_semirings();
 
         // Int/uint type table: (suffix, rust_type)
         const INT_TYPES: [(&str, &str); 8] = [
@@ -82,11 +82,11 @@ impl CodeGen {
             let kind_str = op.semiring_mod();
             let pfx = op.semiring_prefix();
 
-            let int_needs = s.int_needs(op);
-            let float_needs = s.float_needs(op);
+            let int_needs = semirings.int_needs(op);
+            let float_needs = semirings.float_needs(op);
 
             // Int/uint file
-            if int_needs.iter().any(|n| *n) {
+            if int_needs.iter().any(|&n| n) {
                 let mut rendered = int_tmpl.to_string();
                 for (i, (suffix, ty)) in INT_TYPES.iter().enumerate() {
                     if int_needs[i] {
@@ -97,16 +97,15 @@ impl CodeGen {
                         }
                     }
                 }
-                let file_name = format!("{kind_str}_int.rs");
                 files.push((
-                    format!("semiring/{file_name}"),
+                    format!("semiring/{kind_str}_int.rs"),
                     rendered.trim_start().to_string(),
                 ));
                 modules.push(format!("{kind_str}_int"));
             }
 
             // Float file
-            if float_needs.iter().any(|n| *n) {
+            if float_needs.iter().any(|&n| n) {
                 let mut rendered = float_tmpl.to_string();
                 for (i, (suffix, inner)) in FLOAT_TYPES.iter().enumerate() {
                     if float_needs[i] {
@@ -127,9 +126,8 @@ impl CodeGen {
                         }
                     }
                 }
-                let file_name = format!("{kind_str}_float.rs");
                 files.push((
-                    format!("semiring/{file_name}"),
+                    format!("semiring/{kind_str}_float.rs"),
                     rendered.trim_start().to_string(),
                 ));
                 modules.push(format!("{kind_str}_float"));

--- a/crates/flowlog-build/src/common/config.rs
+++ b/crates/flowlog-build/src/common/config.rs
@@ -1,8 +1,9 @@
 //! Command line argument parsing for FlowLog tools.
 
-use clap::{Parser, ValueEnum};
 use std::path::{Path, PathBuf};
 use std::{fs, process};
+
+use clap::{Parser, ValueEnum};
 
 /// Execution strategy for FlowLog workflows
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum, Default)]
@@ -107,8 +108,8 @@ impl Config {
         Path::new(&self.program)
             .file_stem()
             .and_then(|stem| stem.to_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "unknown_program".into())
+            .unwrap_or("unknown_program")
+            .to_string()
     }
 
     pub fn fact_dir(&self) -> Option<&str> {

--- a/crates/flowlog-build/src/parser/declaration/extern_fn.rs
+++ b/crates/flowlog-build/src/parser/declaration/extern_fn.rs
@@ -4,10 +4,10 @@
 
 use std::fmt;
 
-use crate::common::{FileId, Ignored, Span};
 use pest::iterators::Pair;
 
-use crate::parser::error::{grammar_bug, ParseError};
+use crate::common::{FileId, Ignored, Span};
+use crate::parser::error::{ParseError, grammar_bug};
 use crate::parser::primitive::DataType;
 use crate::parser::{span_of, Lexeme, Rule};
 

--- a/crates/flowlog-build/src/parser/logic/arithmetic.rs
+++ b/crates/flowlog-build/src/parser/logic/arithmetic.rs
@@ -4,15 +4,16 @@
 //! - [`Factor`]: variables or constants
 //! - [`Arithmetic`]: `factor (op, factor)*`
 
-use super::FnCall;
-use crate::parser::error::{grammar_bug, ParseError};
-use crate::parser::primitive::ConstType;
-use crate::parser::{span_of, Lexeme, Rule};
-
-use crate::common::{FileId, Ignored, Span};
-use pest::iterators::Pair;
 use std::collections::HashSet;
 use std::fmt;
+
+use pest::iterators::Pair;
+
+use super::FnCall;
+use crate::common::{FileId, Ignored, Span};
+use crate::parser::error::{ParseError, grammar_bug};
+use crate::parser::primitive::ConstType;
+use crate::parser::{span_of, Lexeme, Rule};
 
 /// Arithmetic operator.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/flowlog-build/src/parser/logic/comparison.rs
+++ b/crates/flowlog-build/src/parser/logic/comparison.rs
@@ -121,11 +121,9 @@ impl ComparisonExpr {
     /// Unique variables referenced on either side (deduplicated).
     #[must_use]
     pub(crate) fn vars_set(&self) -> HashSet<&String> {
-        self.left
-            .vars_set()
-            .union(&self.right.vars_set())
-            .cloned()
-            .collect()
+        let mut vars = self.left.vars_set();
+        vars.extend(self.right.vars_set());
+        vars
     }
 }
 

--- a/crates/flowlog-build/src/parser/logic/head.rs
+++ b/crates/flowlog-build/src/parser/logic/head.rs
@@ -3,13 +3,14 @@
 //! - [`HeadArg`]: `Var | Arith | Aggregation`
 //! - [`Head`]: `rel(arg1, ..., argN)`
 
-use super::{Aggregation, Arithmetic};
-use crate::common::compute_fp;
-use crate::common::{FileId, Ignored, Span};
-use crate::parser::error::{grammar_bug, ParseError};
-use crate::parser::{span_of, Lexeme, Rule};
-use pest::iterators::Pair;
 use std::fmt;
+
+use pest::iterators::Pair;
+
+use super::{Aggregation, Arithmetic};
+use crate::common::{FileId, Ignored, Span, compute_fp};
+use crate::parser::error::{ParseError, grammar_bug};
+use crate::parser::{Lexeme, Rule, span_of};
 
 /// Argument in a rule head.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -146,12 +147,10 @@ impl Head {
 impl fmt::Display for Head {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}(", self.name)?;
-        let mut first = true;
-        for arg in &self.head_arguments {
-            if !first {
+        for (i, arg) in self.head_arguments.iter().enumerate() {
+            if i > 0 {
                 write!(f, ", ")?;
             }
-            first = false;
             write!(f, "{arg}")?;
         }
         write!(f, ")")
@@ -170,17 +169,15 @@ impl Lexeme for Head {
         let name = name_pair.as_str().to_lowercase();
         let head_fingerprint = compute_fp(&name);
 
-        let mut args = Vec::new();
-        for pair in inner {
-            if pair.as_rule() == Rule::head_arg {
-                args.push(HeadArg::from_parsed_rule(pair, file)?);
-            }
-        }
+        let head_arguments: Vec<HeadArg> = inner
+            .filter(|pair| pair.as_rule() == Rule::head_arg)
+            .map(|pair| HeadArg::from_parsed_rule(pair, file))
+            .collect::<Result<_, _>>()?;
 
         Ok(Self {
             name,
             head_fingerprint,
-            head_arguments: args,
+            head_arguments,
             span: Ignored(span),
         })
     }

--- a/crates/flowlog-build/src/parser/logic/rule.rs
+++ b/crates/flowlog-build/src/parser/logic/rule.rs
@@ -103,25 +103,20 @@ impl FlowLogRule {
     /// Panics if any head argument is not a simple constant.
     #[must_use]
     pub(crate) fn extract_constants_from_head(&self) -> Vec<ConstType> {
-        let mut out = Vec::new();
-        for arg in self.head.head_arguments() {
-            match arg {
-                HeadArg::Var(_) | HeadArg::Aggregation(_) => {
-                    panic!("Fact head must contain only constants: {self}")
-                }
-                HeadArg::Arith(arith) => {
-                    if arith.is_const() {
-                        if let Factor::Const(c) = arith.init() {
-                            out.push(c.clone());
-                        } else {
-                            // Defensive (shouldn't happen if is_const() is true).
-                            panic!("Fact head must contain only constants: {self}");
-                        }
-                    } else {
-                        panic!("Fact head must contain only constants: {self}");
-                    }
-                }
-            }
+        let args = self.head.head_arguments();
+        let mut out = Vec::with_capacity(args.len());
+        for arg in args {
+            let HeadArg::Arith(arith) = arg else {
+                panic!("Fact head must contain only constants: {self}");
+            };
+            let Factor::Const(c) = arith.init() else {
+                panic!("Fact head must contain only constants: {self}");
+            };
+            assert!(
+                arith.is_const(),
+                "Fact head must contain only constants: {self}"
+            );
+            out.push(c.clone());
         }
         out
     }

--- a/crates/flowlog-build/src/parser/primitive/data_type.rs
+++ b/crates/flowlog-build/src/parser/primitive/data_type.rs
@@ -51,19 +51,7 @@ pub enum DataType {
 impl DataType {
     /// Returns `true` for all integer and floating-point types.
     pub(crate) fn is_numeric(&self) -> bool {
-        matches!(
-            self,
-            Self::Int8
-                | Self::Int16
-                | Self::Int32
-                | Self::Int64
-                | Self::UInt8
-                | Self::UInt16
-                | Self::UInt32
-                | Self::UInt64
-                | Self::Float32
-                | Self::Float64
-        )
+        self.is_integer() || self.is_float()
     }
 
     /// Returns `true` for integer types only (excludes floats, strings, bools).

--- a/crates/flowlog-build/src/planner/arithmetic.rs
+++ b/crates/flowlog-build/src/planner/arithmetic.rs
@@ -75,9 +75,9 @@ impl ArithmeticArgument {
         ) -> FactorArgument {
             match factor {
                 FactorPos::Var(_) => {
-                    let var_signature = &var_arguments[*var_id];
+                    let var = var_arguments[*var_id];
                     *var_id += 1;
-                    FactorArgument::Var(*var_signature)
+                    FactorArgument::Var(var)
                 }
                 FactorPos::Const(constant) => FactorArgument::Const(constant.clone()),
                 FactorPos::FnCall { name, args } => {

--- a/crates/flowlog-build/src/planner/rule_planner.rs
+++ b/crates/flowlog-build/src/planner/rule_planner.rs
@@ -17,11 +17,11 @@
 //! The planner maintains a vector of transformation descriptors along with
 //! dependency analyses.
 
-use crate::planner::{Transformation, TransformationInfo};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write as _;
 
 use crate::parser::{FlowLogRule, Predicate};
+use crate::planner::{Transformation, TransformationInfo};
 
 mod common; // small utilities shared by planner phases
 mod core; // core join, plus fixed-point of semijoin/pushdown and projection removal
@@ -39,7 +39,7 @@ pub(crate) struct RulePlanner {
     /// Linear list of planned transformation infos for the current rule.
     transformation_infos: Vec<TransformationInfo>,
 
-    /// Mapping from an fingerprint to its producer indices and optional
+    /// Mapping from a fingerprint to its producer indices and optional
     /// list of consumer indices.
     ///
     /// Note:
@@ -219,15 +219,13 @@ impl<'a> Walker<'a> {
     fn node_title(&self, id: u64) -> &str {
         self.debug_info_map
             .get(&id)
-            .map(|(lbl, _)| lbl.as_str())
-            .unwrap_or("<unknown>")
+            .map_or("<unknown>", |(lbl, _)| lbl.as_str())
     }
 
     fn children(&self, id: u64) -> &[u64] {
         self.debug_info_map
             .get(&id)
-            .map(|(_, kids)| kids.as_slice())
-            .unwrap_or(&[])
+            .map_or(&[], |(_, kids)| kids.as_slice())
     }
 
     fn get_id(&mut self, node: u64) -> usize {

--- a/crates/flowlog-build/src/planner/rule_planner/fuse.rs
+++ b/crates/flowlog-build/src/planner/rule_planner/fuse.rs
@@ -196,10 +196,7 @@ impl RulePlanner {
 
         for tx_fp in tx_fps {
             // Copy out the producer index and current consumers (if any), then mutate
-            let Some((producer_indices, consumers)) = self
-                .producer_consumer
-                .get(&tx_fp)
-                .map(|(p, c)| (p.clone(), c.clone()))
+            let Some((producer_indices, consumers)) = self.producer_consumer.get(&tx_fp).cloned()
             else {
                 // No producer found - likely an original atom; ignore
                 continue;
@@ -307,16 +304,11 @@ impl RulePlanner {
     // Collect all output positions (keys + values) from an upstream transformation.
     #[inline]
     fn collect_output_positions(&self, producer_idx: usize) -> Vec<ArithmeticPos> {
-        self.transformation_infos[producer_idx]
-            .output_kv_layout()
+        let layout = self.transformation_infos[producer_idx].output_kv_layout();
+        layout
             .key()
             .iter()
-            .chain(
-                self.transformation_infos[producer_idx]
-                    .output_kv_layout()
-                    .value()
-                    .iter(),
-            )
+            .chain(layout.value().iter())
             .cloned()
             .collect()
     }
@@ -499,12 +491,7 @@ impl RulePlanner {
 
         // Second pass: register all consumers for each input fingerprint
         for index in 0..count {
-            let (left_fp, right_fp_opt) = {
-                let tx = &self.transformation_infos[index];
-                let (left_fp, right_fp_opt) = tx.input_info_fp();
-                (left_fp, right_fp_opt)
-            };
-
+            let (left_fp, right_fp_opt) = self.transformation_infos[index].input_info_fp();
             for input_fp in [Some(left_fp), right_fp_opt].into_iter().flatten() {
                 self.insert_consumer(original_atom_fp, input_fp, index)?;
             }

--- a/crates/flowlog-build/src/stratifier/dependency_graph.rs
+++ b/crates/flowlog-build/src/stratifier/dependency_graph.rs
@@ -46,18 +46,21 @@ impl DependencyGraph {
         let mut negative_edges: BTreeSet<(usize, usize)> = BTreeSet::new();
 
         for (rule_id, rule) in rules.iter().enumerate() {
+            // Pre-populated above, so the entry is guaranteed to exist.
+            let deps = dependency_map.get_mut(&rule_id).unwrap();
             for predicate in rule.rhs() {
                 let (atom_name, is_negative) = match predicate {
                     Predicate::PositiveAtom(atom) => (atom.name(), false),
                     Predicate::NegativeAtom(atom) => (atom.name(), true),
                     _ => continue,
                 };
-                if let Some(dep_ids) = head_to_rule_map.get(atom_name) {
-                    for &dep_id in dep_ids {
-                        dependency_map.get_mut(&rule_id).unwrap().insert(dep_id);
-                        if is_negative {
-                            negative_edges.insert((rule_id, dep_id));
-                        }
+                let Some(dep_ids) = head_to_rule_map.get(atom_name) else {
+                    continue;
+                };
+                for &dep_id in dep_ids {
+                    deps.insert(dep_id);
+                    if is_negative {
+                        negative_edges.insert((rule_id, dep_id));
                     }
                 }
             }

--- a/crates/flowlog-compiler/src/assembly/batch.rs
+++ b/crates/flowlog-compiler/src/assembly/batch.rs
@@ -84,10 +84,10 @@ pub(crate) fn gen_batch_main(
                     let mut rels: HashMap<String, Box<dyn Relation>> = HashMap::new();
                     #(#registry_inserts)*
                     #(#file_ingests)*
-                    for (_, r) in rels.iter_mut() {
+                    for r in rels.values_mut() {
                         r.apply_inline(index);
                     }
-                    for (_, r) in rels.iter_mut() {
+                    for r in rels.values_mut() {
                         r.close();
                     }
 


### PR DESCRIPTION
This PR rewrites a set of verbose local patterns into more idiomatic Rust.
It improves readability and consistency without changing APIs or intended behavior.

## Scope

| Touches | What changed |
|---|---|
| 17 files | Replace verbose local patterns with standard Rust idioms |

## Representative rewrites

| Before | After |
|---|---|
| `contains_key` + `get().unwrap()` | `if let Some(...) = map.get(...)` |
| manual push loops | iterator pipelines + `collect::<Result<_, _>>()?` |
| `for (_, v) in map.iter_mut()` | `for v in map.values_mut()` |
| `write!(f, "{}", x)` | `write!(f, "{x}")` |
| manual clones in `map` | `.cloned()` |

**Diffstat:** `+94 / -141`

## Risk note

One `unwrap()` in `stratifier/dependency_graph.rs` now relies on the documented loop invariant that `dependency_map` is pre-populated for every `rule_id`. That invariant already held before this cleanup; the PR just makes it explicit.

## Verification

| Gate | Result |
|---|---|
| `cargo build --release --workspace` | ✅ |
| `cargo test --workspace` | ✅ 168 / 168 |
| `cargo clippy --all-targets -- -D warnings` | ✅ |
| `tests/unit/unit_compiler.sh` | ✅ 95 / 95 |
| `tests/unit/unit_lib.sh` | ✅ 95 / 95 |
| `tests/complex` integer config | ✅ 19 / 19 |

## Supersedes

Replaces #90, #94, and the format-arg subset of #95.
