### PR TITLE
chore: release flowlog-build v0.3.0, flowlog-compiler v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flowlog-build"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-compiler"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "clap",
  "codespan-reporting",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flowlog-build"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "codespan-reporting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 authors = ["Nemo Yu"]
 license = "Apache-2.0"

--- a/crates/flowlog-build/CHANGELOG.md
+++ b/crates/flowlog-build/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.2.3...flowlog-build-v0.2.4) - 2026-05-27
+## [0.3.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.2.3...flowlog-build-v0.3.0) - 2026-05-27
 
 ### Added
 

--- a/crates/flowlog-build/CHANGELOG.md
+++ b/crates/flowlog-build/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.2.3...flowlog-build-v0.2.4) - 2026-05-27
+
+### Added
+
+- `override` keyword in `.comp`
+- support OR predicates
+- support template
+- support subtype
+- build in function
+- support escape string
+- *(planner)* inter-stratum sharing ([#112](https://github.com/flowlog-rs/flowlog/pull/112))
+
+### Fixed
+
+- non recursive pre seed IDB error
+- cargo clippy
+
 ## [0.2.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.2.2...flowlog-build-v0.2.3) - 2026-05-10
 
 ### Fixed

--- a/crates/flowlog-build/Cargo.toml
+++ b/crates/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.2.4"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/flowlog-build/Cargo.toml
+++ b/crates/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release

* `flowlog-build`: 0.2.3 -> 0.3.0
* `flowlog-compiler`: 0.3.1 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

### `flowlog-build`

## [0.3.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.2.3...flowlog-build-v0.3.0) - 2026-05-27

#### Added

- `override` keyword in `.comp`
- support OR predicates
- support template
- support subtype
- build in function
- support escape string
- *(planner)* inter-stratum sharing ([#112](https://github.com/flowlog-rs/flowlog/pull/112))

#### Fixed

- non recursive pre seed IDB error
- cargo clippy

### `flowlog-compiler`

## [0.4.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-compiler-v0.3.1...flowlog-compiler-v0.4.0) - 2026-05-27

#### Added

- support escape string
- *(planner)* inter-stratum sharing ([#112](https://github.com/flowlog-rs/flowlog/pull/112))
- build in function

</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
