### PR TITLE
chore: release flowlog-runtime v0.2.3, flowlog-build v0.3.1, flowlog-compiler v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flowlog-build"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "codespan-reporting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Nemo Yu"]
 license = "Apache-2.0"

--- a/crates/flowlog-build/CHANGELOG.md
+++ b/crates/flowlog-build/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.0...flowlog-build-v0.3.1) - 2026-06-07
+
+### Added
+
+- *(engine)* bridge Datalog/Soufflé gaps for DOOP end-to-end compilation ([#130](https://github.com/flowlog-rs/flowlog/pull/130))
+- support multi-head/multi-body rules in .comp bodies
+- several features make doop migration easier
+- support  hint
+
+### Fixed
+
+- *(codegen)* escape relation names that collide with Rust keywords ([#131](https://github.com/flowlog-rs/flowlog/pull/131))
+- comp-internal directive targeting an enclosing/global relation
+- resolve qualified references to sibling/enclosing-scope instances
+- resolve component-local .type aliases as bare attribute types
+- non texture order type inference in .comp
+- cargo clippy
+- *(codegen)* bridge Spur/String at UDF boundary under --str-intern ([#118](https://github.com/flowlog-rs/flowlog/pull/118))
+
 ## [0.3.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.2.3...flowlog-build-v0.3.0) - 2026-05-27
 
 ### Added

--- a/crates/flowlog-build/Cargo.toml
+++ b/crates/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/flowlog-runtime/CHANGELOG.md
+++ b/crates/flowlog-runtime/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.2...flowlog-runtime-v0.2.3) - 2026-06-07
+
+### Added
+
+- *(engine)* bridge Datalog/Soufflé gaps for DOOP end-to-end compilation ([#130](https://github.com/flowlog-rs/flowlog/pull/130))
+
+### Other
+
+- Migrate to differential-dataflow 0.24 / timely 0.30
+
 ## [0.2.2](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.1...flowlog-runtime-v0.2.2) - 2026-05-10
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `flowlog-runtime`: 0.2.2 -> 0.2.3
* `flowlog-build`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-runtime`

<blockquote>

## [0.2.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.2...flowlog-runtime-v0.2.3) - 2026-06-07

### Added

- *(engine)* bridge Datalog/Soufflé gaps for DOOP end-to-end compilation ([#130](https://github.com/flowlog-rs/flowlog/pull/130))

### Other

- Migrate to differential-dataflow 0.24 / timely 0.30
</blockquote>

## `flowlog-build`

<blockquote>

## [0.3.1](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.0...flowlog-build-v0.3.1) - 2026-06-07

### Added

- *(engine)* bridge Datalog/Soufflé gaps for DOOP end-to-end compilation ([#130](https://github.com/flowlog-rs/flowlog/pull/130))
- support multi-head/multi-body rules in .comp bodies
- several features make doop migration easier
- support  hint

### Fixed

- *(codegen)* escape relation names that collide with Rust keywords ([#131](https://github.com/flowlog-rs/flowlog/pull/131))
- comp-internal directive targeting an enclosing/global relation
- resolve qualified references to sibling/enclosing-scope instances
- resolve component-local .type aliases as bare attribute types
- non texture order type inference in .comp
- cargo clippy
- *(codegen)* bridge Spur/String at UDF boundary under --str-intern ([#118](https://github.com/flowlog-rs/flowlog/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).