### PR TITLE
cleanups(compiler+runtime): tidy parse-codegen helpers, scaffolds, IO

### DIFF
--- a/crates/flowlog-compiler/src/assembly/inc.rs
+++ b/crates/flowlog-compiler/src/assembly/inc.rs
@@ -42,7 +42,6 @@ pub(crate) fn gen_incremental_main(
         preload,
         ..
     } = rp;
-    let merge = merge_blocks;
 
     quote! {
         fn main() {
@@ -269,7 +268,7 @@ pub(crate) fn gen_incremental_main(
 
                                 if index == 0 {
                                     // === Merge output buffers (sort, limit, write) ===
-                                    #(#merge)*
+                                    #(#merge_blocks)*
 
                                     println!("{:?}:\tCommitted & executed", round_timer.elapsed());
                                 }

--- a/crates/flowlog-compiler/src/assembly/mod.rs
+++ b/crates/flowlog-compiler/src/assembly/mod.rs
@@ -12,8 +12,8 @@ pub(crate) mod inc;
 
 use quote::quote;
 
-use flowlog_build::common::ExecutionMode;
 use flowlog_build::CodeParts;
+use flowlog_build::common::ExecutionMode;
 
 use crate::{Compiler, CompilerError};
 

--- a/crates/flowlog-compiler/src/build.rs
+++ b/crates/flowlog-compiler/src/build.rs
@@ -20,7 +20,7 @@ use flowlog_build::profiler::Profiler;
 use quote::quote;
 use tracing::info;
 
-use crate::{imports, relation, scaffold, Compiler};
+use crate::{Compiler, imports, relation, scaffold};
 
 impl Compiler {
     /// Produce the scaffolded Rust crate in [`Config::build_dir`].

--- a/crates/flowlog-compiler/src/imports.rs
+++ b/crates/flowlog-compiler/src/imports.rs
@@ -6,8 +6,8 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use flowlog_build::common::{Config, INTERN_MAX_RETRIES};
 use flowlog_build::Features;
+use flowlog_build::common::{Config, INTERN_MAX_RETRIES};
 
 pub(crate) fn gen_imports(config: &Config, features: &Features) -> TokenStream {
     let inc = config.is_incremental();

--- a/crates/flowlog-compiler/src/io/output.rs
+++ b/crates/flowlog-compiler/src/io/output.rs
@@ -12,8 +12,8 @@
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
 
-use flowlog_build::{field_accessor, gen_drain_block};
 use flowlog_build::parser::Relation;
+use flowlog_build::{field_accessor, gen_drain_block};
 
 use crate::{Compiler, CompilerError};
 
@@ -151,10 +151,7 @@ fn gen_write_row_stderr(idb: &Relation, string_intern: bool) -> TokenStream {
     let fields = data_field_accessors(idb, string_intern);
     // Stderr format shows `Debug` representations for readability; files get
     // `Display` for machine-consumable output.
-    let fmt_cols = (0..idb.arity())
-        .map(|_| "{:?}")
-        .collect::<Vec<_>>()
-        .join(", ");
+    let fmt_cols = vec!["{:?}"; idb.arity()].join(", ");
     let fmt = Literal::string(&format!(
         "[tuple][{prefix}]  t={{:?}}  data=({fmt_cols})  diff={{:+}}"
     ));

--- a/crates/flowlog-compiler/src/lib.rs
+++ b/crates/flowlog-compiler/src/lib.rs
@@ -32,9 +32,9 @@ mod scaffold;
 
 pub use error::CompilerError;
 
+use flowlog_build::CodeGen;
 use flowlog_build::common::BoxError;
 use flowlog_build::common::Config;
-use flowlog_build::CodeGen;
 use flowlog_build::parser::Program;
 use flowlog_build::planner::StratumPlanner;
 use flowlog_build::profiler::Profiler;

--- a/crates/flowlog-compiler/src/main.rs
+++ b/crates/flowlog-compiler/src/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
-use flowlog_build::common::{emit_and_exit, get_example_files, Config, SourceMap, SECTION_BAR};
+use flowlog_build::common::{Config, SECTION_BAR, SourceMap, emit_and_exit, get_example_files};
 use flowlog_build::optimizer::Optimizer;
 use flowlog_build::parser::Program;
 use flowlog_build::planner::StratumPlanner;

--- a/crates/flowlog-compiler/src/relation.rs
+++ b/crates/flowlog-compiler/src/relation.rs
@@ -10,7 +10,7 @@ use quote::{format_ident, quote};
 
 use flowlog_build::common::Span;
 use flowlog_build::parser::{ConstType, DataType, Program, Relation};
-use flowlog_build::{const_to_token, data_type_tokens, CodegenError, Features};
+use flowlog_build::{CodegenError, Features, const_to_token, data_type_tokens};
 
 /// Emit the shared relation-handler module body for binary mode.
 pub(crate) fn gen_relation(
@@ -463,295 +463,171 @@ fn gen_inline_facts(
 
 /// Parse from `it: Iterator<Item=&str>` into f0..f{n-1}.
 fn gen_parse_from_str(rel: &str, dts: &[DataType], string_intern: bool) -> TokenStream {
-    let mut stmts = Vec::<TokenStream>::new();
-
-    for (i, dt) in dts.iter().enumerate() {
-        let v = format_ident!("f{i}");
-        let idx = i;
-
-        let get = quote! {
-            let s = match it.next() {
-                Some(s) => s,
-                None => {
-                    eprintln!("[relation][{}] bad tuple '{}': missing col {}", #rel, tuple, #idx);
-                    return;
-                }
+    let stmts: Vec<TokenStream> = dts
+        .iter()
+        .enumerate()
+        .map(|(idx, dt)| {
+            let v = format_ident!("f{idx}");
+            let get = quote! {
+                let s = match it.next() {
+                    Some(s) => s,
+                    None => {
+                        eprintln!("[relation][{}] bad tuple '{}': missing col {}", #rel, tuple, #idx);
+                        return;
+                    }
+                };
             };
-        };
-
-        let parse = match *dt {
-            DataType::Int8 => quote! {
-                #get
-                let #v: i8 = match s.parse::<i8>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not i8: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::Int16 => quote! {
-                #get
-                let #v: i16 = match s.parse::<i16>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not i16: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::Int32 => quote! {
-                #get
-                let #v: i32 = match s.parse::<i32>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not i32: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::Int64 => quote! {
-                #get
-                let #v: i64 = match s.parse::<i64>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not i64: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::UInt8 => quote! {
-                #get
-                let #v: u8 = match s.parse::<u8>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not u8: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::UInt16 => quote! {
-                #get
-                let #v: u16 = match s.parse::<u16>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not u16: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::UInt32 => quote! {
-                #get
-                let #v: u32 = match s.parse::<u32>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not u32: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::UInt64 => quote! {
-                #get
-                let #v: u64 = match s.parse::<u64>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not u64: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::Float32 => quote! {
-                #get
-                let #v: OrderedFloat<f32> = match s.parse::<f32>() {
-                    Ok(v) => OrderedFloat(v),
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not f32: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::Float64 => quote! {
-                #get
-                let #v: OrderedFloat<f64> = match s.parse::<f64>() {
-                    Ok(v) => OrderedFloat(v),
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not f64: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-            DataType::String => {
-                if string_intern {
-                    quote! {
-                        #get
-                        let #v: Spur = intern(s);
-                    }
-                } else {
-                    quote! {
-                        #get
-                        let #v: String = s.to_string();
-                    }
-                }
-            }
-            DataType::Bool => quote! {
-                #get
-                let #v: bool = match s.parse::<bool>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!("[relation][{}] bad tuple '{}': col {} not bool: '{}'", #rel, tuple, #idx, s);
-                        return;
-                    }
-                };
-            },
-        };
-
-        stmts.push(parse);
-    }
-
-    quote! { #(#stmts)* }
-}
-
-/// Parse from `cols: Iterator<Item=&[u8]>` into f0..f{n-1}.
-fn gen_parse_from_bytes(rel: &str, dts: &[DataType], string_intern: bool) -> TokenStream {
-    let mut stmts = Vec::<TokenStream>::new();
-
-    for (i, dt) in dts.iter().enumerate() {
-        let v = format_ident!("f{i}");
-        let idx = i;
-
-        let get_raw = quote! {
-            let raw = match cols.next() {
-                Some(b) => b,
-                None => {
-                    eprintln!(
-                        "[relation][{}] bad row in {}: '{:?}' (missing col {})",
-                        #rel,
-                        path.display(),
-                        String::from_utf8_lossy(&line),
-                        #idx
-                    );
-                    return None;
-                }
-            };
-        };
-
-        let parse = match *dt {
-            DataType::Int8 => parse_int_bytes(&v, quote! { i8 }, "i8", rel, idx, &get_raw),
-            DataType::Int16 => parse_int_bytes(&v, quote! { i16 }, "i16", rel, idx, &get_raw),
-            DataType::Int32 => parse_int_bytes(&v, quote! { i32 }, "i32", rel, idx, &get_raw),
-            DataType::Int64 => parse_int_bytes(&v, quote! { i64 }, "i64", rel, idx, &get_raw),
-            DataType::UInt8 => parse_int_bytes(&v, quote! { u8 }, "u8", rel, idx, &get_raw),
-            DataType::UInt16 => parse_int_bytes(&v, quote! { u16 }, "u16", rel, idx, &get_raw),
-            DataType::UInt32 => parse_int_bytes(&v, quote! { u32 }, "u32", rel, idx, &get_raw),
-            DataType::UInt64 => parse_int_bytes(&v, quote! { u64 }, "u64", rel, idx, &get_raw),
-            DataType::Float32 => quote! {
-                #get_raw
-                let s = match std::str::from_utf8(raw) {
-                    Ok(s) => s.trim(),
-                    Err(_) => {
-                        eprintln!(
-                            "[relation][{}] bad row in {}: '{:?}' (col {} not utf8)",
-                            #rel, path.display(), String::from_utf8_lossy(&line), #idx
-                        );
-                        return None;
-                    }
-                };
-                let #v: OrderedFloat<f32> = match s.parse::<f32>() {
-                    Ok(v) => OrderedFloat(v),
-                    Err(_) => {
-                        eprintln!(
-                            "[relation][{}] bad row in {}: '{:?}' (col {} not f32: '{}')",
-                            #rel, path.display(), String::from_utf8_lossy(&line), #idx, s
-                        );
-                        return None;
-                    }
-                };
-            },
-            DataType::Float64 => quote! {
-                #get_raw
-                let s = match std::str::from_utf8(raw) {
-                    Ok(s) => s.trim(),
-                    Err(_) => {
-                        eprintln!(
-                            "[relation][{}] bad row in {}: '{:?}' (col {} not utf8)",
-                            #rel, path.display(), String::from_utf8_lossy(&line), #idx
-                        );
-                        return None;
-                    }
-                };
-                let #v: OrderedFloat<f64> = match s.parse::<f64>() {
-                    Ok(v) => OrderedFloat(v),
-                    Err(_) => {
-                        eprintln!(
-                            "[relation][{}] bad row in {}: '{:?}' (col {} not f64: '{}')",
-                            #rel, path.display(), String::from_utf8_lossy(&line), #idx, s
-                        );
-                        return None;
-                    }
-                };
-            },
-            DataType::String => {
-                let field_stmt = if string_intern {
-                    quote! { let #v: Spur = intern(s); }
-                } else {
-                    quote! { let #v: String = s.to_string(); }
-                };
-                quote! {
-                    #get_raw
-                    let s = match std::str::from_utf8(raw) {
-                        Ok(s) => s.trim(),
-                        Err(_) => {
-                            eprintln!(
-                                "[relation][{}] bad row in {}: '{:?}' (col {} not utf8)",
-                                #rel, path.display(), String::from_utf8_lossy(&line), #idx
-                            );
-                            return None;
-                        }
+            match *dt {
+                DataType::Int8 => parse_str_scalar(&v, quote! { i8 }, "i8", rel, idx, &get),
+                DataType::Int16 => parse_str_scalar(&v, quote! { i16 }, "i16", rel, idx, &get),
+                DataType::Int32 => parse_str_scalar(&v, quote! { i32 }, "i32", rel, idx, &get),
+                DataType::Int64 => parse_str_scalar(&v, quote! { i64 }, "i64", rel, idx, &get),
+                DataType::UInt8 => parse_str_scalar(&v, quote! { u8 }, "u8", rel, idx, &get),
+                DataType::UInt16 => parse_str_scalar(&v, quote! { u16 }, "u16", rel, idx, &get),
+                DataType::UInt32 => parse_str_scalar(&v, quote! { u32 }, "u32", rel, idx, &get),
+                DataType::UInt64 => parse_str_scalar(&v, quote! { u64 }, "u64", rel, idx, &get),
+                DataType::Bool => parse_str_scalar(&v, quote! { bool }, "bool", rel, idx, &get),
+                DataType::Float32 => parse_str_float(&v, quote! { f32 }, "f32", rel, idx, &get),
+                DataType::Float64 => parse_str_float(&v, quote! { f64 }, "f64", rel, idx, &get),
+                DataType::String => {
+                    let field = if string_intern {
+                        quote! { let #v: Spur = intern(s); }
+                    } else {
+                        quote! { let #v: String = s.to_string(); }
                     };
-                    #field_stmt
+                    quote! { #get #field }
                 }
             }
-            DataType::Bool => quote! {
-                #get_raw
-                let s = match std::str::from_utf8(raw) {
-                    Ok(s) => s.trim(),
-                    Err(_) => {
-                        eprintln!(
-                            "[relation][{}] bad row in {}: '{:?}' (col {} not utf8)",
-                            #rel, path.display(), String::from_utf8_lossy(&line), #idx
-                        );
-                        return None;
-                    }
-                };
-                let #v: bool = match s.parse::<bool>() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        eprintln!(
-                            "[relation][{}] bad row in {}: '{:?}' (col {} not bool: '{}')",
-                            #rel, path.display(), String::from_utf8_lossy(&line), #idx, s
-                        );
-                        return None;
-                    }
-                };
-            },
-        };
-
-        stmts.push(parse);
-    }
+        })
+        .collect();
 
     quote! { #(#stmts)* }
 }
 
-fn parse_int_bytes(
+/// Emit a `let v: T = s.parse::<T>()…` block for a scalar primitive (int / uint / bool).
+fn parse_str_scalar(
     v: &proc_macro2::Ident,
     ty: TokenStream,
     ty_name: &str,
     rel: &str,
     idx: usize,
-    get_raw: &TokenStream,
+    get: &TokenStream,
 ) -> TokenStream {
     quote! {
-        #get_raw
+        #get
+        let #v: #ty = match s.parse::<#ty>() {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!(
+                    "[relation][{}] bad tuple '{}': col {} not {}: '{}'",
+                    #rel, tuple, #idx, #ty_name, s
+                );
+                return;
+            }
+        };
+    }
+}
+
+/// Emit a `let v: OrderedFloat<T> = s.parse::<T>().map(OrderedFloat)…` block.
+fn parse_str_float(
+    v: &proc_macro2::Ident,
+    ty: TokenStream,
+    ty_name: &str,
+    rel: &str,
+    idx: usize,
+    get: &TokenStream,
+) -> TokenStream {
+    quote! {
+        #get
+        let #v: OrderedFloat<#ty> = match s.parse::<#ty>() {
+            Ok(v) => OrderedFloat(v),
+            Err(_) => {
+                eprintln!(
+                    "[relation][{}] bad tuple '{}': col {} not {}: '{}'",
+                    #rel, tuple, #idx, #ty_name, s
+                );
+                return;
+            }
+        };
+    }
+}
+
+/// Parse from `cols: Iterator<Item=&[u8]>` into f0..f{n-1}.
+fn gen_parse_from_bytes(rel: &str, dts: &[DataType], string_intern: bool) -> TokenStream {
+    let stmts: Vec<TokenStream> = dts
+        .iter()
+        .enumerate()
+        .map(|(idx, dt)| {
+            let v = format_ident!("f{idx}");
+            let get_raw = quote! {
+                let raw = match cols.next() {
+                    Some(b) => b,
+                    None => {
+                        eprintln!(
+                            "[relation][{}] bad row in {}: '{:?}' (missing col {})",
+                            #rel,
+                            path.display(),
+                            String::from_utf8_lossy(&line),
+                            #idx
+                        );
+                        return None;
+                    }
+                };
+            };
+            match *dt {
+                DataType::Int8 => parse_scalar_bytes(&v, quote! { i8 }, "i8", rel, idx, &get_raw),
+                DataType::Int16 => {
+                    parse_scalar_bytes(&v, quote! { i16 }, "i16", rel, idx, &get_raw)
+                }
+                DataType::Int32 => {
+                    parse_scalar_bytes(&v, quote! { i32 }, "i32", rel, idx, &get_raw)
+                }
+                DataType::Int64 => {
+                    parse_scalar_bytes(&v, quote! { i64 }, "i64", rel, idx, &get_raw)
+                }
+                DataType::UInt8 => parse_scalar_bytes(&v, quote! { u8 }, "u8", rel, idx, &get_raw),
+                DataType::UInt16 => {
+                    parse_scalar_bytes(&v, quote! { u16 }, "u16", rel, idx, &get_raw)
+                }
+                DataType::UInt32 => {
+                    parse_scalar_bytes(&v, quote! { u32 }, "u32", rel, idx, &get_raw)
+                }
+                DataType::UInt64 => {
+                    parse_scalar_bytes(&v, quote! { u64 }, "u64", rel, idx, &get_raw)
+                }
+                DataType::Bool => {
+                    parse_scalar_bytes(&v, quote! { bool }, "bool", rel, idx, &get_raw)
+                }
+                DataType::Float32 => {
+                    parse_float_bytes(&v, quote! { f32 }, "f32", rel, idx, &get_raw)
+                }
+                DataType::Float64 => {
+                    parse_float_bytes(&v, quote! { f64 }, "f64", rel, idx, &get_raw)
+                }
+                DataType::String => {
+                    let utf8 = utf8_trim_or_return_none(rel, idx);
+                    let field = if string_intern {
+                        quote! { let #v: Spur = intern(s); }
+                    } else {
+                        quote! { let #v: String = s.to_string(); }
+                    };
+                    quote! {
+                        #get_raw
+                        #utf8
+                        #field
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! { #(#stmts)* }
+}
+
+/// Decode the raw column bytes as utf8 + trim, binding `s`. Bails out of the
+/// enclosing `(|| -> Option<_> { … })()` closure with `None` on invalid utf8.
+fn utf8_trim_or_return_none(rel: &str, idx: usize) -> TokenStream {
+    quote! {
         let s = match std::str::from_utf8(raw) {
             Ok(s) => s.trim(),
             Err(_) => {
@@ -762,8 +638,52 @@ fn parse_int_bytes(
                 return None;
             }
         };
+    }
+}
+
+/// Emit a `let v: T = s.parse::<T>()…` block for a scalar primitive (int / uint / bool)
+/// against the bytes-iterator parsing path.
+fn parse_scalar_bytes(
+    v: &proc_macro2::Ident,
+    ty: TokenStream,
+    ty_name: &str,
+    rel: &str,
+    idx: usize,
+    get_raw: &TokenStream,
+) -> TokenStream {
+    let utf8 = utf8_trim_or_return_none(rel, idx);
+    quote! {
+        #get_raw
+        #utf8
         let #v: #ty = match s.parse::<#ty>() {
             Ok(v) => v,
+            Err(_) => {
+                eprintln!(
+                    "[relation][{}] bad row in {}: '{:?}' (col {} not {}: '{}')",
+                    #rel, path.display(), String::from_utf8_lossy(&line), #idx, #ty_name, s
+                );
+                return None;
+            }
+        };
+    }
+}
+
+/// Emit a `let v: OrderedFloat<T> = s.parse::<T>().map(OrderedFloat)…` block
+/// against the bytes-iterator parsing path.
+fn parse_float_bytes(
+    v: &proc_macro2::Ident,
+    ty: TokenStream,
+    ty_name: &str,
+    rel: &str,
+    idx: usize,
+    get_raw: &TokenStream,
+) -> TokenStream {
+    let utf8 = utf8_trim_or_return_none(rel, idx);
+    quote! {
+        #get_raw
+        #utf8
+        let #v: OrderedFloat<#ty> = match s.parse::<#ty>() {
+            Ok(v) => OrderedFloat(v),
             Err(_) => {
                 eprintln!(
                     "[relation][{}] bad row in {}: '{:?}' (col {} not {}: '{}')",

--- a/crates/flowlog-compiler/src/scaffold.rs
+++ b/crates/flowlog-compiler/src/scaffold.rs
@@ -21,7 +21,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use toml_edit::{value, Array, DocumentMut, InlineTable, Item, Value};
+use toml_edit::{Array, DocumentMut, InlineTable, Item, Value, value};
 
 use flowlog_build::common::Config;
 use flowlog_build::{CodeParts, Features};
@@ -68,10 +68,8 @@ impl Compiler {
         }
 
         // Aggregation-specific semiring modules (paths are relative to src/).
-        if !parts.semiring_modules.is_empty() {
-            for (rel_path, content) in &parts.semiring_modules {
-                write_file(&src_dir.join(rel_path), content)?;
-            }
+        for (rel_path, content) in &parts.semiring_modules {
+            write_file(&src_dir.join(rel_path), content)?;
         }
 
         // Optional UDF module — copied verbatim from a user-supplied file.
@@ -163,10 +161,7 @@ pub(crate) fn render_cargo_config() -> String {
 fn inline_versioned_dep(version: &str, features: &[&str]) -> InlineTable {
     let mut tbl = InlineTable::new();
     tbl.insert("version", version.into());
-    let mut arr = Array::new();
-    for f in features {
-        arr.push(*f);
-    }
+    let arr: Array = features.iter().copied().collect();
     tbl.insert("features", Value::Array(arr));
     tbl
 }

--- a/crates/flowlog-runtime/src/io.rs
+++ b/crates/flowlog-runtime/src/io.rs
@@ -42,8 +42,7 @@ use std::path::Path;
 /// doesn't come out evenly.
 pub fn partition<T>(v: Vec<T>, n: usize) -> Vec<Vec<T>> {
     let n = n.max(1);
-    let total = v.len();
-    let chunk = total / n;
+    let chunk = v.len() / n;
     let mut iter = v.into_iter();
     (0..n)
         .map(|i| {
@@ -71,27 +70,25 @@ pub fn byte_range_reader(
     index: usize,
     peers: usize,
 ) -> Option<(BufReader<File>, u64)> {
-    let mut file = match File::open(path) {
-        Ok(f) => f,
-        Err(e) => {
+    let mut file = File::open(path)
+        .inspect_err(|e| {
             eprintln!(
                 "[flowlog-runtime::io] failed to open {}: {e}",
                 path.display()
             );
-            return None;
-        }
-    };
+        })
+        .ok()?;
 
-    let file_size = match file.metadata() {
-        Ok(m) => m.len(),
-        Err(e) => {
+    let file_size = file
+        .metadata()
+        .inspect_err(|e| {
             eprintln!(
                 "[flowlog-runtime::io] failed to stat {}: {e}",
                 path.display()
             );
-            return None;
-        }
-    };
+        })
+        .ok()?
+        .len();
 
     let chunk = file_size / peers as u64;
     let start = chunk * index as u64;


### PR DESCRIPTION
Self-contained tidy of the `flowlog-compiler` binary and one helper in `flowlog-runtime`. Largest deletion: per-type match arms in `compiler/src/relation.rs` are pulled behind small named helpers.

### Why

`flowlog-compiler` is the binary frontend — it scaffolds a Cargo crate around generated code, handles IO, and emits per-type parse/print snippets. The `parse_*` helpers in `relation.rs` had grown up as inlined per-type matches with copy-pasted error labels; the IO formatter had inconsistent column-format construction; `scaffold.rs` had a manual `for + push` and a couple of stale guards.

### Commits

- **`compiler/relation.rs`** — extract `parse_str_scalar`, `parse_str_float`, `parse_int_bytes`, and `utf8_trim_or_return_none` private helpers; per-type error labels preserved via `#ty_name` interpolation. Touches `imports.rs` / `lib.rs` / `main.rs` / `mod.rs` for in-scope rustfmt-style import reorders only.
- **`compiler/scaffold.rs + assembly/inc.rs`** — drop a redundant guard, an alias rebind, and replace a manual push-loop with `iter().collect()`.
- **`compiler/build.rs + io/output.rs`** — align the stderr row formatter's column-format construction with its sibling's `vec![…; n].join(sep)` style; group imports.
- **`runtime/io.rs`** — flatten error handling in `byte_range_reader` (early-return `?`); remove a single-use binding in `partition`.

### Validation

- `cargo test --release --workspace` ✓
- L2 Souffle smoke (`tc/sg/crdt @ G5K-0.001`, both compiler and library lowering) ✓

### Risk

Low. All public APIs unchanged. The relation.rs helpers preserve every per-type error label and panic message. The IO formatter changes are byte-for-byte equivalent on every input the L2 oracle exercises.

---
_Authored by [groomer](https://github.com/azureuser/groomer); every commit individually judged `like` by the inline diff judge._
