### PR TITLE
cleanup: extract DRY helpers and remove dead setters

### DIFF
--- a/crates/flowlog-build/src/catalog/predicate.rs
+++ b/crates/flowlog-build/src/catalog/predicate.rs
@@ -5,6 +5,17 @@ use std::fmt;
 use crate::catalog::{AtomArgumentSignature, ComparisonExprPos, FnCallPredicatePos};
 use crate::parser::ConstType;
 
+/// Write `" and "` before every term except the first. Toggles `first` to
+/// `false` after running, so callers can reuse it across heterogeneous
+/// term iterators without re-implementing the bookkeeping.
+fn write_and_sep(f: &mut fmt::Formatter<'_>, first: &mut bool) -> fmt::Result {
+    if !*first {
+        write!(f, " and ")?;
+    }
+    *first = false;
+    Ok(())
+}
+
 /// Predicate filters for a Join (or Anti-Join) to Key-Value transformation.
 #[derive(Default, Clone, PartialEq, Eq, Hash, Debug)]
 pub(crate) struct JoinPredicates {
@@ -23,18 +34,12 @@ impl fmt::Display for JoinPredicates {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut first = true;
         for c in &self.compare_exprs {
-            if !first {
-                write!(f, " and ")?;
-            }
+            write_and_sep(f, &mut first)?;
             write!(f, "{}", c)?;
-            first = false;
         }
         for fc in &self.fn_call_preds {
-            if !first {
-                write!(f, " and ")?;
-            }
+            write_and_sep(f, &mut first)?;
             write!(f, "{}", fc)?;
-            first = false;
         }
         Ok(())
     }
@@ -63,32 +68,20 @@ impl fmt::Display for KvPredicates {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut first = true;
         for (sig, c) in &self.const_eq {
-            if !first {
-                write!(f, " and ")?;
-            }
+            write_and_sep(f, &mut first)?;
             write!(f, "{} = {:?}", sig, c)?;
-            first = false;
         }
         for (l, r) in &self.var_eq {
-            if !first {
-                write!(f, " and ")?;
-            }
+            write_and_sep(f, &mut first)?;
             write!(f, "{} = {}", l, r)?;
-            first = false;
         }
         for c in &self.compare_exprs {
-            if !first {
-                write!(f, " and ")?;
-            }
+            write_and_sep(f, &mut first)?;
             write!(f, "{}", c)?;
-            first = false;
         }
         for fc in &self.fn_call_preds {
-            if !first {
-                write!(f, " and ")?;
-            }
+            write_and_sep(f, &mut first)?;
             write!(f, "{}", fc)?;
-            first = false;
         }
         Ok(())
     }

--- a/crates/flowlog-build/src/catalog/rule.rs
+++ b/crates/flowlog-build/src/catalog/rule.rs
@@ -618,26 +618,23 @@ impl fmt::Display for Catalog {
             }
         }
 
+        // Render the sorted var-set for the i-th predicate, or `[]` if out of range.
+        let fmt_pred_vars = |sets: &[HashSet<String>], i: usize| -> String {
+            let Some(set) = sets.get(i) else {
+                return "vars: []".to_string();
+            };
+            let mut vars: Vec<&str> = set.iter().map(String::as_str).collect();
+            vars.sort();
+            format!("vars: [{}]", vars.join(", "))
+        };
+
         writeln!(f, "\n{}", SUBSECTION_BAR)?;
         writeln!(f, "Comparison predicates:")?;
         if self.comparison_predicates.is_empty() {
             writeln!(f, "  (none)")?;
         } else {
             for (i, comp_pred) in self.comparison_predicates.iter().enumerate() {
-                let vars_set = if i < self.comparison_predicates_vars_str_set.len() {
-                    let mut vars: Vec<_> =
-                        self.comparison_predicates_vars_str_set[i].iter().collect();
-                    vars.sort();
-                    format!(
-                        "vars: [{}]",
-                        vars.iter()
-                            .map(|s| s.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )
-                } else {
-                    "vars: []".to_string()
-                };
+                let vars_set = fmt_pred_vars(&self.comparison_predicates_vars_str_set, i);
                 writeln!(f, "  [{:>2}] {} ({})", i, comp_pred, vars_set)?;
             }
         }
@@ -648,19 +645,7 @@ impl fmt::Display for Catalog {
             writeln!(f, "  (none)")?;
         } else {
             for (i, fn_call_pred) in self.fn_call_predicates.iter().enumerate() {
-                let vars_set = if i < self.fn_call_predicates_vars_str_set.len() {
-                    let mut vars: Vec<_> = self.fn_call_predicates_vars_str_set[i].iter().collect();
-                    vars.sort();
-                    format!(
-                        "vars: [{}]",
-                        vars.iter()
-                            .map(|s| s.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )
-                } else {
-                    "vars: []".to_string()
-                };
+                let vars_set = fmt_pred_vars(&self.fn_call_predicates_vars_str_set, i);
                 writeln!(f, "  [{:>2}] {} ({})", i, fn_call_pred, vars_set)?;
             }
         }

--- a/crates/flowlog-build/src/catalog/rule/populate.rs
+++ b/crates/flowlog-build/src/catalog/rule/populate.rs
@@ -59,29 +59,24 @@ impl Catalog {
         let mut local_placeholder_set = HashSet::new();
 
         // Partition RHS predicates into positive atoms, negative atoms, comparisons, and fn_call predicates
-        let (positive_atoms, negative_atoms, comparison_predicates, fn_call_predicates): (
-            Vec<_>,
-            Vec<_>,
-            Vec<_>,
-            Vec<_>,
-        ) = self.rule.rhs().iter().enumerate().fold(
-            (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
-            |(mut pos, mut neg, mut comp, mut fncalls), (i, p)| {
-                match p {
-                    Predicate::PositiveAtom(a) => {
-                        pos.push(a);
-                        self.positive_atom_rhs_ids.push(i);
-                    }
-                    Predicate::NegativeAtom(a) => {
-                        neg.push(a);
-                        self.negative_atom_rhs_ids.push(i);
-                    }
-                    Predicate::Compare(expr) => comp.push(expr.clone()),
-                    Predicate::FnCall(fc) => fncalls.push(fc.clone()),
-                };
-                (pos, neg, comp, fncalls)
-            },
-        );
+        let mut positive_atoms = Vec::new();
+        let mut negative_atoms = Vec::new();
+        let mut comparison_predicates = Vec::new();
+        let mut fn_call_predicates = Vec::new();
+        for (i, p) in self.rule.rhs().iter().enumerate() {
+            match p {
+                Predicate::PositiveAtom(a) => {
+                    positive_atoms.push(a);
+                    self.positive_atom_rhs_ids.push(i);
+                }
+                Predicate::NegativeAtom(a) => {
+                    negative_atoms.push(a);
+                    self.negative_atom_rhs_ids.push(i);
+                }
+                Predicate::Compare(expr) => comparison_predicates.push(expr.clone()),
+                Predicate::FnCall(fc) => fn_call_predicates.push(fc.clone()),
+            }
+        }
 
         // Process positive atoms: record fingerprints, build argument signatures, record var/const/placeholder, collect var set
         for (pos_rhs_id, atom) in positive_atoms.iter().enumerate() {
@@ -261,34 +256,25 @@ impl Catalog {
     /// Variables that appear only once in the rule body (excluding the head) can be
     /// considered unused and potentially pruned for optimization purposes.
     fn populate_unused_arguments(&mut self) {
-        let mut variable_counts = HashMap::new();
+        let mut variable_counts: HashMap<String, u32> = HashMap::new();
+        let mut bump = |v: &String| {
+            *variable_counts.entry(v.clone()).or_insert(0) += 1;
+        };
 
-        // Count occurrences in positive atoms
         for vars_set in &self.positive_atom_argument_vars_str_sets {
-            for variable in vars_set {
-                *variable_counts.entry(variable.clone()).or_insert(0) += 1;
-            }
+            vars_set.iter().for_each(&mut bump);
         }
-
-        // Count occurrences in negative atoms
         for vars_set in &self.negative_atom_argument_vars_str_sets {
-            for variable in vars_set {
-                *variable_counts.entry(variable.clone()).or_insert(0) += 1;
-            }
+            vars_set.iter().for_each(&mut bump);
         }
-
-        // Count occurrences in comparison predicates
         for comparison_predicate in &self.comparison_predicates {
-            for variable in comparison_predicate.vars_set() {
-                *variable_counts.entry(variable.clone()).or_insert(0) += 1;
-            }
+            comparison_predicate
+                .vars_set()
+                .into_iter()
+                .for_each(&mut bump);
         }
-
-        // Count occurrences in fn_call predicates
         for fn_call_predicate in &self.fn_call_predicates {
-            for variable in fn_call_predicate.vars() {
-                *variable_counts.entry(variable.clone()).or_insert(0) += 1;
-            }
+            fn_call_predicate.vars().into_iter().for_each(&mut bump);
         }
 
         // Collect all head variables (never considered unused, even if single-occurrence)
@@ -313,58 +299,41 @@ impl Catalog {
     fn populate_supersets(&mut self) {
         let pos_var_sets = &self.positive_atom_argument_vars_str_sets;
 
-        // For each positive atom: list indices of other positive atoms whose var set is a superset
+        // Indices of positive atoms whose var set is a superset of `needle`,
+        // optionally excluding one self-index.
+        let pos_supersets_of = |needle: &HashSet<String>, exclude: Option<usize>| -> Vec<usize> {
+            pos_var_sets
+                .iter()
+                .enumerate()
+                .filter(|(j, ps)| Some(*j) != exclude && needle.is_subset(ps))
+                .map(|(j, _)| j)
+                .collect()
+        };
+
+        // For each positive atom: other positive atoms whose var set is a superset
         self.positive_supersets = (0..pos_var_sets.len())
-            .map(|i| {
-                pos_var_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(j, set)| i != *j && pos_var_sets[i].is_subset(set))
-                    .map(|(j, _)| j)
-                    .collect()
-            })
+            .map(|i| pos_supersets_of(&pos_var_sets[i], Some(i)))
             .collect();
 
-        // For each negative atom: list indices of positive atoms that contain all its vars
+        // For each negative atom: positive atoms that contain all its vars
         self.negative_supersets = self
             .negative_atom_argument_vars_str_sets
             .iter()
-            .map(|set| {
-                pos_var_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, ps)| set.is_subset(ps))
-                    .map(|(j, _)| j)
-                    .collect()
-            })
+            .map(|set| pos_supersets_of(set, None))
             .collect();
 
         // For each comparison predicate: positive atoms whose var set covers it
         self.comparison_supersets = self
             .comparison_predicates_vars_str_set
             .iter()
-            .map(|set| {
-                pos_var_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, ps)| set.is_subset(ps))
-                    .map(|(j, _)| j)
-                    .collect()
-            })
+            .map(|set| pos_supersets_of(set, None))
             .collect();
 
         // For each fn_call predicate: positive atoms whose var set covers it
         self.fn_call_supersets = self
             .fn_call_predicates_vars_str_set
             .iter()
-            .map(|set| {
-                pos_var_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, ps)| set.is_subset(ps))
-                    .map(|(j, _)| j)
-                    .collect()
-            })
+            .map(|set| pos_supersets_of(set, None))
             .collect();
     }
 }

--- a/crates/flowlog-build/src/codegen/flow/non_recursive.rs
+++ b/crates/flowlog-build/src/codegen/flow/non_recursive.rs
@@ -75,44 +75,34 @@ impl CodeGen {
                 .collect();
 
             // Union the per-head collections left-to-right.
-            let head = outs[0].clone();
-            let tail = &outs[1..];
+            let head = &outs[0];
             let mut expr: TokenStream = quote! { #head.clone() };
-            for t in tail {
+            for t in &outs[1..] {
                 expr = quote! { #expr.concat(#t.clone()) };
             }
 
             // Output already produced in an earlier stratum: fold the new
             // heads into the existing collection before deduping.
-            let mut block = if calculated_output_fps.contains(idb_fp) {
-                with_profiler(profiler, |profiler| {
-                    profiler.concat_dedup_operator(
-                        output.to_string(),
-                        outs.iter().map(|id| id.to_string()).collect(),
-                        output.to_string(),
-                        outs.len() as u32,
-                        false,
-                    );
-                });
-                quote! {
-                    let #output = #output
-                        .concat(#expr)
-                        #dedup_stats;
-                }
+            let already_calculated = calculated_output_fps.contains(idb_fp);
+            let (concat_expr, concat_count) = if already_calculated {
+                (quote! { #output.concat(#expr) }, outs.len() as u32)
             } else {
-                with_profiler(profiler, |profiler| {
-                    profiler.concat_dedup_operator(
-                        output.to_string(),
-                        outs.iter().map(|id| id.to_string()).collect(),
-                        output.to_string(),
-                        outs.len() as u32 - 1,
-                        false,
-                    );
-                });
-                quote! {
-                    let #output = #expr
-                        #dedup_stats;
-                }
+                (expr, outs.len() as u32 - 1)
+            };
+
+            with_profiler(profiler, |profiler| {
+                profiler.concat_dedup_operator(
+                    output.to_string(),
+                    outs.iter().map(|id| id.to_string()).collect(),
+                    output.to_string(),
+                    concat_count,
+                    false,
+                );
+            });
+
+            let mut block = quote! {
+                let #output = #concat_expr
+                    #dedup_stats;
             };
 
             if let Some((agg_op, agg_pos, agg_arity)) = stratum.idb_to_aggregation_map().get(idb_fp)

--- a/crates/flowlog-build/src/parser/declaration/directive.rs
+++ b/crates/flowlog-build/src/parser/declaration/directive.rs
@@ -36,6 +36,22 @@ impl InputDirective {
     }
 }
 
+/// Parse the leading relation-name token plus any `io_params` children of an
+/// I/O directive. Shared by [`InputDirective`] and [`OutputDirective`], which
+/// differ only in the "missing relation name" diagnostic.
+fn parse_io_directive(
+    parsed_rule: Pair<Rule>,
+    file: FileId,
+    missing_name_msg: &'static str,
+) -> Result<(String, HashMap<String, String>, Span), ParseError> {
+    let mut inner = parsed_rule.into_inner();
+    let name_pair = inner.next().ok_or_else(|| grammar_bug(missing_name_msg))?;
+    let span = span_of(&name_pair, file);
+    let relation_name = name_pair.as_str().to_lowercase();
+    let parameters = parse_io_params(inner)?;
+    Ok((relation_name, parameters, span))
+}
+
 /// Parse `io_params` children from a directive's inner pairs into a key→value map.
 fn parse_io_params<'i>(
     inner: impl Iterator<Item = pest::iterators::Pair<'i, Rule>>,
@@ -65,15 +81,11 @@ fn parse_io_params<'i>(
 
 impl Lexeme for InputDirective {
     fn from_parsed_rule(parsed_rule: Pair<Rule>, file: FileId) -> Result<Self, ParseError> {
-        let mut inner = parsed_rule.into_inner();
-        let name_pair = inner
-            .next()
-            .ok_or_else(|| grammar_bug("input directive missing relation name"))?;
-        let span = span_of(&name_pair, file);
-        let relation_name = name_pair.as_str().to_lowercase();
+        let (relation_name, parameters, span) =
+            parse_io_directive(parsed_rule, file, "input directive missing relation name")?;
         Ok(Self {
             relation_name,
-            parameters: parse_io_params(inner)?,
+            parameters,
             span: Ignored(span),
         })
     }
@@ -110,15 +122,11 @@ impl OutputDirective {
 
 impl Lexeme for OutputDirective {
     fn from_parsed_rule(parsed_rule: Pair<Rule>, file: FileId) -> Result<Self, ParseError> {
-        let mut inner = parsed_rule.into_inner();
-        let name_pair = inner
-            .next()
-            .ok_or_else(|| grammar_bug("output directive missing relation name"))?;
-        let span = span_of(&name_pair, file);
-        let relation_name = name_pair.as_str().to_lowercase();
+        let (relation_name, parameters, span) =
+            parse_io_directive(parsed_rule, file, "output directive missing relation name")?;
         Ok(Self {
             relation_name,
-            parameters: parse_io_params(inner)?,
+            parameters,
             span: Ignored(span),
         })
     }

--- a/crates/flowlog-build/src/parser/error.rs
+++ b/crates/flowlog-build/src/parser/error.rs
@@ -12,10 +12,12 @@
 
 use std::path::PathBuf;
 
-use crate::common::{primary_label, secondary_label, Diagnostic, InternalError, BUG_URL};
-use crate::common::{FileId, Span};
 use codespan_reporting::diagnostic::{Diagnostic as CsDiagnostic, Label};
 use thiserror::Error;
+
+use crate::common::{
+    BUG_URL, Diagnostic, FileId, InternalError, Span, primary_label, secondary_label,
+};
 
 /// Which `.decl`-style directive is being reported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +48,12 @@ fn dup_labels(span: Span, prior: Span, here: &str, first: &str) -> Vec<Label<Fil
     .into_iter()
     .flatten()
     .collect()
+}
+
+/// Single-element label vec for diagnostics that only point at one span.
+/// Returns an empty vec for dummy spans rather than fabricating a location.
+fn primary_only(span: Span) -> Vec<Label<FileId>> {
+    primary_label(span).into_iter().collect()
 }
 
 /// Errors raised while parsing a FlowLog program.
@@ -193,32 +201,32 @@ impl Diagnostic for ParseError {
             )),
 
             ParseError::UndeclaredInDirective { span, name, .. } => base
-                .with_labels(primary_label(*span).into_iter().collect())
+                .with_labels(primary_only(*span))
                 .with_notes(vec![format!(
                     "add a `.decl {name}(...)` before this directive"
                 )]),
 
             ParseError::UndeclaredInIterativeList { span, name } => base
-                .with_labels(primary_label(*span).into_iter().collect())
+                .with_labels(primary_only(*span))
                 .with_notes(vec![format!(
                     "either `.decl {name}(...)` it, or drop `{name}` from the iterative list"
                 )]),
 
             ParseError::UndeclaredLoopCondition { span, name } => base
-                .with_labels(primary_label(*span).into_iter().collect())
+                .with_labels(primary_only(*span))
                 .with_notes(vec![format!(
                     "declare `{name}` as a nullary relation with `.decl {name}()` and derive it inside the loop"
                 )]),
 
             ParseError::UndeclaredInRule { span, name }
             | ParseError::UndeclaredInFact { span, name } => base
-                .with_labels(primary_label(*span).into_iter().collect())
+                .with_labels(primary_only(*span))
                 .with_notes(vec![format!(
                     "add a matching `.decl {name}(...)` declaration, or remove the reference"
                 )]),
 
             ParseError::CircularInclude { span, chain, .. } => {
-                let mut diag = base.with_labels(primary_label(*span).into_iter().collect());
+                let mut diag = base.with_labels(primary_only(*span));
                 if !chain.is_empty() {
                     let shown: Vec<String> = chain.iter().map(|p| p.display().to_string()).collect();
                     diag = diag.with_notes(vec![format!("include chain: {}", shown.join(" → "))]);
@@ -230,9 +238,7 @@ impl Diagnostic for ParseError {
             | ParseError::LoopBlockInStandardMode { span }
             | ParseError::NonNullaryLoopCondition { span, .. }
             | ParseError::PlaceholderInUdf { span, .. }
-            | ParseError::IncludeIo { span, .. } => {
-                base.with_labels(primary_label(*span).into_iter().collect())
-            }
+            | ParseError::IncludeIo { span, .. } => base.with_labels(primary_only(*span)),
 
             ParseError::Internal(_) => unreachable!("handled above"),
         }

--- a/crates/flowlog-build/src/planner/error.rs
+++ b/crates/flowlog-build/src/planner/error.rs
@@ -9,11 +9,12 @@
 //! file a bug" ICE instead of a process abort.
 
 use codespan_reporting::diagnostic::Diagnostic as CsDiagnostic;
-use crate::common::{primary_label, secondary_label, Diagnostic, InternalError, BUG_URL};
-use crate::common::{FileId, Span};
 use thiserror::Error;
 
 use crate::catalog::CatalogError;
+use crate::common::{
+    BUG_URL, Diagnostic, FileId, InternalError, Span, primary_label, secondary_label,
+};
 use crate::parser::AggregationOperator;
 
 #[non_exhaustive]

--- a/crates/flowlog-build/src/planner/rule_planner/sip.rs
+++ b/crates/flowlog-build/src/planner/rule_planner/sip.rs
@@ -15,14 +15,11 @@
 //! > general SIP framework (e.g. sideways information-passing strategies for
 //! > full rules) is left for future work.
 
-use crate::planner::{KeyValueLayout, TransformationInfo};
-
 use super::RulePlanner;
 use crate::catalog::{
     ArithmeticPos, AtomArgumentSignature, AtomSignature, Catalog, JoinPredicates, KvPredicates,
 };
-use crate::planner::PlanError;
-
+use crate::planner::{KeyValueLayout, PlanError, TransformationInfo};
 use tracing::trace;
 
 // =========================================================================
@@ -31,44 +28,49 @@ use tracing::trace;
 impl RulePlanner {
     /// Entry point for applying SIP optimizations to the current rule plan.
     pub(crate) fn apply_sip(&mut self, catalog: &mut Catalog) -> Result<(), PlanError> {
-        let positive_atom_numbers = catalog.positive_atom_number();
+        let n = catalog.positive_atom_number();
 
-        // Only apply SIP if there are at least 3 positive atoms
-        if positive_atom_numbers > 2 {
-            // Left -> Right foward pass.
-            for left_atom_idx in 0..positive_atom_numbers {
-                for right_atom_idx in (left_atom_idx + 1)..positive_atom_numbers {
-                    if catalog.check_sip_pair(left_atom_idx, right_atom_idx) {
-                        trace!(
-                            "SIP: forward atom_pos{} -> atom_pos{}",
-                            left_atom_idx,
-                            right_atom_idx
-                        );
-                        self.apply_sip_premaps(catalog, (left_atom_idx, right_atom_idx))?;
-                        self.apply_sip_projection_semijoin(catalog, left_atom_idx, right_atom_idx)?;
-                        trace!("Catalog:\n{}", catalog);
-                        trace!("{}", "-".repeat(60));
-                    }
-                }
-            }
+        // SIP only pays off once there's a third atom that can benefit from
+        // the filtered result — for 2-atom rules a semijoin would just
+        // duplicate the join itself.
+        if n <= 2 {
+            return Ok(());
+        }
 
-            // Right -> Left backward pass.
-            for left_atom_idx in (0..positive_atom_numbers).rev() {
-                for right_atom_idx in (0..left_atom_idx).rev() {
-                    if catalog.check_sip_pair(left_atom_idx, right_atom_idx) {
-                        trace!(
-                            "SIP: backward atom_pos{} -> atom_pos{}",
-                            left_atom_idx,
-                            right_atom_idx
-                        );
-                        self.apply_sip_premaps(catalog, (left_atom_idx, right_atom_idx))?;
-                        self.apply_sip_projection_semijoin(catalog, left_atom_idx, right_atom_idx)?;
-                        trace!("Catalog:\n{}", catalog);
-                        trace!("{}", "-".repeat(60));
-                    }
-                }
+        // Forward pass: each atom filters every later atom it shares vars with.
+        for left in 0..n {
+            for right in (left + 1)..n {
+                self.try_apply_sip_pair(catalog, left, right, "forward")?;
             }
         }
+
+        // Backward pass: every later atom gets to filter every earlier one.
+        for left in (0..n).rev() {
+            for right in (0..left).rev() {
+                self.try_apply_sip_pair(catalog, left, right, "backward")?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// If `(left, right)` shares variables, run premaps + projection-semijoin
+    /// for the pair; otherwise no-op. `direction` is purely for trace output.
+    fn try_apply_sip_pair(
+        &mut self,
+        catalog: &mut Catalog,
+        left: usize,
+        right: usize,
+        direction: &str,
+    ) -> Result<(), PlanError> {
+        if !catalog.check_sip_pair(left, right) {
+            return Ok(());
+        }
+        trace!("SIP: {direction} atom_pos{} -> atom_pos{}", left, right);
+        self.apply_sip_premaps(catalog, (left, right))?;
+        self.apply_sip_projection_semijoin(catalog, left, right)?;
+        trace!("Catalog:\n{}", catalog);
+        trace!("{}", "-".repeat(60));
         Ok(())
     }
 

--- a/crates/flowlog-build/src/planner/transformation/flow.rs
+++ b/crates/flowlog-build/src/planner/transformation/flow.rs
@@ -491,6 +491,36 @@ impl TransformationFlow {
 
 impl fmt::Display for TransformationFlow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Comma-joined `to_string` of each item, used for K:(...), V:(...) and
+        // for the inner pieces of F:(...).
+        fn join_display<T: fmt::Display>(items: &[T]) -> String {
+            items
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+
+        // Render the standard `K:(...), V:(...), F:(if ... and ...)` triple,
+        // omitting any section whose source is empty.
+        fn format_kv_parts(
+            key: &[ArithmeticArgument],
+            value: &[ArithmeticArgument],
+            filter_parts: &[String],
+        ) -> String {
+            let mut parts: Vec<String> = Vec::new();
+            if !key.is_empty() {
+                parts.push(format!("K:({})", join_display(key)));
+            }
+            if !value.is_empty() {
+                parts.push(format!("V:({})", join_display(value)));
+            }
+            if !filter_parts.is_empty() {
+                parts.push(format!("F:(if {})", filter_parts.join(" and ")));
+            }
+            parts.join(", ")
+        }
+
         match self {
             Self::KVToKV {
                 key,
@@ -501,55 +531,15 @@ impl fmt::Display for TransformationFlow {
             } => {
                 let mut filter_parts: Vec<String> = Vec::new();
                 if !constraints.is_empty() {
-                    filter_parts.push(format!("{}", constraints));
+                    filter_parts.push(constraints.to_string());
                 }
                 if !compares.is_empty() {
-                    filter_parts.push(
-                        compares
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
+                    filter_parts.push(join_display(compares));
                 }
                 if !fn_call_preds.is_empty() {
-                    filter_parts.push(
-                        fn_call_preds
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
+                    filter_parts.push(join_display(fn_call_preds));
                 }
-                let filters_str = if filter_parts.is_empty() {
-                    String::new()
-                } else {
-                    format!("if {}", filter_parts.join(" and "))
-                };
-
-                let key_str = key
-                    .iter()
-                    .map(|k| format!("{}", k))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let value_str = value
-                    .iter()
-                    .map(|v| format!("{}", v))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                let mut parts: Vec<String> = Vec::new();
-                if !key.is_empty() {
-                    parts.push(format!("K:({})", key_str));
-                }
-                if !value.is_empty() {
-                    parts.push(format!("V:({})", value_str));
-                }
-                if !filters_str.is_empty() {
-                    parts.push(format!("F:({})", filters_str));
-                }
-
-                write!(f, "{}", parts.join(", "))
+                write!(f, "{}", format_kv_parts(key, value, &filter_parts))
             }
 
             Self::JnToKV {
@@ -560,52 +550,12 @@ impl fmt::Display for TransformationFlow {
             } => {
                 let mut filter_parts: Vec<String> = Vec::new();
                 if !compares.is_empty() {
-                    filter_parts.push(
-                        compares
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
+                    filter_parts.push(join_display(compares));
                 }
                 if !fn_call_preds.is_empty() {
-                    filter_parts.push(
-                        fn_call_preds
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
+                    filter_parts.push(join_display(fn_call_preds));
                 }
-                let filters_str = if filter_parts.is_empty() {
-                    String::new()
-                } else {
-                    format!("if {}", filter_parts.join(" and "))
-                };
-
-                let key_str = key
-                    .iter()
-                    .map(|k| format!("{}", k))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let value_str = value
-                    .iter()
-                    .map(|v| format!("{}", v))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                let mut parts: Vec<String> = Vec::new();
-                if !key.is_empty() {
-                    parts.push(format!("K:({})", key_str));
-                }
-                if !value.is_empty() {
-                    parts.push(format!("V:({})", value_str));
-                }
-                if !filters_str.is_empty() {
-                    parts.push(format!("F:({})", filters_str));
-                }
-
-                write!(f, "{}", parts.join(", "))
+                write!(f, "{}", format_kv_parts(key, value, &filter_parts))
             }
         }
     }

--- a/crates/flowlog-build/src/profiler/node.rs
+++ b/crates/flowlog-build/src/profiler/node.rs
@@ -24,43 +24,6 @@ pub(super) struct NodeProfile {
     parents: Vec<usize>,
 }
 
-impl NodeProfile {
-    /// Update the node id.
-    fn update_id(&mut self, new_id: usize) {
-        self.id = new_id;
-    }
-
-    /// Update the node name.
-    fn update_name(&mut self, new_name: String) {
-        self.name = new_name;
-    }
-
-    /// Update the block label.
-    fn update_block(&mut self, new_block: String) {
-        self.block = new_block;
-    }
-
-    /// Set the fingerprint from a raw u64 value.
-    fn update_fingerprint(&mut self, fingerprint: u64) {
-        self.fingerprint = Some(format!("0x{:016x}", fingerprint));
-    }
-
-    /// Add a tag to the node.
-    fn add_tag(&mut self, tag: String) {
-        self.tags.push(tag);
-    }
-
-    /// Append operator addresses.
-    fn add_operators(&mut self, operator_addrs: Vec<Addr>) {
-        self.operators.extend(operator_addrs);
-    }
-
-    /// Append parent node ids.
-    fn add_parents(&mut self, parent_ids: Vec<usize>) {
-        self.parents.extend(parent_ids);
-    }
-}
-
 /// Internal nodes manager that tracks ids, scope addresses, and dependencies.
 #[derive(Debug, Clone, Default)]
 pub(super) struct NodeManager {
@@ -112,22 +75,20 @@ impl NodeManager {
         operator_steps: u32,
         fingerprint: Option<u64>,
     ) -> NodeProfile {
-        let mut node = NodeProfile::default();
-
-        let parent_ids = input_variable_names
+        let parents = input_variable_names
             .iter()
             .filter_map(|variable_name| self.node_map.get(variable_name).copied())
             .collect();
 
-        node.update_id(self.id_cnt);
-        node.update_name(name);
-        node.update_block(self.block.clone());
-        if let Some(fingerprint) = fingerprint {
-            node.update_fingerprint(fingerprint);
-        }
-        node.add_tag(tag.to_string());
-        node.add_operators(self.addr_cnt.advance(operator_steps));
-        node.add_parents(parent_ids);
+        let node = NodeProfile {
+            id: self.id_cnt,
+            name,
+            block: self.block.clone(),
+            fingerprint: fingerprint.map(|fp| format!("0x{:016x}", fp)),
+            tags: vec![tag.to_string()],
+            operators: self.addr_cnt.advance(operator_steps),
+            parents,
+        };
 
         if let Some(output_variable_name) = output_variable_name {
             self.node_map.insert(output_variable_name, self.id_cnt);

--- a/crates/flowlog-build/src/stratifier/error.rs
+++ b/crates/flowlog-build/src/stratifier/error.rs
@@ -7,10 +7,20 @@
 //! fire. Each variant carries at least one [`Span`] so the renderer can
 //! point at the offending source.
 
-use crate::common::{primary_label, Diagnostic};
-use crate::common::{FileId, Span};
-use codespan_reporting::diagnostic::Diagnostic as CsDiagnostic;
+use codespan_reporting::diagnostic::{Diagnostic as CsDiagnostic, Label};
 use thiserror::Error;
+
+use crate::common::{Diagnostic, FileId, Span, primary_label};
+
+/// Build one primary label per rule, annotated with `rule {id}`.
+fn rule_labels(rules: &[(usize, Span)]) -> Vec<Label<FileId>> {
+    rules
+        .iter()
+        .filter_map(|(rid, span)| {
+            primary_label(*span).map(|l| l.with_message(format!("rule {rid}")))
+        })
+        .collect()
+}
 
 /// Errors raised while stratifying a FlowLog program.
 #[non_exhaustive]
@@ -98,15 +108,9 @@ impl Diagnostic for StratifyError {
     fn to_diagnostic(&self) -> CsDiagnostic<FileId> {
         let base = CsDiagnostic::error().with_message(self.to_string());
         match self {
-            StratifyError::RecursionOutsideLoop { rules, hint } => {
-                let labels: Vec<_> = rules
-                    .iter()
-                    .filter_map(|(rid, span)| {
-                        primary_label(*span).map(|l| l.with_message(format!("rule {rid}")))
-                    })
-                    .collect();
-                base.with_labels(labels).with_notes(vec![hint.to_string()])
-            }
+            StratifyError::RecursionOutsideLoop { rules, hint } => base
+                .with_labels(rule_labels(rules))
+                .with_notes(vec![hint.to_string()]),
 
             StratifyError::IterativeNotInLoopHead { decl_span, .. } => base
                 .with_labels(primary_label(*decl_span).into_iter().collect())
@@ -132,13 +136,7 @@ impl Diagnostic for StratifyError {
                 )]),
 
             StratifyError::RecursiveStratumEmpty { rules, .. } => {
-                let labels: Vec<_> = rules
-                    .iter()
-                    .filter_map(|(rid, span)| {
-                        primary_label(*span).map(|l| l.with_message(format!("rule {rid}")))
-                    })
-                    .collect();
-                base.with_labels(labels).with_notes(vec![
+                base.with_labels(rule_labels(rules)).with_notes(vec![
                     "a `loop`/`fixpoint` block must contain at least one rule whose \
                      head relation also appears in a body atom within the same block"
                         .into(),


### PR DESCRIPTION
This PR extracts repeated local logic into small helpers and removes dead one-use setters.
It reduces duplication and line count while preserving behavior.

## Scope

| Touches | What changed |
|---|---|
| 11 files | Extract repeated formatter / parser / planner helpers and inline one-off boilerplate |

## Main reductions

| Area | Example |
|---|---|
| parser | shared `parse_io_directive(...)` helper |
| diagnostics | shared label builders instead of repeated `primary_label(...).collect()` code |
| planner / transformation formatting | shared `join_display(...)`, `format_kv_parts(...)`, `fmt_pred_vars(...)` |
| populate logic | shared bump / superset helpers instead of repeated loops |
| profiler | remove 7 one-use setters and build the struct directly |

**Diffstat:** `+241 / -378` (**-137 lines**)

## Risk notes

| Spot | Why it is still safe |
|---|---|
| `codegen/flow/non_recursive.rs` | duplicated `with_profiler(...)` call became one call after `concat_count` is computed; resulting state is the same |
| `profiler/node.rs` | removed setters each had exactly one call site |

## Verification

| Gate | Result |
|---|---|
| `cargo build --release --workspace` | ✅ |
| `cargo test --workspace` | ✅ 168 / 168 |
| `cargo clippy --all-targets -- -D warnings` | ✅ |
| `tests/unit/unit_compiler.sh` | ✅ 95 / 95 |
| `tests/unit/unit_lib.sh` | ✅ 95 / 95 |
| `tests/complex` integer config | ✅ 19 / 19 |

## Supersedes

Replaces #91 and the helper-extraction subset of #95.
