### PR TITLE
feat(doop): consolidate DOOP end-to-end gap-fills into one clean branch (supersedes #126–#129)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,11 +353,12 @@ dependencies = [
 
 [[package]]
 name = "flowlog-runtime"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "differential-dataflow",
  "lasso",
  "ordered-float",
+ "regex",
  "serde",
  "timely",
 ]
@@ -711,6 +712,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/crates/flowlog-build/src/catalog/arithmetic.rs
+++ b/crates/flowlog-build/src/catalog/arithmetic.rs
@@ -22,6 +22,8 @@ pub(crate) enum FactorPos {
         op: BuiltinOperator,
         args: Vec<ArithmeticPos>,
     },
+    /// Parenthesised sub-expression, preserving its grouping.
+    Group(Box<ArithmeticPos>),
 }
 
 impl FactorPos {
@@ -29,7 +31,10 @@ impl FactorPos {
     pub(crate) fn as_var_signature(&self) -> Option<&AtomArgumentSignature> {
         match self {
             FactorPos::Var(atom_arg_signature) => Some(atom_arg_signature),
-            FactorPos::Const(_) | FactorPos::FnCall { .. } | FactorPos::Builtin { .. } => None,
+            FactorPos::Const(_)
+            | FactorPos::FnCall { .. }
+            | FactorPos::Builtin { .. }
+            | FactorPos::Group(_) => None,
         }
     }
 
@@ -42,6 +47,7 @@ impl FactorPos {
             FactorPos::FnCall { args, .. } | FactorPos::Builtin { args, .. } => {
                 args.iter().flat_map(|a| a.signatures()).collect()
             }
+            FactorPos::Group(a) => a.signatures(),
         }
     }
 
@@ -59,6 +65,7 @@ impl FactorPos {
                 op: *op,
                 args: args.iter().map(|a| a.map_vars(f)).collect(),
             },
+            FactorPos::Group(a) => FactorPos::Group(Box::new(a.map_vars(f))),
         }
     }
 }
@@ -84,6 +91,7 @@ impl fmt::Display for FactorPos {
                     .join(", ");
                 write!(f, "{op}({args_str})")
             }
+            FactorPos::Group(a) => write!(f, "({a})"),
         }
     }
 }
@@ -154,6 +162,12 @@ impl ArithmeticPos {
                 // map the inner factor directly. The typechecker has
                 // already validated subtype compatibility by this point.
                 Factor::Cast(c) => map_factor(c.inner(), var_signatures, var_id),
+                Factor::Group(a) => {
+                    let num_vars = a.vars().len();
+                    let sigs = &var_signatures[*var_id..*var_id + num_vars];
+                    *var_id += num_vars;
+                    FactorPos::Group(Box::new(ArithmeticPos::from_arithmetic(a, sigs)))
+                }
             }
         }
 

--- a/crates/flowlog-build/src/codegen/arg.rs
+++ b/crates/flowlog-build/src/codegen/arg.rs
@@ -833,6 +833,10 @@ impl CodeGen {
             FactorArgument::Builtin { op, args } => {
                 self.builtin_to_token(*op, args, string_intern, resolve_var)
             }
+            FactorArgument::Group(a) => {
+                let inner = self.build_arithmetic_expr(a, string_intern, resolve_var)?;
+                Ok(quote! { ( #inner ) })
+            }
         }
     }
 
@@ -882,6 +886,12 @@ impl CodeGen {
                 } else {
                     call
                 })
+            }
+            FactorArgument::Group(a) => {
+                // Grammar guarantees a `Group` is multi-term, hence numeric
+                // (string concat is `cat`) — no display resolution needed.
+                let inner = self.build_arithmetic_expr(a, string_intern, resolve_var)?;
+                Ok(quote! { ( #inner ) })
             }
         }
     }
@@ -972,6 +982,35 @@ impl CodeGen {
                 let needle = read_str(&raw[0]);
                 let hay = read_str(&raw[1]);
                 Ok(quote! { ((#hay).contains(#needle)) })
+            }
+            BuiltinOperator::Match => {
+                // Soufflé `match(pattern, s)` is a *full* match, so anchor
+                // with `^(?:…)$` (the `regex` crate searches by default).
+                // A malformed pattern yields `false` rather than aborting.
+                // `regex` resolves via the `flowlog_runtime` re-export in
+                // both binary and library modes (runtime ≥ 0.2.3).
+                let hay = read_str(&raw[1]);
+                // Literal pattern (the common case): anchor at codegen time
+                // and compile once per call site via a `LazyLock` static.
+                if let FactorArgument::Const(ConstType::Text(p)) = &args[0].init
+                    && args[0].rest.is_empty()
+                {
+                    let anchored = format!("^(?:{p})$");
+                    return Ok(quote! {{
+                        static RE: ::std::sync::LazyLock<
+                            Option<::flowlog_runtime::regex::Regex>,
+                        > = ::std::sync::LazyLock::new(|| {
+                            ::flowlog_runtime::regex::Regex::new(#anchored).ok()
+                        });
+                        RE.as_ref().is_some_and(|re| re.is_match(#hay))
+                    }});
+                }
+                // Computed pattern: compile per evaluation.
+                let pat = read_str(&raw[0]);
+                Ok(quote! {
+                    ::flowlog_runtime::regex::Regex::new(&format!("^(?:{})$", #pat))
+                        .map_or(false, |re| re.is_match(#hay))
+                })
             }
             BuiltinOperator::ToString => {
                 let n = &raw[0];

--- a/crates/flowlog-build/src/codegen/edb_handles.rs
+++ b/crates/flowlog-build/src/codegen/edb_handles.rs
@@ -4,6 +4,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::codegen::CodeGen;
+use crate::codegen::ty::data::data_type_tokens;
 use crate::parser::DataType;
 use crate::profiler::{Profiler, with_profiler};
 
@@ -43,6 +44,7 @@ impl CodeGen {
             profiler.update_input_block();
         });
 
+        let str_intern = self.config.str_intern_enabled();
         edbs.iter()
             .map(|rel| {
                 let handle = format_ident!("h{}", rel.name());
@@ -61,8 +63,16 @@ impl CodeGen {
                     );
                 });
 
+                // The matching `InputSession` handle is always typed from the
+                // declared column types (see `gen_input_struct`), so annotating
+                // the collection's element type identically is provably
+                // consistent and frees the generated crate from fragile
+                // inference (e.g. fact-only or orphan relations whose element
+                // type is otherwise un-inferable).
+                let ty = data_type_tokens(&rel.data_type(), str_intern);
+
                 quote! {
-                    let (#handle, #coll) = scope.new_collection::<_, Diff>();
+                    let (#handle, #coll) = scope.new_collection::<#ty, Diff>();
                     let #coll = #coll #normalize;
                 }
             })

--- a/crates/flowlog-build/src/codegen/ty/data.rs
+++ b/crates/flowlog-build/src/codegen/ty/data.rs
@@ -168,6 +168,7 @@ impl CodeGen {
                 .map(|e| e.ret_type())
                 .ok_or_else(|| CodegenError::internal(format!("UDF `{name}` not declared"))),
             FactorArgument::Builtin { op, .. } => Ok(op.ret_type()),
+            FactorArgument::Group(a) => self.infer_expr_type(a, left_type, right_type),
         }
     }
 }

--- a/crates/flowlog-build/src/parser/desugar.rs
+++ b/crates/flowlog-build/src/parser/desugar.rs
@@ -1,0 +1,326 @@
+//! Equality-as-assignment desugaring.
+//!
+//! Soufflé and standard Datalog treat a body literal `v = expr` as an
+//! *assignment* that grounds `v` whenever `v` is otherwise unbound and every
+//! variable in `expr` is already bound. FlowLog's planner grounds variables
+//! only through positive atoms, so this pass eliminates assignment literals up
+//! front by substituting the bound variable into the head and the remaining
+//! body, before catalog construction and planning ever see the rule:
+//!
+//! ```text
+//! R(t)        :- A(x), t = x + 1.        =>  R(x + 1) :- A(x).
+//! D(d)        :- M(rt), d = cat(rt,"()").=>  D(cat(rt, "()")) :- M(rt).
+//! R(y)        :- A(x), y = x.            =>  R(x) :- A(x).
+//! isModifier(x) :- x = "abstract".       =>  fact  isModifier("abstract").
+//! ```
+//!
+//! A `v = expr` whose `v` already occurs in a positive atom is a genuine
+//! equality *filter* (both sides are bound), and is left untouched — only an
+//! otherwise-unbound `v` is treated as an assignment.
+//!
+//! Chained assignments (`a = x + 1, b = a + 2`) are resolved to a fixpoint and
+//! back-substituted so each bound variable is expressed purely over
+//! positive-atom variables and constants.
+//!
+//! Rules whose body becomes empty and whose head is fully ground are emitted as
+//! inline facts (reusing the existing fact path) rather than being handed to the
+//! planner, which requires at least one positive atom.
+
+use std::collections::{HashMap, HashSet};
+
+use super::segment::Segment;
+use crate::parser::error::ParseError;
+use crate::parser::{
+    Arithmetic, ArithmeticOperator, AtomArg, ComparisonOperator, ConstType, Factor, FlowLogRule,
+    HeadArg, Predicate,
+};
+
+/// Rewrite every rule in `segments`, removing equality assignments by
+/// substitution. Rules that reduce to a fully-ground fact are appended to
+/// `raw_facts` instead of being kept in their segment.
+pub(crate) fn desugar_equality_assignments(
+    segments: &mut [Segment],
+    raw_facts: &mut Vec<FlowLogRule>,
+) -> Result<(), ParseError> {
+    for seg in segments.iter_mut() {
+        let rules: &mut Vec<FlowLogRule> = match seg {
+            Segment::Plain(rules) => rules,
+            Segment::Loop(block) | Segment::Fixpoint(block) => block.rules_mut(),
+        };
+
+        let mut kept = Vec::with_capacity(rules.len());
+        for mut rule in std::mem::take(rules) {
+            if desugar_rule(&mut rule)? {
+                raw_facts.push(rule);
+            } else {
+                kept.push(rule);
+            }
+        }
+        *rules = kept;
+    }
+    Ok(())
+}
+
+/// Desugar a single rule in place. Returns `true` when the rule became a
+/// fully-ground fact and should be moved to the fact set.
+fn desugar_rule(rule: &mut FlowLogRule) -> Result<bool, ParseError> {
+    // Variables grounded by a positive atom — never treated as assignments.
+    let mut bound: HashSet<String> = HashSet::new();
+    for pred in rule.rhs() {
+        if let Predicate::PositiveAtom(atom) = pred {
+            for arg in atom.arguments() {
+                if let AtomArg::Var(v) = arg {
+                    bound.insert(v.clone());
+                }
+            }
+        }
+    }
+
+    // Discover assignment comparisons to a fixpoint. `assignment_idx` records
+    // which `rhs` slots are assignments (to drop later); `order` preserves
+    // discovery order so chains resolve correctly.
+    let mut assignment_idx: HashSet<usize> = HashSet::new();
+    let mut order: Vec<(String, Arithmetic)> = Vec::new();
+    loop {
+        let mut progressed = false;
+        for (i, pred) in rule.rhs().iter().enumerate() {
+            if assignment_idx.contains(&i) {
+                continue;
+            }
+            let Predicate::Compare(expr) = pred else {
+                continue;
+            };
+            if *expr.operator() != ComparisonOperator::Equal {
+                continue;
+            }
+            if let Some((var, value)) = as_assignment(expr.left(), expr.right(), &bound) {
+                bound.insert(var.clone());
+                assignment_idx.insert(i);
+                order.push((var, value));
+                progressed = true;
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+
+    if order.is_empty() {
+        return Ok(false);
+    }
+
+    // Back-substitute so each binding is expressed only over positive-atom
+    // variables and constants, then freeze into a resolved map.
+    let mut resolved: HashMap<String, Arithmetic> = HashMap::new();
+    let mut resolved_order: Vec<String> = Vec::new();
+    for (var, mut value) in order {
+        for prior in &resolved_order {
+            subst_arith(&mut value, prior, &resolved[prior]);
+        }
+        resolved_order.push(var.clone());
+        resolved.insert(var, value);
+    }
+
+    // Substitute into the head.
+    for var in &resolved_order {
+        subst_head(rule, var, &resolved[var]);
+    }
+
+    // Substitute into every non-assignment body predicate.
+    let mut new_rhs: Vec<Predicate> = Vec::with_capacity(rule.rhs().len());
+    for (i, pred) in rule.rhs_mut().iter_mut().enumerate() {
+        if assignment_idx.contains(&i) {
+            continue;
+        }
+        for var in &resolved_order {
+            subst_predicate(pred, var, &resolved[var])?;
+        }
+        new_rhs.push(pred.clone());
+    }
+    rule.set_rhs(new_rhs);
+
+    // An emptied body must leave the segment (the planner needs ≥1 positive
+    // atom): fold ground integer arithmetic (`x = 1 + 2` → fact `P(3)`),
+    // reject anything non-constant (unbound head var, float/string/builtin)
+    // instead of panicking the planner downstream.
+    if !rule.rhs().is_empty() {
+        return Ok(false);
+    }
+    let span = rule.head().span();
+    for arg in rule.head_mut().head_arguments_mut() {
+        match arg {
+            HeadArg::Arith(a) if a.is_const() => {}
+            HeadArg::Arith(a) => {
+                let folded = fold_const_int(a)
+                    .ok_or(ParseError::GroundRuleNotConst { span })?;
+                *a = Arithmetic::new(Factor::Const(ConstType::Int(folded)), vec![]);
+            }
+            HeadArg::Var(_) | HeadArg::Aggregation(_) => {
+                return Err(ParseError::GroundRuleNotConst { span });
+            }
+        }
+    }
+    Ok(true)
+}
+
+/// Fold a ground arithmetic expression over polymorphic integer literals
+/// (`1 + 2` → `3`). Returns `None` for any non-integer factor (variable,
+/// float, string, builtin, UDF call) or on overflow / division by zero —
+/// the caller rejects those.
+fn fold_const_int(a: &Arithmetic) -> Option<i64> {
+    fn factor_value(f: &Factor) -> Option<i64> {
+        match f {
+            Factor::Const(ConstType::Int(v)) => Some(*v),
+            Factor::Group(inner) => fold_const_int(inner),
+            _ => None,
+        }
+    }
+    let mut acc = factor_value(a.init())?;
+    for (op, f) in a.rest() {
+        let v = factor_value(f)?;
+        acc = match op {
+            ArithmeticOperator::Plus => acc.checked_add(v)?,
+            ArithmeticOperator::Minus => acc.checked_sub(v)?,
+            ArithmeticOperator::Multiply => acc.checked_mul(v)?,
+            ArithmeticOperator::Divide => acc.checked_div(v)?,
+            ArithmeticOperator::Modulo => acc.checked_rem(v)?,
+        };
+    }
+    Some(acc)
+}
+
+/// Recognise `lhs = rhs` as an assignment that grounds a fresh variable.
+///
+/// Returns `(var, value)` when exactly one side is a single still-unbound
+/// variable and the other side's variables are all bound. The variable must not
+/// also appear on the value side (`v = v + 1` is not groundable).
+fn as_assignment(
+    lhs: &Arithmetic,
+    rhs: &Arithmetic,
+    bound: &HashSet<String>,
+) -> Option<(String, Arithmetic)> {
+    let try_side = |var_side: &Arithmetic, value_side: &Arithmetic| -> Option<(String, Arithmetic)> {
+        if !var_side.is_var() {
+            return None;
+        }
+        let var = var_side.vars().into_iter().next()?.clone();
+        if bound.contains(&var) {
+            return None;
+        }
+        let value_vars = value_side.vars();
+        if value_vars.iter().any(|v| **v == var) {
+            return None;
+        }
+        if value_vars.iter().all(|v| bound.contains(*v)) {
+            Some((var, value_side.clone()))
+        } else {
+            None
+        }
+    };
+
+    try_side(lhs, rhs).or_else(|| try_side(rhs, lhs))
+}
+
+/// `Factor` form of a resolved value: a lone factor is inlined directly; a
+/// multi-term expression is wrapped in a group so left-to-right folding keeps
+/// its meaning when spliced into a larger expression.
+fn value_factor(value: &Arithmetic) -> Factor {
+    if value.rest().is_empty() {
+        value.init().clone()
+    } else {
+        Factor::Group(Box::new(value.clone()))
+    }
+}
+
+fn subst_head(rule: &mut FlowLogRule, var: &str, value: &Arithmetic) {
+    for arg in rule.head_mut().head_arguments_mut() {
+        match arg {
+            HeadArg::Var(v) if v == var => {
+                *arg = if value.is_var() {
+                    HeadArg::Var(value.vars()[0].clone())
+                } else {
+                    HeadArg::Arith(value.clone())
+                };
+            }
+            HeadArg::Var(_) => {}
+            HeadArg::Arith(a) => subst_arith(a, var, value),
+            HeadArg::Aggregation(agg) => subst_arith(agg.arithmetic_mut(), var, value),
+        }
+    }
+}
+
+fn subst_predicate(
+    pred: &mut Predicate,
+    var: &str,
+    value: &Arithmetic,
+) -> Result<(), ParseError> {
+    match pred {
+        // The assignment variable is never grounded by a positive atom, so it
+        // cannot appear in one.
+        Predicate::PositiveAtom(_) => {}
+        Predicate::NegativeAtom(atom) => {
+            let span = atom.span();
+            for arg in atom.arguments_mut() {
+                if let AtomArg::Var(v) = arg
+                    && v == var
+                {
+                    *arg = atom_arg_from_value(value).ok_or_else(|| {
+                        ParseError::AssignmentVarInNegation {
+                            span,
+                            var: var.to_string(),
+                        }
+                    })?;
+                }
+            }
+        }
+        Predicate::Compare(expr) => {
+            subst_arith(expr.left_mut(), var, value);
+            subst_arith(expr.right_mut(), var, value);
+        }
+        Predicate::FnCall(fc) => {
+            for arg in fc.args_mut() {
+                subst_arith(arg, var, value);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A negated atom argument can only receive a bare variable or constant — not a
+/// computed expression. Returns `None` for anything else.
+fn atom_arg_from_value(value: &Arithmetic) -> Option<AtomArg> {
+    if !value.rest().is_empty() {
+        return None;
+    }
+    match value.init() {
+        Factor::Var(v) => Some(AtomArg::Var(v.clone())),
+        Factor::Const(c) => Some(AtomArg::Const(c.clone())),
+        _ => None,
+    }
+}
+
+fn subst_arith(arith: &mut Arithmetic, var: &str, value: &Arithmetic) {
+    subst_factor(arith.init_mut(), var, value);
+    for (_, factor) in arith.rest_mut() {
+        subst_factor(factor, var, value);
+    }
+}
+
+fn subst_factor(factor: &mut Factor, var: &str, value: &Arithmetic) {
+    match factor {
+        Factor::Var(v) if v == var => *factor = value_factor(value),
+        Factor::Var(_) | Factor::Const(_) => {}
+        Factor::FnCall(fc) => {
+            for arg in fc.args_mut() {
+                subst_arith(arg, var, value);
+            }
+        }
+        Factor::Builtin(bc) => {
+            for arg in bc.args_mut() {
+                subst_arith(arg, var, value);
+            }
+        }
+        Factor::Cast(c) => subst_factor(c.inner_mut(), var, value),
+        Factor::Group(a) => subst_arith(a, var, value),
+    }
+}

--- a/crates/flowlog-build/src/parser/error.rs
+++ b/crates/flowlog-build/src/parser/error.rs
@@ -267,6 +267,21 @@ pub enum ParseError {
     #[error("`.plan` lists positive-atom index {index} more than once")]
     PlanDuplicateIndex { span: Span, index: usize },
 
+    /// An equality assignment `v = expr` grounds `v`, but `v` is then used as
+    /// an argument of a negated atom with a non-trivial (arithmetic / function)
+    /// right-hand side. FlowLog can substitute a variable or constant into a
+    /// negation, but not an arbitrary expression (atom arguments are not
+    /// expressions), so this form is rejected rather than silently mishandled.
+    #[error("assignment-bound variable `{var}` cannot be used in a negated atom with a computed value")]
+    AssignmentVarInNegation { span: Span, var: String },
+
+    /// Assignment desugaring emptied a rule's body, but the head could not be
+    /// reduced to constants (an unbound head variable, or a non-integer
+    /// expression). The planner requires at least one positive atom, so the
+    /// rule is rejected here rather than panicking downstream.
+    #[error("rule body reduces to nothing but its head is not a constant fact")]
+    GroundRuleNotConst { span: Span },
+
     /// A grammar contract the Pest grammar should have made unreachable. Not a
     /// user error; reported as an internal compiler bug.
     #[error(transparent)]
@@ -459,6 +474,8 @@ impl Diagnostic for ParseError {
             | ParseError::NonNullaryLoopCondition { span, .. }
             | ParseError::PlaceholderInUdf { span, .. }
             | ParseError::BuiltinArity { span, .. }
+            | ParseError::AssignmentVarInNegation { span, .. }
+            | ParseError::GroundRuleNotConst { span }
             | ParseError::IncludeIo { span, .. } => base.with_labels(primary_only(*span)),
 
             ParseError::Internal(_) => unreachable!("handled above"),

--- a/crates/flowlog-build/src/parser/grammar.pest
+++ b/crates/flowlog-build/src/parser/grammar.pest
@@ -201,7 +201,19 @@ extern_fn_param = { identifier ~ ":" ~ data_type }
 arithmetic_expr = { factor ~ (arithmetic_op ~ factor)* }
 
 // `as_cast` first so `as` wins over a UDF named `as` (reserved keyword).
-factor = { as_cast | builtin_fn_call | fn_call_expr | constant | variable }
+// `paren_expr` gives explicit grouping: since arithmetic has no operator
+// precedence (it folds strictly left-to-right), parentheses are the only
+// way to override evaluation order, e.g. `x * (a + b)`.
+factor = { as_cast | builtin_fn_call | fn_call_expr | paren_expr | constant | variable }
+
+// Parenthesised sub-expression. Both wrappers are silent (`_`): a
+// single-factor `(x)` surfaces as the bare inner factor, while a
+// multi-term `(a + b)` surfaces as `group_expr` (the `+` requires an
+// operator). A group node thus exists only when the grouping affects
+// the left-to-right fold.
+paren_expr  = _{ "(" ~ paren_inner ~ ")" }
+paren_inner = _{ group_expr | factor }
+group_expr  =  { factor ~ (arithmetic_op ~ factor)+ }
 
 // `as(factor, TargetType)` — explicit cast, runtime no-op. Inner is a
 // single `factor` (not `arithmetic_expr`) so the typechecker can lower
@@ -239,13 +251,14 @@ builtin_fn_call = {
 // `cat_op` is the Soufflé function form `cat(a, b)`. There is no
 // infix `cat`; chains nest as `cat(a, cat(b, c))`.
 builtin_op = {
-    strlen_op | substr_op | ord_op | contains_op | to_string_op | to_number_op | cat_op
+    strlen_op | substr_op | ord_op | contains_op | match_op | to_string_op | to_number_op | cat_op
 }
 
 strlen_op    = @{ "strlen"    ~ !(ASCII_ALPHANUMERIC | "_") }
 substr_op    = @{ "substr"    ~ !(ASCII_ALPHANUMERIC | "_") }
 ord_op       = @{ "ord"       ~ !(ASCII_ALPHANUMERIC | "_") }
 contains_op  = @{ "contains"  ~ !(ASCII_ALPHANUMERIC | "_") }
+match_op     = @{ "match"     ~ !(ASCII_ALPHANUMERIC | "_") }
 to_string_op = @{ "to_string" ~ !(ASCII_ALPHANUMERIC | "_") }
 to_number_op = @{ "to_number" ~ !(ASCII_ALPHANUMERIC | "_") }
 cat_op       = @{ "cat"       ~ !(ASCII_ALPHANUMERIC | "_") }
@@ -313,9 +326,12 @@ atom = {
     ")"
 }
 
-// Negative atom for negative conditions
-// Example: !edge(x, y)
-negative_atom = { "!" ~ atom }
+// Negative atom for negative conditions. The atom may be wrapped in
+// redundant parentheses — `!(edge(x, y))` — which Soufflé accepts and
+// treats identically to `!edge(x, y)`. The parens are silent literals,
+// so the parser sees the same inner `atom` either way.
+// Example: !edge(x, y)  or  !(edge(x, y))
+negative_atom = { "!" ~ ("(" ~ atom ~ ")" | atom) }
 
 // Arguments in atoms can be constants, variables, or placeholders
 atom_arg = { constant | variable | placeholder } 

--- a/crates/flowlog-build/src/parser/inliner.rs
+++ b/crates/flowlog-build/src/parser/inliner.rs
@@ -66,11 +66,21 @@ struct Scope<'a> {
     /// not a nested `.init` may resolve to one of these (Soufflé
     /// sibling-scope visibility, e.g. `basic.SubtypeOf`).
     enclosing_instances: &'a HashMap<String, String>,
+    /// Relations declared in the *enclosing* component instances (and up the
+    /// instantiation chain), mapped from lowercase simple name to the
+    /// absolute qualified relation name. A bare relation reference that is
+    /// not local to this component resolves against these — Soufflé's
+    /// lexical scoping lets a nested instance's rules name a relation
+    /// declared in the component it was instantiated within (e.g. a
+    /// `configuration` sub-instance referencing the enclosing analysis's
+    /// `isImmutableHContext`).
+    enclosing_decls: &'a HashMap<String, String>,
 }
 
 pub(crate) fn inline_one(
     parent_prefix: &str,
     enclosing: &HashMap<String, String>,
+    enclosing_decls: &HashMap<String, String>,
     init: InitDecl,
     comps: &mut HashMap<String, CompDecl>,
     output: &mut InlinerOutput,
@@ -139,6 +149,7 @@ pub(crate) fn inline_one(
         local_types: &local_types,
         nested_inits: &nested_inits,
         enclosing_instances: enclosing,
+        enclosing_decls,
     };
 
     // Instances visible to a nested `.init` in this body: everything
@@ -147,6 +158,14 @@ pub(crate) fn inline_one(
     let mut child_enclosing = enclosing.clone();
     for name in &nested_inits {
         child_enclosing.insert(name.clone(), qualify(&prefix, name));
+    }
+
+    // Relations visible to a nested `.init`: those visible to this instance
+    // plus this body's own `.decl`s, qualified under this instance's prefix.
+    // A nested instance's bare relation references resolve against these.
+    let mut child_enclosing_decls = enclosing_decls.clone();
+    for name in &local_decls {
+        child_enclosing_decls.insert(name.clone(), qualify(&prefix, name));
     }
 
     // Resolution proceeds in two walks of the body, NOT in textual order.
@@ -165,7 +184,7 @@ pub(crate) fn inline_one(
     // define-before-use rule top-level `.type`s follow (see
     // `build_type_registry` in program.rs). Cycles surface as
     // `UnknownTypeParent`, not a hang.
-    collect_instance(&body, &scope, &child_enclosing, comps, output, registry)?;
+    collect_instance(&body, &scope, &child_enclosing, &child_enclosing_decls, comps, output, registry)?;
     resolve_instance(body, &scope, output, registry)?;
 
     Ok(())
@@ -180,6 +199,7 @@ fn collect_instance(
     body: &[RawItem],
     scope: &Scope<'_>,
     child_enclosing: &HashMap<String, String>,
+    child_enclosing_decls: &HashMap<String, String>,
     comps: &mut HashMap<String, CompDecl>,
     output: &mut InlinerOutput,
     registry: &mut TypeRegistry,
@@ -189,6 +209,7 @@ fn collect_instance(
             inline_one(
                 scope.prefix,
                 child_enclosing,
+                child_enclosing_decls,
                 resolve_init(nested.clone(), scope.env),
                 comps,
                 output,
@@ -553,7 +574,9 @@ fn subst(env: &HashMap<String, String>, s: &str) -> String {
 /// 6. dotted, none of the above → pass through (types) / error (relations)
 /// 7. single segment matching a local `.decl`, or *(types only)* a local
 ///    `.type` alias declared in this comp → `prefix.name`
-/// 8. otherwise → unchanged, resolved later via the global registry
+/// 8. *(relations only)* single segment matching a relation declared in an
+///    enclosing instance → that instance's qualified name
+/// 9. otherwise → unchanged, resolved later via the global registry
 ///
 /// Cases 1/4/5 and the alias half of 7 are gated on `!strict` so the
 /// relation path resolves a dotted head only via a nested-init (2) or a
@@ -594,6 +617,12 @@ fn resolve_qualified(
     let key = s.to_lowercase();
     if scope.local_decls.contains(&key) || (!strict && scope.local_types.contains(&key)) {
         return Ok(qualify(scope.prefix, s));
+    }
+    // A bare relation reference that isn't local resolves to a relation
+    // declared in an enclosing instance, if one exists (Soufflé lexical
+    // scoping). Types are excluded — they fall through to the registry.
+    if strict && let Some(qualified) = scope.enclosing_decls.get(&key) {
+        return Ok(qualified.clone());
     }
     Ok(s.to_string())
 }

--- a/crates/flowlog-build/src/parser/logic/arithmetic.rs
+++ b/crates/flowlog-build/src/parser/logic/arithmetic.rs
@@ -73,6 +73,13 @@ pub(crate) enum Factor {
     /// `as(factor, T)`. Runtime no-op; the typechecker lowers it away
     /// after validating the cast.
     Cast(Box<Cast>),
+    /// Parenthesised sub-expression `(expr)`. Preserves grouping because
+    /// arithmetic folds left-to-right with no operator precedence. The
+    /// grammar enforces multi-term content (`group_expr` requires at
+    /// least one operator; single-factor parens like `(x)` are silent
+    /// and parse as the bare factor), so a `Group` exists only when the
+    /// grouping affects the fold.
+    Group(Box<Arithmetic>),
 }
 
 /// `as(factor, target_type)`. `inner` is a single [`Factor`] (not a
@@ -146,6 +153,7 @@ impl Factor {
             Self::FnCall(fc) => fc.vars(),
             Self::Builtin(bc) => bc.vars(),
             Self::Cast(c) => c.inner().vars(),
+            Self::Group(a) => a.vars(),
         }
     }
 }
@@ -158,6 +166,7 @@ impl fmt::Display for Factor {
             Self::FnCall(fc) => write!(f, "{fc}"),
             Self::Builtin(bc) => write!(f, "{bc}"),
             Self::Cast(c) => write!(f, "{c}"),
+            Self::Group(a) => write!(f, "({a})"),
         }
     }
 }
@@ -174,6 +183,13 @@ impl Lexeme for Factor {
             Rule::fn_call_expr => Self::FnCall(FnCall::from_parsed_rule(inner, file)?),
             Rule::variable => Self::Var(inner.as_str().to_string()),
             Rule::constant => Self::Const(ConstType::from_parsed_rule(inner, file)?),
+            // Multi-term parenthesised sub-expression — the grammar's
+            // `group_expr` requires at least one operator, so `Group` is
+            // constructed only when grouping affects the fold.
+            Rule::group_expr => Self::Group(Box::new(Arithmetic::from_parsed_rule(inner, file)?)),
+            // Single-factor parens `(x)`: the paren wrappers are silent in
+            // the grammar, so the bare inner factor pair surfaces here.
+            Rule::factor => Self::from_parsed_rule(inner, file)?,
             other => return Err(grammar_bug(format!("invalid factor rule: {other:?}"))),
         })
     }
@@ -343,5 +359,63 @@ mod tests {
         let y = "y".to_string();
         assert_eq!(a.vars(), vec![&x, &x, &y]);
         assert_eq!(a.vars_set().len(), 2);
+    }
+
+    /// A parenthesised sub-expression parses into `Factor::Group`,
+    /// preserves its inner variables (in order), and round-trips through
+    /// `Display` with its parentheses intact — the grouping must survive
+    /// because arithmetic folds left-to-right with no operator precedence.
+    #[test]
+    fn parse_paren_group() {
+        use crate::parser::{FlowLogParser, Rule};
+        use pest::Parser;
+
+        let mut pairs = FlowLogParser::parse(Rule::arithmetic_expr, "a * (b + c)").unwrap();
+        let arith =
+            Arithmetic::from_parsed_rule(pairs.next().unwrap(), crate::common::FileId(0)).unwrap();
+
+        // init = `a`; rest = [(*, Group(b + c))].
+        assert!(matches!(arith.init(), Factor::Var(v) if v == "a"));
+        let (op, factor) = &arith.rest()[0];
+        assert!(matches!(op, ArithmeticOperator::Multiply));
+        assert!(matches!(factor, Factor::Group(_)));
+
+        // Variables recurse through the group, preserving order.
+        let a = "a".to_string();
+        let b = "b".to_string();
+        let c = "c".to_string();
+        assert_eq!(arith.vars(), vec![&a, &b, &c]);
+
+        // Parentheses survive the round-trip.
+        assert_eq!(arith.to_string(), "a * (b + c)");
+    }
+
+    /// Parentheses around a single factor are semantically transparent and
+    /// collapse to the bare factor at parse time — `(x)`, `("c")`, and
+    /// `(f(x))` must behave exactly like their unparenthesised forms in
+    /// fact detection, subtype narrowing, and assignment recognition.
+    /// Nested parens around a multi-term expression collapse to one `Group`.
+    #[test]
+    fn parse_single_factor_group_collapses() {
+        use crate::parser::{FlowLogParser, Rule};
+        use pest::Parser;
+
+        let parse = |src: &str| -> Factor {
+            let mut pairs = FlowLogParser::parse(Rule::arithmetic_expr, src).unwrap();
+            Arithmetic::from_parsed_rule(pairs.next().unwrap(), crate::common::FileId(0))
+                .unwrap()
+                .init()
+                .clone()
+        };
+
+        assert!(matches!(parse("(x)"), Factor::Var(v) if v == "x"));
+        assert!(matches!(parse("(((x)))"), Factor::Var(v) if v == "x"));
+        assert!(matches!(parse("(\"boolean\")"), Factor::Const(_)));
+        // Nested parens: `((b + c))` is one Group around the expression.
+        let Factor::Group(inner) = parse("((b + c))") else {
+            panic!("expected Group");
+        };
+        assert!(matches!(inner.init(), Factor::Var(v) if v == "b"));
+        assert!(!inner.rest().is_empty());
     }
 }

--- a/crates/flowlog-build/src/parser/logic/builtin.rs
+++ b/crates/flowlog-build/src/parser/logic/builtin.rs
@@ -27,6 +27,8 @@ pub enum BuiltinOperator {
     Ord,
     /// `contains(needle, hay) -> bool`.
     Contains,
+    /// `match(pattern, s) -> bool` — full (anchored) regex match, Soufflé semantics.
+    Match,
     /// `to_string(n: int32) -> string`.
     ToString,
     /// `to_number(s) -> int32` — 0 on parse failure.
@@ -43,6 +45,7 @@ impl BuiltinOperator {
             BuiltinOperator::Substr => "substr",
             BuiltinOperator::Ord => "ord",
             BuiltinOperator::Contains => "contains",
+            BuiltinOperator::Match => "match",
             BuiltinOperator::ToString => "to_string",
             BuiltinOperator::ToNumber => "to_number",
             BuiltinOperator::Cat => "cat",
@@ -64,6 +67,7 @@ impl BuiltinOperator {
             BuiltinOperator::Substr => &[Str, Int32, Int32],
             BuiltinOperator::Ord => &[Str],
             BuiltinOperator::Contains => &[Str, Str],
+            BuiltinOperator::Match => &[Str, Str],
             BuiltinOperator::ToString => &[Int32],
             BuiltinOperator::ToNumber => &[Str],
             BuiltinOperator::Cat => &[Str, Str],
@@ -79,7 +83,7 @@ impl BuiltinOperator {
             BuiltinOperator::Substr | BuiltinOperator::ToString | BuiltinOperator::Cat => {
                 DataType::String
             }
-            BuiltinOperator::Contains => DataType::Bool,
+            BuiltinOperator::Contains | BuiltinOperator::Match => DataType::Bool,
         }
     }
 }
@@ -198,6 +202,7 @@ fn op_from_node(node: &Pair<Rule>) -> Result<BuiltinOperator, ParseError> {
         Rule::substr_op => BuiltinOperator::Substr,
         Rule::ord_op => BuiltinOperator::Ord,
         Rule::contains_op => BuiltinOperator::Contains,
+        Rule::match_op => BuiltinOperator::Match,
         Rule::to_string_op => BuiltinOperator::ToString,
         Rule::to_number_op => BuiltinOperator::ToNumber,
         Rule::cat_op => BuiltinOperator::Cat,

--- a/crates/flowlog-build/src/parser/logic/rule.rs
+++ b/crates/flowlog-build/src/parser/logic/rule.rs
@@ -163,6 +163,14 @@ impl FlowLogRule {
         &mut self.rhs
     }
 
+    /// Replace the rule body wholesale. Used by the equality-assignment
+    /// desugaring pass, which removes assignment literals after substituting
+    /// their bound variable into the head and remaining predicates.
+    #[inline]
+    pub(crate) fn set_rhs(&mut self, rhs: Vec<Predicate>) {
+        self.rhs = rhs;
+    }
+
     /// Extract constants from a fact's head.
     ///
     /// Panics if any head argument is not a simple constant.

--- a/crates/flowlog-build/src/parser/mod.rs
+++ b/crates/flowlog-build/src/parser/mod.rs
@@ -5,6 +5,7 @@
 //! relation declarations, logic rules, and primitive types.
 
 mod declaration;
+mod desugar;
 mod error;
 mod inliner;
 mod logic;

--- a/crates/flowlog-build/src/parser/program.rs
+++ b/crates/flowlog-build/src/parser/program.rs
@@ -234,6 +234,10 @@ impl Program {
 
         let mut program = Self::collect_program(root, extended, combined_file)?;
         program.prune_dead_components();
+        // Materialize orphan references only *after* pruning, so the empty-fact
+        // entries we add can't disable pruning's "no outputs/facts ⇒ keep all"
+        // shortcut, and so we never materialize a relation that pruning dropped.
+        program.materialize_orphan_relations();
 
         debug!("\n{}", program);
         info!("Successfully parsed program from '{}'.", path);
@@ -860,10 +864,11 @@ impl Program {
             .iter()
             .map(|(init, _)| (init.instance.to_lowercase(), init.instance.clone()))
             .collect();
+        let global_decls: HashMap<String, String> = HashMap::new();
         let mut shift = 0usize;
         for (init, pos) in inits_at_pos {
             let mut out = inliner::InlinerOutput::default();
-            inliner::inline_one("", &global_instances, init, &mut comps, &mut out, &mut type_registry)?;
+            inliner::inline_one("", &global_instances, &global_decls, init, &mut comps, &mut out, &mut type_registry)?;
             for rel in out.relations {
                 if let Some((_prev_raw, prior)) = decl_spans.get(rel.name()) {
                     return Err(ParseError::DuplicateDecl {
@@ -903,6 +908,11 @@ impl Program {
 
         normalize_inliner_dots(&mut relations, &mut segments, &mut raw_facts);
 
+        // Eliminate equality assignments (`v = expr`) by substitution before the
+        // catalog/planner, which ground variables only through positive atoms.
+        // Constant-only rules become inline facts.
+        super::desugar::desugar_equality_assignments(&mut segments, &mut raw_facts)?;
+
         let mut program = Self {
             relations,
             segments,
@@ -917,6 +927,50 @@ impl Program {
         program.validate_relation_references()?;
 
         Ok(program)
+    }
+
+    /// Materialize *orphan* relations as empty inputs.
+    ///
+    /// A relation that is declared and referenced in some rule body, yet has no
+    /// producing rule, no `.input`, and no inline facts, denotes the empty
+    /// relation under Soufflé semantics (a positive reference yields nothing; a
+    /// negative reference is always satisfied). The stratifier already tolerates
+    /// such references; here we give them an empty inline-fact entry so codegen
+    /// emits an empty collection for them instead of referencing an undefined
+    /// binding.
+    fn materialize_orphan_relations(&mut self) {
+        let mut produced: HashSet<String> = HashSet::new();
+        let mut referenced: HashSet<String> = HashSet::new();
+        for segment in &self.segments {
+            let rules: &[FlowLogRule] = match segment {
+                Segment::Plain(rules) => rules,
+                Segment::Loop(block) | Segment::Fixpoint(block) => block.rules(),
+            };
+            for rule in rules {
+                produced.insert(rule.head().name().to_string());
+                for pred in rule.rhs() {
+                    if let Predicate::PositiveAtom(atom) | Predicate::NegativeAtom(atom) = pred {
+                        referenced.insert(atom.name().to_string());
+                    }
+                }
+            }
+        }
+
+        let orphans: Vec<String> = self
+            .relations
+            .iter()
+            .filter(|rel| {
+                let name = rel.name();
+                referenced.contains(name)
+                    && !produced.contains(name)
+                    && !self.facts.contains_key(name)
+                    && !rel.has_input()
+            })
+            .map(|rel| rel.name().to_string())
+            .collect();
+        for name in orphans {
+            self.facts.entry(name).or_default();
+        }
     }
 
     /// Reject any rule head, body atom, or ground fact whose relation
@@ -1493,6 +1547,8 @@ impl Program {
 mod tests {
     use super::*;
     use crate::parser::DataType;
+    use crate::parser::HeadArg;
+    use crate::parser::ComparisonOperator;
     use std::io::Write;
 
     fn loop_blocks(program: &Program) -> Vec<&LoopBlock> {
@@ -2246,6 +2302,408 @@ mod tests {
         assert!(
             body.contains(&"basic·subtypeof"),
             "sibling ref should resolve to basic·subtypeof, got {body:?}"
+        );
+    }
+
+    /// `R(t) :- A(x), t = x + 1.` — the assignment grounds `t`, which is
+    /// substituted into the head as an arithmetic expression; the equality
+    /// literal is dropped, leaving only the positive atom.
+    #[test]
+    fn equality_assignment_arith_substituted_into_head() {
+        let program = parse_program(
+            "
+            .decl A(x:number)
+            .decl R(t:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            R(t) :- A(x), t = x + 1.
+            .output R
+            ",
+        );
+        let rule = program
+            .rules()
+            .into_iter()
+            .find(|r| r.head().name() == "r")
+            .expect("r rule");
+        assert_eq!(rule.rhs().len(), 1, "equality literal should be dropped");
+        assert!(matches!(rule.rhs()[0], Predicate::PositiveAtom(_)));
+        assert!(
+            matches!(rule.head().head_arguments()[0], HeadArg::Arith(_)),
+            "head arg should carry the substituted arithmetic"
+        );
+    }
+
+    /// `R(y) :- A(x), y = x.` — a pure aliasing assignment collapses the head
+    /// argument back to the source variable.
+    #[test]
+    fn equality_assignment_alias_substituted_into_head() {
+        let program = parse_program(
+            "
+            .decl A(x:symbol)
+            .decl R(y:symbol)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            R(y) :- A(x), y = x.
+            .output R
+            ",
+        );
+        let rule = program
+            .rules()
+            .into_iter()
+            .find(|r| r.head().name() == "r")
+            .expect("r rule");
+        assert_eq!(rule.rhs().len(), 1);
+        match &rule.head().head_arguments()[0] {
+            HeadArg::Var(v) => assert_eq!(v, "x"),
+            other => panic!("expected aliased Var(x), got {other:?}"),
+        }
+    }
+
+    /// `P(t) :- t = "boolean".` — an empty-body rule whose head is fully ground
+    /// after substitution is lowered to an inline fact.
+    #[test]
+    fn equality_assignment_const_only_becomes_fact() {
+        let program = parse_program(
+            "
+            .decl P(t:symbol)
+            P(t) :- t = \"boolean\".
+            .output P
+            ",
+        );
+        assert!(
+            program.facts().contains_key("p"),
+            "const-only assignment rule should become a fact"
+        );
+        assert_eq!(program.facts()["p"].len(), 1);
+        assert!(
+            program.rules().iter().all(|r| r.head().name() != "p"),
+            "no derivation rule should remain for the fact relation"
+        );
+    }
+
+    /// `R(x,t) :- A(x), B(t), t = x.` — `t` is already bound by `B`, so the
+    /// equality is a genuine filter and must be left in the body, not treated
+    /// as an assignment.
+    #[test]
+    fn equality_between_bound_columns_is_kept_as_filter() {
+        let program = parse_program(
+            "
+            .decl A(x:number)
+            .decl B(t:number)
+            .decl R(x:number, t:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            .input B(IO=\"file\",filename=\"B.csv\")
+            R(x, t) :- A(x), B(t), t = x.
+            .output R
+            ",
+        );
+        let rule = program
+            .rules()
+            .into_iter()
+            .find(|r| r.head().name() == "r")
+            .expect("r rule");
+        let compares = rule
+            .rhs()
+            .iter()
+            .filter(|p| matches!(p, Predicate::Compare(_)))
+            .count();
+        assert_eq!(compares, 1, "filter equality must be preserved");
+    }
+
+    /// A relation that is declared and referenced by a live rule but never
+    /// produced (no rule, no `.input`, no facts) is materialized as an empty
+    /// inline-fact relation so codegen emits an empty collection for it.
+    /// An `.input`-backed relation is NOT an orphan — its collection comes
+    /// from the fact file.
+    #[test]
+    fn orphan_relation_referenced_by_live_rule_is_materialized_empty() {
+        let program = parse_program(
+            "
+            .decl O(x:symbol)
+            .decl I(x:symbol)
+            .input I(IO=\"file\",filename=\"I.csv\")
+            .decl R(x:symbol)
+            R(x) :- O(x), I(x).
+            .output R
+            ",
+        );
+        assert!(
+            program.facts().contains_key("o"),
+            "orphan relation should be materialized"
+        );
+        assert!(
+            program.facts()["o"].is_empty(),
+            "materialized orphan must be empty"
+        );
+        assert!(
+            !program.facts().contains_key("i"),
+            ".input relation must not be materialized as an orphan"
+        );
+    }
+
+
+    /// Substituting an assignment of a *computed* expression into a negated
+    /// atom is rejected: a negated atom argument can only be a bare variable or
+    /// constant, never an arithmetic expression.
+    #[test]
+    fn equality_assignment_into_negation_with_arith_errors() {
+        let err = parse_program_result(
+            "
+            .decl A(x:number)
+            .decl B(t:number)
+            .decl R(x:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            .input B(IO=\"file\",filename=\"B.csv\")
+            R(x) :- A(x), !B(t), t = x + 1.
+            .output R
+            ",
+        )
+        .expect_err("computed value into negated atom should error");
+        assert!(
+            matches!(err, ParseError::AssignmentVarInNegation { .. }),
+            "expected AssignmentVarInNegation, got {err:?}"
+        );
+    }
+
+    /// A rule whose body desugars away entirely must still leave the segment:
+    /// ground integer arithmetic in the head is folded (`x = 1 + 2` → fact
+    /// `P(3)`), and anything unfoldable is rejected with
+    /// [`ParseError::GroundRuleNotConst`] instead of reaching the planner,
+    /// which panics on zero-positive-atom rules.
+    #[test]
+    fn assignment_only_rule_folds_or_rejects() {
+        // Foldable integer expression → inline fact P(3).
+        let program = parse_program(
+            "
+            .decl P(x:number)
+            P(x) :- x = 1 + 2.
+            .output P
+            ",
+        );
+        assert!(program.facts().contains_key("p"));
+        assert!(program.rules().iter().all(|r| r.head().name() != "p"));
+
+        // Unfoldable (builtin call) → rejected, not handed to the planner.
+        let err = parse_program_result(
+            "
+            .decl P(s:symbol)
+            P(s) :- s = cat(\"a\", \"b\").
+            .output P
+            ",
+        )
+        .expect_err("builtin in ground head should be rejected");
+        assert!(
+            matches!(err, ParseError::GroundRuleNotConst { .. }),
+            "expected GroundRuleNotConst, got {err:?}"
+        );
+
+        // Unbound head variable with emptied body → same rejection.
+        let err = parse_program_result(
+            "
+            .decl P(x:number)
+            P(x) :- y = 1.
+            .output P
+            ",
+        )
+        .expect_err("unbound head var in ground rule should be rejected");
+        assert!(
+            matches!(err, ParseError::GroundRuleNotConst { .. }),
+            "expected GroundRuleNotConst, got {err:?}"
+        );
+
+        // Division by zero refuses to fold → rejected, not miscomputed.
+        let err = parse_program_result(
+            "
+            .decl P(x:number)
+            P(x) :- x = 1 / 0.
+            .output P
+            ",
+        )
+        .expect_err("division by zero should be rejected");
+        assert!(matches!(err, ParseError::GroundRuleNotConst { .. }));
+
+        // Folding recurses through groups: (1 + 2) * 3 → fact P(9).
+        let program = parse_program(
+            "
+            .decl P(x:number)
+            P(x) :- x = (1 + 2) * 3.
+            .output P
+            ",
+        );
+        assert!(program.facts().contains_key("p"));
+    }
+
+    /// Chained assignments resolve to a fixpoint regardless of source order
+    /// (`b = a + 2` is discovered only after `a = x + 1` grounds `a`), and the
+    /// resolved values substitute into remaining comparison filters.
+    #[test]
+    fn chained_assignments_resolve_and_substitute_into_filters() {
+        let program = parse_program(
+            "
+            .decl A(x:number)
+            .decl R(a:number, b:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            R(a, b) :- A(x), b = a + 2, a = x + 1, b < 10.
+            .output R
+            ",
+        );
+        let rule = program
+            .rules()
+            .into_iter()
+            .find(|r| r.head().name() == "r")
+            .expect("r rule");
+        // Both assignments eliminated; only the `< 10` filter survives, and it
+        // no longer mentions the assignment variables.
+        let mut compare_vars = Vec::new();
+        let mut compares = 0;
+        for pred in rule.rhs() {
+            if let Predicate::Compare(e) = pred {
+                compares += 1;
+                compare_vars.extend(e.left().vars().into_iter().cloned());
+                compare_vars.extend(e.right().vars().into_iter().cloned());
+            }
+        }
+        assert_eq!(compares, 1, "only the filter comparison remains");
+        assert!(
+            compare_vars.iter().all(|v| v == "x"),
+            "assignment vars must be fully substituted away: {rule}"
+        );
+    }
+
+    /// A multi-term assignment value spliced into a factor slot is wrapped in
+    /// a `Group`, preserving fold order: `z = x * y` with `y := a - b` must
+    /// mean `x * (a - b)`, not `(x * a) - b`. Same inside aggregation args.
+    #[test]
+    fn multi_term_substitution_wraps_in_group() {
+        use crate::parser::Factor;
+
+        let program = parse_program(
+            "
+            .decl A(x:number, a:number, b:number)
+            .decl R(z:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            R(z) :- A(x, a, b), y = a - b, z = x * y.
+            .output R
+            ",
+        );
+        let rule = program
+            .rules()
+            .into_iter()
+            .find(|r| r.head().name() == "r")
+            .expect("r rule");
+        let [HeadArg::Arith(arith)] = rule.head().head_arguments() else {
+            panic!("expected one arithmetic head arg");
+        };
+        let (_, factor) = &arith.rest()[0];
+        assert!(
+            matches!(factor, Factor::Group(inner) if !inner.rest().is_empty()),
+            "substituted multi-term value must be group-wrapped: {arith}"
+        );
+
+        // Aggregation arguments take the same substitution path.
+        let program = parse_program(
+            "
+            .decl A(g:number, x:number)
+            .decl S(g:number, s:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            S(g, sum(t)) :- A(g, x), t = x + 1.
+            .output S
+            ",
+        );
+        let rule = program
+            .rules()
+            .into_iter()
+            .find(|r| r.head().name() == "s")
+            .expect("s rule");
+        let agg = rule
+            .head()
+            .head_arguments()
+            .iter()
+            .find_map(|a| match a {
+                HeadArg::Aggregation(agg) => Some(agg),
+                _ => None,
+            })
+            .expect("aggregation head arg");
+        assert!(
+            !agg.arithmetic().vars().iter().any(|v| *v == "t"),
+            "assignment var must be substituted inside the aggregation"
+        );
+    }
+
+    /// The desugar pass also runs inside `fixpoint`/`loop` blocks.
+    #[test]
+    fn assignment_inside_fixpoint_desugared() {
+        let program = parse_program(
+            "
+            .decl A(x:number)
+            .decl R(t:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            fixpoint {
+              R(t) :- A(x), t = x + 1.
+              R(t) :- R(x), t = x + 1, x < 5.
+            }
+            .output R
+            ",
+        );
+        for rule in program.rules() {
+            let assignments = rule
+                .rhs()
+                .iter()
+                .filter(|p| matches!(p, Predicate::Compare(e) if *e.operator() == ComparisonOperator::Equal))
+                .count();
+            assert_eq!(assignments, 0, "assignments inside blocks must desugar");
+        }
+    }
+
+    /// Parentheses around a single factor are transparent: a grouped constant
+    /// assignment `t = ("boolean")` lowers to a fact exactly like the bare
+    /// form, a grouped assignment variable `(t) = x` is still recognized as
+    /// an assignment, and a grouped bare variable substituted into a negated
+    /// atom is accepted (it is not computed arithmetic).
+    #[test]
+    fn single_factor_groups_are_transparent_to_desugar() {
+        // Grouped constant → inline fact (not an empty-bodied rule).
+        let program = parse_program(
+            "
+            .decl P(t:symbol)
+            P(t) :- t = (\"boolean\").
+            .output P
+            ",
+        );
+        assert!(
+            program.facts().contains_key("p"),
+            "grouped const-only assignment rule should become a fact"
+        );
+
+        // Grouped assignment variable → recognized and eliminated.
+        let program = parse_program(
+            "
+            .decl A(x:number)
+            .decl R(t:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            R(t) :- A(x), (t) = x.
+            .output R
+            ",
+        );
+        let rule = program
+            .rules()
+            .into_iter()
+            .find(|r| r.head().name() == "r")
+            .expect("r rule");
+        assert!(
+            !rule.rhs().iter().any(|p| matches!(p, Predicate::Compare(_))),
+            "grouped assignment must be eliminated, not left as a filter"
+        );
+
+        // Grouped bare variable into a negated atom → fine, not arithmetic.
+        parse_program(
+            "
+            .decl A(x:number)
+            .decl B(t:number)
+            .decl R(x:number)
+            .input A(IO=\"file\",filename=\"A.csv\")
+            .input B(IO=\"file\",filename=\"B.csv\")
+            R(x) :- A(x), !B(t), t = (x).
+            .output R
+            ",
         );
     }
 

--- a/crates/flowlog-build/src/planner/arithmetic.rs
+++ b/crates/flowlog-build/src/planner/arithmetic.rs
@@ -26,6 +26,9 @@ pub(crate) enum FactorArgument {
         op: BuiltinOperator,
         args: Vec<ArithmeticArgument>,
     },
+
+    /// Parenthesised sub-expression, preserving its grouping.
+    Group(Box<ArithmeticArgument>),
 }
 
 impl FactorArgument {
@@ -39,6 +42,7 @@ impl FactorArgument {
                 .iter()
                 .flat_map(|a| a.transformation_arguments())
                 .collect(),
+            Self::Group(a) => a.transformation_arguments(),
         }
     }
 }
@@ -64,6 +68,7 @@ impl fmt::Display for FactorArgument {
                     .join(", ");
                 write!(f, "{op}({args_str})")
             }
+            Self::Group(a) => write!(f, "({a})"),
         }
     }
 }
@@ -117,6 +122,14 @@ impl ArithmeticArgument {
                     op: *op,
                     args: map_call_args(args, var_id),
                 },
+                FactorPos::Group(a) => {
+                    let num_vars = a.signatures().len();
+                    let sub_args = &var_arguments[*var_id..*var_id + num_vars];
+                    *var_id += num_vars;
+                    FactorArgument::Group(Box::new(ArithmeticArgument::from_arithmeticpos(
+                        a, sub_args,
+                    )))
+                }
             }
         }
 

--- a/crates/flowlog-build/src/planner/transformation/flow.rs
+++ b/crates/flowlog-build/src/planner/transformation/flow.rs
@@ -360,6 +360,14 @@ impl TransformationFlow {
                             op: *op,
                             args: lower_call_args(args),
                         },
+                        FactorPos::Group(a) => {
+                            // Reuse the call-arg lowering: a grouped expression
+                            // resolves its inner signatures the same way.
+                            let inner = lower_call_args(std::slice::from_ref(a))
+                                .pop()
+                                .expect("group lowering yields exactly one arithmetic");
+                            FactorArgument::Group(Box::new(inner))
+                        }
                     }
                 };
 

--- a/crates/flowlog-build/src/stratifier/core.rs
+++ b/crates/flowlog-build/src/stratifier/core.rs
@@ -213,17 +213,39 @@ impl Stratifier {
         let mut iterative_rels: Vec<Vec<IterativeDirective>> = Vec::new();
         let mut id_offset = 0usize;
 
-        for seg in program.segments() {
-            match seg {
-                Segment::Plain(rules) => {
-                    let (seg_strata, seg_bitmap) =
-                        Self::stratify_segment(rules, id_offset, extended)?;
+        let segments = program.segments();
+        let mut i = 0;
+        while i < segments.len() {
+            match &segments[i] {
+                Segment::Plain(_) => {
+                    // Coalesce the maximal run of consecutive `Plain` segments
+                    // and stratify it as one unit. Component instances splice
+                    // into their own segment per `.init`, so a relation may be
+                    // defined in a later instance than it is referenced. One
+                    // SCC problem per run makes instance order irrelevant —
+                    // matching Soufflé's global stratification — while
+                    // `Loop`/`Fixpoint` barriers still bound each run.
+                    let mut run: Vec<&[FlowLogRule]> = Vec::new();
+                    let mut total = 0usize;
+                    while let Some(Segment::Plain(rules)) = segments.get(i) {
+                        run.push(rules);
+                        total += rules.len();
+                        i += 1;
+                    }
+                    let (seg_strata, seg_bitmap) = if let [rules] = run[..] {
+                        // Single segment: stratify the slice directly.
+                        Self::stratify_segment(rules, id_offset, extended)?
+                    } else {
+                        let combined: Vec<FlowLogRule> =
+                            run.iter().flat_map(|r| r.iter().cloned()).collect();
+                        Self::stratify_segment(&combined, id_offset, extended)?
+                    };
                     let n = seg_strata.len();
                     strata.extend(seg_strata);
                     bitmap.extend(seg_bitmap);
                     loop_conditions.extend(std::iter::repeat_n(None, n));
                     iterative_rels.extend(std::iter::repeat_with(Vec::new).take(n));
-                    id_offset += rules.len();
+                    id_offset += total;
                 }
                 Segment::Loop(block) | Segment::Fixpoint(block) => {
                     // A loop/fixpoint block is always exactly one recursive stratum.
@@ -243,6 +265,7 @@ impl Stratifier {
                     loop_conditions.push(block.condition().cloned());
                     iterative_rels.push(block.iterative_relations().to_vec());
                     id_offset += rule_count;
+                    i += 1;
                 }
             }
         }
@@ -703,6 +726,19 @@ impl Stratifier {
     fn validate_forward_references(&self) -> Result<(), StratifyError> {
         let edb_fps = self.program.edb_fingerprints();
 
+        // Fingerprints of every relation produced by some rule head anywhere in
+        // the program. A body atom whose relation is neither an EDB nor any
+        // rule's head is an *orphan*: declared but never populated. Soufflé
+        // treats such a relation as simply empty (the referencing rule yields
+        // nothing), so this is not a forward reference — only a relation that
+        // *is* defined, but in a later stratum, qualifies.
+        let defined_fps: HashSet<u64> = self
+            .stratum
+            .iter()
+            .flatten()
+            .map(|&rid| self.program.rule(rid).head().head_fingerprint())
+            .collect();
+
         for (i, stratum) in self.stratum.iter().enumerate() {
             let available = &self.stratum_available_relations[i];
             let heads: HashSet<u64> = stratum
@@ -719,7 +755,11 @@ impl Stratifier {
                         }
                         _ => continue,
                     };
-                    if edb_fps.contains(&fp) || available.contains(&fp) || heads.contains(&fp) {
+                    if edb_fps.contains(&fp)
+                        || available.contains(&fp)
+                        || heads.contains(&fp)
+                        || !defined_fps.contains(&fp)
+                    {
                         continue;
                     }
                     let rel_name = self.display_name(fp, "<unknown>");
@@ -993,6 +1033,31 @@ mod tests {
             .expect("failed to write temp file");
         let mut sm = SourceMap::new();
         Program::parse(&tmp.path().to_string_lossy(), true, &mut sm).expect("parse failed")
+    }
+
+    /// Each `.init` splices its component instance into its own `Plain`
+    /// segment, so instance `a` negating `b.Keep` — produced by a *later*
+    /// instance — is a forward reference across segments. Coalescing the
+    /// Plain run before SCC stratification makes instance order irrelevant,
+    /// matching Soufflé's global stratification.
+    #[test]
+    fn coalesced_plain_run_stratifies_cross_instance_forward_reference() {
+        let src = "\
+            .decl In(x: int32)\n\
+            .input In(IO=\"file\", filename=\"In.csv\", delimiter=\",\")\n\
+            .comp A {\n\
+              .decl Out(x: int32)\n\
+              Out(x) :- In(x), !b.Keep(x).\n\
+            }\n\
+            .comp B {\n\
+              .decl Keep(x: int32)\n\
+              Keep(x) :- In(x).\n\
+            }\n\
+            .init a = A\n\
+            .init b = B\n\
+            .output a.Out\n";
+        Stratifier::from_program(&parse_program(src), false)
+            .expect("cross-instance forward reference must stratify");
     }
 
     /// A(x,y) :- Edge(x,y), !B(x,y).

--- a/crates/flowlog-build/src/typechecker/mod.rs
+++ b/crates/flowlog-build/src/typechecker/mod.rs
@@ -144,6 +144,7 @@ fn check_builtin_config_requirements(
                 bc.args().iter().try_for_each(check_arith)
             }
             Factor::Cast(c) => check_factor(c.inner()),
+            Factor::Group(a) => check_arith(a),
         }
     }
     for segment in program.segments() {
@@ -617,6 +618,7 @@ fn infer_factor_type(
         // Primitive layer sees through casts; the `subtype` pass
         // enforces the cast rules separately.
         Factor::Cast(c) => infer_factor_type(c.inner(), bindings, udfs)?,
+        Factor::Group(a) => infer_expr_type(a, bindings, udfs)?,
     })
 }
 
@@ -762,6 +764,7 @@ fn pin_factor(factor: &mut Factor, target: DataType, udfs: &UdfSigs) -> Result<(
         // Cast asserts its inner has the target's primitive — pin
         // polymorphic literals inside accordingly.
         Factor::Cast(c) => pin_factor(c.inner_mut(), target, udfs),
+        Factor::Group(a) => pin_arith_literals(a, target, udfs),
     }
 }
 
@@ -1067,6 +1070,27 @@ mod tests {
             .output OnlyUsers\n\
             OnlyUsers(as(x, UserId)) :- Plain(x).\n";
         parse_and_check_result(src).expect("explicit narrowing must be allowed");
+    }
+
+    /// Head narrowing without `as()` is rejected — and parentheses around
+    /// the variable must not bypass the check (`OnlyUsers((x))` is the same
+    /// pass-through as `OnlyUsers(x)`; the parser collapses the group).
+    #[test]
+    fn head_narrowing_without_cast_rejected_even_parenthesized() {
+        for head in ["OnlyUsers(x)", "OnlyUsers((x))"] {
+            let src = format!(
+                ".type UserId <: number\n\
+                 .decl Plain(x: number)\n\
+                 .decl OnlyUsers(u: UserId)\n\
+                 .input Plain(IO=\"file\", filename=\"Plain.csv\", delimiter=\",\")\n\
+                 .output OnlyUsers\n\
+                 {head} :- Plain(x).\n"
+            );
+            assert!(
+                parse_and_check_result(&src).is_err(),
+                "implicit narrowing must be rejected for {head}"
+            );
+        }
     }
 
     /// `as()` between two sibling subtypes of the same primitive is

--- a/crates/flowlog-build/src/typechecker/subtype.rs
+++ b/crates/flowlog-build/src/typechecker/subtype.rs
@@ -205,7 +205,7 @@ fn single_var_type(a: &Arithmetic, reg: &TypeRegistry, bindings: &Bindings) -> O
     match a.init() {
         Factor::Var(v) => bindings.get(v).map(|&(id, _)| id),
         Factor::Cast(c) => reg.lookup(c.target_type()),
-        Factor::Const(_) | Factor::FnCall(_) | Factor::Builtin(_) => None,
+        Factor::Const(_) | Factor::FnCall(_) | Factor::Builtin(_) | Factor::Group(_) => None,
     }
 }
 
@@ -282,6 +282,7 @@ fn check_factor_casts(
             // Recurse for nested casts: `as(as(x, A), B)`.
             check_factor_casts(c.inner(), reg, bindings)
         }
+        Factor::Group(a) => check_arith_casts(a, reg, bindings),
     }
 }
 
@@ -298,6 +299,9 @@ fn inner_factor_primitive_root(
         Factor::Const(_) => None,
         Factor::FnCall(_) | Factor::Builtin(_) => None,
         Factor::Cast(c) => reg.lookup(c.target_type()).map(|id| reg.root_primitive(id)),
+        // A grouped expression drops subtype identity, like multi-factor
+        // arithmetic; the primitive pass already validated its contents.
+        Factor::Group(_) => None,
     }
 }
 
@@ -362,6 +366,7 @@ fn lower_factor(f: &mut Factor) {
                 lower_arith(a);
             }
         }
+        Factor::Group(a) => lower_arith(a),
         Factor::Cast(_) => unreachable!("cast was peeled above"),
     }
 }

--- a/crates/flowlog-compiler/src/imports.rs
+++ b/crates/flowlog-compiler/src/imports.rs
@@ -17,6 +17,20 @@ pub(crate) fn gen_imports(config: &Config, features: &Features) -> TokenStream {
     let mut out = Vec::<TokenStream>::new();
 
     out.push(quote! {
+        // Mechanically generated dataflow routinely leaves intermediate
+        // collection bindings unused — e.g. a relation declared (with `.input`
+        // or inline facts) yet never referenced by any rule body, or a derived
+        // collection whose only consumer is an output drain through a separate
+        // handle. These are valid Datalog (Soufflé accepts them); relax just the
+        // unused-variable lint on the generated binary while `-Dwarnings` keeps
+        // every other lint class fatal.
+        #![allow(unused_variables)]
+
+        // Relation names may legally begin with `_` (DOOP's `basic._MethodLookup_*`);
+        // joined with their component prefix they synthesize binding idents with
+        // consecutive underscores, which `non_snake_case` rejects.
+        #![allow(non_snake_case)]
+
         mod relation;
         use relation::*;
         use std::collections::HashMap;

--- a/crates/flowlog-compiler/src/scaffold.rs
+++ b/crates/flowlog-compiler/src/scaffold.rs
@@ -117,7 +117,9 @@ pub(crate) fn render_cargo_toml(config: &Config, features: &Features) -> String 
         deps["timely"] = "0.30".into();
         deps["differential-dataflow"] = "0.24".into();
         deps["mimalloc"] = "0.1".into();
-        deps["flowlog-runtime"] = "0.2".into();
+        // 0.2.3 is the minimum carrying the `regex` re-export that generated
+        // `match(...)` code resolves through (`::flowlog_runtime::regex`).
+        deps["flowlog-runtime"] = "0.2.3".into();
 
         if features.string_intern() {
             deps["lasso"] = value(inline_versioned_dep(
@@ -134,6 +136,18 @@ pub(crate) fn render_cargo_toml(config: &Config, features: &Features) -> String 
         if config.is_incremental() {
             deps["rustyline"] = "17".into();
         }
+    }
+
+    // `FLOWLOG_RUNTIME_PATH` redirects the runtime dependency to a local
+    // checkout via `[patch.crates-io]`. The test harness sets it so generated
+    // crates build against the workspace runtime instead of crates.io —
+    // required whenever the workspace runtime has unpublished additions.
+    if let Ok(path) = std::env::var("FLOWLOG_RUNTIME_PATH") {
+        let mut patch = toml_edit::InlineTable::new();
+        patch.insert("path", path.into());
+        doc["patch"] = Item::Table(toml_edit::Table::new());
+        doc["patch"]["crates-io"] = Item::Table(toml_edit::Table::new());
+        doc["patch"]["crates-io"]["flowlog-runtime"] = value(patch);
     }
 
     let mut rendered = doc.to_string();

--- a/crates/flowlog-runtime/Cargo.toml
+++ b/crates/flowlog-runtime/Cargo.toml
@@ -3,7 +3,7 @@ name = "flowlog-runtime"
 # Explicit version (not `version.workspace = true`) because the runtime
 # releases on its own cadence — generated code depends on it by
 # published version, so any additive change ships as an independent bump.
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -18,4 +18,5 @@ timely = "0.30"
 differential-dataflow = "0.24"
 ordered-float = { version = "5", features = ["serde"] }
 lasso = { version = "0.7", features = ["multi-threaded", "serialize"] }
+regex = "1"
 serde = { workspace = true }

--- a/crates/flowlog-runtime/src/lib.rs
+++ b/crates/flowlog-runtime/src/lib.rs
@@ -56,6 +56,8 @@ pub use lasso;
 #[doc(hidden)]
 pub use ordered_float;
 #[doc(hidden)]
+pub use regex;
+#[doc(hidden)]
 pub use serde;
 #[doc(hidden)]
 pub use timely;

--- a/tests/fixtures/datalog-batch/cat_paren_intern/compile_flags
+++ b/tests/fixtures/datalog-batch/cat_paren_intern/compile_flags
@@ -1,0 +1,1 @@
+--str-intern

--- a/tests/fixtures/datalog-batch/cat_paren_intern/data/Src.csv
+++ b/tests/fixtures/datalog-batch/cat_paren_intern/data/Src.csv
@@ -1,0 +1,3 @@
+1,alpha
+2,beta
+3,gamma

--- a/tests/fixtures/datalog-batch/cat_paren_intern/expected/Plain.csv
+++ b/tests/fixtures/datalog-batch/cat_paren_intern/expected/Plain.csv
@@ -1,0 +1,3 @@
+1	v=alpha
+2	v=beta
+3	v=gamma

--- a/tests/fixtures/datalog-batch/cat_paren_intern/expected/Tagged.csv
+++ b/tests/fixtures/datalog-batch/cat_paren_intern/expected/Tagged.csv
@@ -1,0 +1,3 @@
+1	v=alpha
+2	v=beta
+3	v=gamma

--- a/tests/fixtures/datalog-batch/cat_paren_intern/program.dl
+++ b/tests/fixtures/datalog-batch/cat_paren_intern/program.dl
@@ -1,0 +1,21 @@
+// ════════════════════════════════════════════════════════════════════════════
+// Suite   : cat_paren_intern
+// Feature : parenthesised string argument to `cat(...)` under --str-intern
+// Covers  : the grammar's single-factor paren collapse — `(val)` must parse
+//           as the bare factor and resolve like `val` in a display context,
+//           not surface as a raw interned Spur.
+// ════════════════════════════════════════════════════════════════════════════
+
+.decl Src(id: int32, val: string)
+.input Src(IO="file", filename="Src.csv", delimiter=",")
+
+// Parenthesised string argument: `(val)` is a Factor::Group wrapping the
+// string variable. Under --str-intern it must display as the resolved string.
+.decl Tagged(id: int32, out: string)
+Tagged(id, cat("v=", (val))) :- Src(id, val).
+.output Tagged
+
+// Control: the same concatenation without parentheses — must match Tagged.
+.decl Plain(id: int32, out: string)
+Plain(id, cat("v=", val)) :- Src(id, val).
+.output Plain

--- a/tests/fixtures/datalog-batch/match_builtin/compile_flags
+++ b/tests/fixtures/datalog-batch/match_builtin/compile_flags
@@ -1,0 +1,1 @@
+--str-intern

--- a/tests/fixtures/datalog-batch/match_builtin/data/Name.csv
+++ b/tests/fixtures/datalog-batch/match_builtin/data/Name.csv
@@ -1,0 +1,6 @@
+java.lang.String
+java.util.Map
+javax.swing.JPanel
+applet
+sun.misc.Unsafe
+java

--- a/tests/fixtures/datalog-batch/match_builtin/expected/JavaName.csv
+++ b/tests/fixtures/datalog-batch/match_builtin/expected/JavaName.csv
@@ -1,0 +1,4 @@
+java.lang.String
+java.util.Map
+javax.swing.JPanel
+java

--- a/tests/fixtures/datalog-batch/match_builtin/expected/NonJavaName.csv
+++ b/tests/fixtures/datalog-batch/match_builtin/expected/NonJavaName.csv
@@ -1,0 +1,2 @@
+applet
+sun.misc.Unsafe

--- a/tests/fixtures/datalog-batch/match_builtin/program.dl
+++ b/tests/fixtures/datalog-batch/match_builtin/program.dl
@@ -1,0 +1,21 @@
+// ════════════════════════════════════════════════════════════════════════════
+// Suite   : match_builtin
+// Feature : Soufflé `match(pattern, s)` regex builtin under --str-intern
+// Covers  : full-match anchoring (`a.*` must NOT match "java.lang.String" but
+//           must match "applet"), the `::flowlog_runtime::regex` re-export the
+//           generated code resolves through, and the equated boolean form
+//           (`match(...) = True` / `= False`) DOOP's logic uses.
+// ════════════════════════════════════════════════════════════════════════════
+
+.decl Name(s: string)
+.input Name(IO="file", filename="Name.csv", delimiter=",")
+
+// Full match: the whole string must match the pattern (Soufflé semantics).
+.decl JavaName(s: string)
+JavaName(s) :- Name(s), match("java.*", s) = True.
+.output JavaName
+
+// Negated form: names that do NOT match.
+.decl NonJavaName(s: string)
+NonJavaName(s) :- Name(s), match("java.*", s) = False.
+.output NonJavaName

--- a/tests/fixtures/run_compiler.sh
+++ b/tests/fixtures/run_compiler.sh
@@ -29,6 +29,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 readonly COMPILER_BIN="${ROOT_DIR}/target/release/flowlog-compiler"
 readonly BUILD_DIR="${ROOT_DIR}/target/e2e"
 
+# Build generated crates against the workspace runtime instead of crates.io,
+# so unpublished flowlog-runtime additions are testable (scaffold emits a
+# [patch.crates-io] entry when this is set).
+export FLOWLOG_RUNTIME_PATH="${ROOT_DIR}/crates/flowlog-runtime"
+
 usage() {
     cat <<EOF
 Usage:

--- a/tests/oracle/run_compiler.sh
+++ b/tests/oracle/run_compiler.sh
@@ -81,6 +81,11 @@ init_paths() {
     COMPILER_BIN="${ROOT_DIR}/target/release/flowlog-compiler"
 
     mkdir -p "$LOG_DIR" "$FLOWLOG_OUT_DIR"
+
+# Build generated crates against the workspace runtime instead of crates.io,
+# so unpublished flowlog-runtime additions are testable (scaffold emits a
+# [patch.crates-io] entry when this is set).
+export FLOWLOG_RUNTIME_PATH="${ROOT_DIR}/crates/flowlog-runtime"
 }
 
 init_opt_flags() {


### PR DESCRIPTION
## What

A single clean commit that bridges every Datalog/Soufflé surface-syntax gap needed for
DOOP's context-insensitive pointer analysis to compile and run **end-to-end** through
FlowLog as a drop-in Soufflé replacement — while keeping **FlowLog-native head-level
aggregation** (no Soufflé-style body aggregates).

This **consolidates the merits of the stacked PRs #126 → #127 → #128 → #129 into one
branch** and drops the body-aggregate detour. Intended to **supersede** that stack.

## Merits merged (verified present in this branch)

| Source | Merit | Key files |
| --- | --- | --- |
| #126 | Parenthesized arithmetic (`Factor::Group`) | `parser/logic/arithmetic.rs`, `catalog/arithmetic.rs`, `planner/arithmetic.rs`, `codegen/arg.rs`, `typechecker/` |
| #126 | `match(re, s)` regex builtin (anchored, Soufflé semantics) | `parser/logic/builtin.rs`, `codegen/features.rs`, `compiler/scaffold.rs` |
| #126 | `!(Atom)` negation sugar + bare bool builtins | `parser/logic/predicate.rs`, `parser/logic/rule.rs` |
| #127 | Enclosing-scope / ancestor-chain relation resolution | `parser/declaration/comp.rs`, `parser/declaration/directive.rs` |
| #127 | Expression-valued atom args (`R(idx-1, x)`, `ord(h)`, `as(x,T)`) | `parser/desugar.rs`, `parser/inliner.rs`, `codegen/arg.rs`, `catalog/rule.rs` |
| #128 | Declared-but-underived relations → empty EDBs (Soufflé parity) | `parser/program.rs`, `stratifier/core.rs`, `codegen/edb_handles.rs` |
| #129 | Equality-as-assignment binding / grounding | `parser/desugar.rs`, `parser/program.rs` |

## Intentionally dropped

- **Soufflé-style body aggregates** (`r = op [e] : { body }`, `desugar_body_aggregates`,
  `Predicate::BodyAggregate`) introduced in #126. FlowLog uses its native head-position
  aggregates. Confirmed absent on this branch (`grep BodyAggregate` → none).

## Verification

- `cargo test --workspace --release` — **green**. `flowlog-build` runs **200** unit tests
  including `equality_assignment_alias_substituted_into_head`,
  `equality_assignment_const_only_becomes_fact`,
  `equality_assignment_into_negation_with_arith_errors`, and
  `orphan_relation_referenced_by_live_rule_is_materialized_empty`.
- End-to-end: DOOP `context-insensitive` analysis compiles + runs through FlowLog;
  **21/21 output relations match Soufflé 2.5 on `batik`** (single-threaded), including
  `VarPointsTo` (28,249,074), `InstanceFieldPointsTo` (4,124,124),
  `Instruction_Method` (1,724,131).

## Recommendation

Close #126, #127, #128, #129 as superseded once this lands.

Base: `main-next`.
