### PR TITLE
chore: release flowlog-runtime 0.2.2, flowlog-build 0.2.3, flowlog-compiler 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flowlog-build"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-runtime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "differential-dataflow",
  "lasso",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Nemo Yu"]
 license = "Apache-2.0"

--- a/crates/flowlog-build/CHANGELOG.md
+++ b/crates/flowlog-build/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.2.2...flowlog-build-v0.2.3) - 2026-05-10
+
+### Fixed
+
+- *(planner)* key TransformationInfo Eq/Hash on output fingerprint ([#108](https://github.com/flowlog-rs/flowlog/pull/108))
+
+### Other
+
+- *(parser)* tidy AST/Display/Parser impls + new round-trip test ([#104](https://github.com/flowlog-rs/flowlog/pull/104))
+- *(errors)* tidy diagnostic formatting + label boilerplate ([#105](https://github.com/flowlog-rs/flowlog/pull/105))
+- *(planner)* extract helpers across rule planner + transformations ([#106](https://github.com/flowlog-rs/flowlog/pull/106))
+- split correctness from perf; modular harness for the correctness surface ([#101](https://github.com/flowlog-rs/flowlog/pull/101))
+- *(imports)* consolidate and regroup `use` blocks across the workspace
+- *(docs)* fix stale and misleading doc comments
+- *(idiomatic)* small idiomatic-Rust rewrites across the workspace
+- *(dry)* extract small DRY helpers across catalog/parser/planner/profiler

--- a/crates/flowlog-build/Cargo.toml
+++ b/crates/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/flowlog-runtime/CHANGELOG.md
+++ b/crates/flowlog-runtime/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.1...flowlog-runtime-v0.2.2) - 2026-05-10
+
+### Other
+
+- split correctness from perf; modular harness for the correctness surface ([#101](https://github.com/flowlog-rs/flowlog/pull/101))

--- a/crates/flowlog-runtime/Cargo.toml
+++ b/crates/flowlog-runtime/Cargo.toml
@@ -3,7 +3,7 @@ name = "flowlog-runtime"
 # Explicit version (not `version.workspace = true`) because the runtime
 # releases on its own cadence — generated code depends on it by
 # published version, so any additive change ships as an independent bump.
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `flowlog-runtime`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `flowlog-build`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-runtime`

<blockquote>

## [0.2.2](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.1...flowlog-runtime-v0.2.2) - 2026-05-10

### Other

- split correctness from perf; modular harness for the correctness surface ([#101](https://github.com/flowlog-rs/flowlog/pull/101))
</blockquote>

## `flowlog-build`

<blockquote>

## [0.2.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.2.2...flowlog-build-v0.2.3) - 2026-05-10

### Fixed

- *(planner)* key TransformationInfo Eq/Hash on output fingerprint ([#108](https://github.com/flowlog-rs/flowlog/pull/108))

### Other

- *(parser)* tidy AST/Display/Parser impls + new round-trip test ([#104](https://github.com/flowlog-rs/flowlog/pull/104))
- *(errors)* tidy diagnostic formatting + label boilerplate ([#105](https://github.com/flowlog-rs/flowlog/pull/105))
- *(planner)* extract helpers across rule planner + transformations ([#106](https://github.com/flowlog-rs/flowlog/pull/106))
- split correctness from perf; modular harness for the correctness surface ([#101](https://github.com/flowlog-rs/flowlog/pull/101))
- *(imports)* consolidate and regroup `use` blocks across the workspace
- *(docs)* fix stale and misleading doc comments
- *(idiomatic)* small idiomatic-Rust rewrites across the workspace
- *(dry)* extract small DRY helpers across catalog/parser/planner/profiler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).