### PR TITLE
fix(planner): key TransformationInfo Eq/Hash on output fingerprint

### DIFF
--- a/crates/flowlog-build/src/planner/transformation/info.rs
+++ b/crates/flowlog-build/src/planner/transformation/info.rs
@@ -12,7 +12,7 @@
 //! replaced with real ones once they are known. This allows building
 //! a transformation plan before all details are finalized.
 
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 
 use crate::catalog::{
     ArithmeticPos, AtomArgumentSignature, ComparisonExprPos, FnCallPredicatePos, JoinPredicates,
@@ -89,7 +89,12 @@ impl KeyValueLayout {
 
 /// Transformation information, describing how to transform input collection(s)
 /// into an output collection, along with any constraints that must hold.
-#[derive(PartialEq, Clone, Eq, Hash, Debug)]
+///
+/// `PartialEq`/`Eq`/`Hash` key on `output_info_fp` only — the fingerprint is
+/// the canonical identity. The `*_name` strings carry rule-local variable
+/// aliases that would split semantically-identical infos under a derive,
+/// defeating the dedup in `StratumPlanner::deduplicate_transformation_infos`.
+#[derive(Clone, Debug)]
 pub(crate) enum TransformationInfo {
     /// Unary Key-Value to Key-Value transformation (filter, map, projection, etc.).
     KVToKV {
@@ -164,6 +169,23 @@ pub(crate) enum TransformationInfo {
         /// Output layout (key/value positions) (fake until resolved).
         output_kv_layout: KeyValueLayout,
     },
+}
+
+// ========================
+// Identity (Eq / Hash)
+// ========================
+impl PartialEq for TransformationInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.output_info_fp() == other.output_info_fp()
+    }
+}
+
+impl Eq for TransformationInfo {}
+
+impl Hash for TransformationInfo {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.output_info_fp().hash(state);
+    }
 }
 
 // ========================


### PR DESCRIPTION
Derived PartialEq/Hash compared every field including the human-readable input_name/output_name strings, which embed rule-local variable aliases. Two structurally-identical transformations from different rule contexts (e.g. same EDB projected the same way under different alias names) hashed unequal, slipped past StratumPlanner::deduplicate_transformation_infos, and codegen emitted duplicate `let t_<fp>` bindings — the first shadowed before use, tripping unused-variable under the scaffold's -Dwarnings.

The fingerprint already encodes every structurally-relevant field (variant discriminant, input fp, layouts, predicates), so equality should match it. Replace the derive with manual impls keyed on output_info_fp.