### PR TITLE
Migrate to differential-dataflow 0.24 / timely 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "columnar"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161f39fb04ec1e1446e76f65ee5fc19f59240d9095b0b89b9a325da608c927f1"
+checksum = "31b280b1509d6a79dccc29a809a4eda5916af652d479afb0e27f7718af6639f1"
 dependencies = [
  "bytemuck",
  "columnar_derive",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "columnar_derive"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce04f84a935806d52753e5deac1119605977f9aac6ab92d6daf32977659928"
+checksum = "72c9c88441fb60d0d5d9e939b5765abdff87d1a4d4cc80a90e0f945a6711c438"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "differential-dataflow"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d842a3e5e50bcd08a7f247c01a41cb057fde0c16f3865772682bff2edef5f40a"
+checksum = "befdc46c04f5671a2dfe32a9d06ce8efe44f650f0f6f974d190b9a6ee1c17665"
 dependencies = [
  "columnar",
  "columnation",
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdba58f1357fd65576620166d88afb7911b0d4f83b97c0624b03797e85ef4e9"
+checksum = "c5af6859fde675a87f12da672e0bdf08bfc809e68d8c6728f50942d09c0480a3"
 dependencies = [
  "bincode",
  "byteorder",
@@ -917,15 +917,15 @@ dependencies = [
 
 [[package]]
 name = "timely_bytes"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb91e9fc11841c4b07af1c95cea20470aaf144d6b412daddf63593cd8e7df50"
+checksum = "4b427b919d60d815c9c30b52d8080ebde599380db18c7c98a8c99fc172601ca1"
 
 [[package]]
 name = "timely_communication"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9efbf4f3899dc9905b780ec3646920022de3323086cc05ba84f4ffaad9a80c8"
+checksum = "2137e50f9c368c04d9971b7909c6fceadedb24c6e4fa4173bf55bf6d415329db"
 dependencies = [
  "byteorder",
  "columnar",
@@ -938,15 +938,15 @@ dependencies = [
 
 [[package]]
 name = "timely_container"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39eed4292e8e49f341c3d6cdfc8c43431634676a42dc8021cfd67e939c129a9"
+checksum = "b45d41809553b99db9abc2ad2c5f5b8f755df1f2191051527deaadeea12d5a7e"
 
 [[package]]
 name = "timely_logging"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ef86afa8b06f1bfa6e088b87909592a14622189f91ae4b5a49e76ac10ab73c"
+checksum = "00582f3cfc652e3173eb9a140981133f359029e6b746667414a8d334285163d6"
 dependencies = [
  "timely_container",
 ]

--- a/crates/flowlog-compiler/src/scaffold.rs
+++ b/crates/flowlog-compiler/src/scaffold.rs
@@ -114,8 +114,8 @@ pub(crate) fn render_cargo_toml(config: &Config, features: &Features) -> String 
     doc["dependencies"] = Item::Table(toml_edit::Table::new());
     {
         let deps = doc["dependencies"].as_table_mut().unwrap();
-        deps["timely"] = "0.29".into();
-        deps["differential-dataflow"] = "0.23".into();
+        deps["timely"] = "0.30".into();
+        deps["differential-dataflow"] = "0.24".into();
         deps["mimalloc"] = "0.1".into();
         deps["flowlog-runtime"] = "0.2".into();
 

--- a/crates/flowlog-runtime/Cargo.toml
+++ b/crates/flowlog-runtime/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["datalog", "dataflow", "differential", "timely"]
 categories = ["database", "compilers"]
 
 [dependencies]
-timely = "0.29"
-differential-dataflow = "0.23"
+timely = "0.30"
+differential-dataflow = "0.24"
 ordered-float = { version = "5", features = ["serde"] }
 lasso = { version = "0.7", features = ["multi-threaded", "serialize"] }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

Bump `differential-dataflow` 0.23 → **0.24** and `timely` 0.29 → **0.30**.

The change is intentionally minimal and surgical — 3 files:
- `Cargo.lock`
- `crates/flowlog-runtime/Cargo.toml`
- `crates/flowlog-compiler/src/scaffold.rs` (generated-binary deps follow the new pins)

A prior columnar-container investigation concluded the new DD's columnar path offers no win for FlowLog's workloads, so this PR keeps the existing `Vec` containers — the bump is **correctness-neutral and performance-neutral by design**.

## Validation

Full `flowlog-bench` A/B at **32 threads**, median of 3 runs, capturing wall time, peak RSS, **and per-relation output cardinality** (BASE = `main-next` vs HEAD = this branch):

- **37 / 37 runnable program×dataset pairs: output MATCH, 0 MISMATCH.**
- Stable benches (>3 s base, n=15 — incl. twitter 31 s, arabic-cc 73 s, mag 37 s, z3 13 s, cspa/cvc5): **time −6.3 … +4.8 %, peak RSS −5.9 … +2.4 %**. No `+10 % time / +20 % RSS` gate breach. Sub-3 s programs swing ±15 % = timing noise.
- Engine unit/integration test suite green.

### DOOP coverage

DOOP is included in the A/B (6 cached DaCapo apps). 5/6 produce substantial, identical points-to output on both refs:

| app | tuples | output |
|---|---|---|
| batik | 1.23 M | MATCH |
| biojava | 1.99 M | MATCH |
| eclipse | 576 K | MATCH |
| xalan | 1.12 M | MATCH |
| zxing | 956 K | MATCH |
| tomcat | not loaded* | trivial MATCH |

Fact format / program dialect cross-checked against canonical `flowlog-rs/doop-flowlog` and the HF `NemoYuu/flowlog_benchmark` dataset.

## Risk

Low. Dependency-only version bump; behaviour and output verified identical across the full benchmark corpus including DOOP.

> \*tomcat is **not** empty — it ships the raw Soufflé fact format (`.facts`, tab-delimited, string-encoded, hyphenated filenames; `ActualParam.facts` alone is ~139 k rows). The other five apps ship the preprocessed integer-interned `.csv` form this harness consumes, so tomcat's files weren't picked up → 0 tuples. Identical (empty) output on both refs, so still a valid no-regression MATCH, just non-informative. Not an engine/bump issue — a benchmark fact-preprocessing gap in the local cache.
