### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-compiler"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-runtime"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "differential-dataflow",
  "lasso",

--- a/crates/flowlog-runtime/CHANGELOG.md
+++ b/crates/flowlog-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.3...flowlog-runtime-v0.2.4) - 2026-06-07
+
+### Other
+
+- release flowlog-runtime v0.2.3, flowlog-build v0.3.1, flowlog-compiler v0.4.1 ([#133](https://github.com/flowlog-rs/flowlog/pull/133))
+
 ## [0.2.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.2...flowlog-runtime-v0.2.3) - 2026-06-07
 
 ### Added

--- a/crates/flowlog-runtime/Cargo.toml
+++ b/crates/flowlog-runtime/Cargo.toml
@@ -3,7 +3,7 @@ name = "flowlog-runtime"
 # Explicit version (not `version.workspace = true`) because the runtime
 # releases on its own cadence — generated code depends on it by
 # published version, so any additive change ships as an independent bump.
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `flowlog-runtime`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `flowlog-build`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-runtime`

<blockquote>

## [0.2.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.3...flowlog-runtime-v0.2.4) - 2026-06-07

### Other

- release flowlog-runtime v0.2.3, flowlog-build v0.3.1, flowlog-compiler v0.4.1 ([#133](https://github.com/flowlog-rs/flowlog/pull/133))
</blockquote>

## `flowlog-build`

<blockquote>

## [0.3.1](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.0...flowlog-build-v0.3.1) - 2026-06-07

### Added

- *(engine)* bridge Datalog/Soufflé gaps for DOOP end-to-end compilation ([#130](https://github.com/flowlog-rs/flowlog/pull/130))
- support multi-head/multi-body rules in .comp bodies
- several features make doop migration easier
- support  hint

### Fixed

- *(codegen)* escape relation names that collide with Rust keywords ([#131](https://github.com/flowlog-rs/flowlog/pull/131))
- comp-internal directive targeting an enclosing/global relation
- resolve qualified references to sibling/enclosing-scope instances
- resolve component-local .type aliases as bare attribute types
- non texture order type inference in .comp
- cargo clippy
- *(codegen)* bridge Spur/String at UDF boundary under --str-intern ([#118](https://github.com/flowlog-rs/flowlog/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).