### PR TITLE
perf: FlowLog string-handling optimizations (output resolve + direct writes + FxHash interner)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "lasso",
  "ordered-float",
  "regex",
+ "rustc-hash",
  "serde",
  "timely",
 ]
@@ -742,6 +743,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"

--- a/crates/flowlog-build/src/build/imports.rs
+++ b/crates/flowlog-build/src/build/imports.rs
@@ -146,5 +146,9 @@ fn string_intern_imports(f: &Features) -> TokenStream {
         .string_resolve()
         .then(|| quote! { use ::flowlog_runtime::intern::resolve; });
 
-    quote! { #base #resolve }
+    let resolve_out = f
+        .string_resolve_out()
+        .then(|| quote! { use ::flowlog_runtime::intern::resolve_out; });
+
+    quote! { #base #resolve #resolve_out }
 }

--- a/crates/flowlog-build/src/build/relation/user.rs
+++ b/crates/flowlog-build/src/build/relation/user.rs
@@ -65,7 +65,8 @@ pub(crate) fn user_to_tuple_expr(
 }
 
 /// Inverse of `user_to_tuple_expr`: internal slot → user-facing expression,
-/// used at drain time.
+/// used at drain time. Interned strings resolve through the flat snapshot
+/// path (`resolve_out`) since drain runs after the dataflow's fixpoint.
 pub(crate) fn tuple_to_user_expr(
     dt: &DataType,
     string_intern: bool,
@@ -73,7 +74,7 @@ pub(crate) fn tuple_to_user_expr(
 ) -> TokenStream {
     match *dt {
         DataType::Float32 | DataType::Float64 => quote! { (#src).into_inner() },
-        DataType::String if string_intern => quote! { resolve(#src).to_string() },
+        DataType::String if string_intern => quote! { resolve_out(#src).to_string() },
         _ => src,
     }
 }

--- a/crates/flowlog-build/src/codegen/features.rs
+++ b/crates/flowlog-build/src/codegen/features.rs
@@ -93,6 +93,7 @@ pub struct Features {
     // -- library support --
     string_intern: bool,
     string_resolve: bool,
+    string_resolve_out: bool,
     ordered_float: bool,
     udf: bool,
     output_buffers: bool,
@@ -117,6 +118,7 @@ impl Features {
         (aggregation,    mark_aggregation),
         (string_intern,  mark_string_intern),
         (string_resolve, mark_string_resolve),
+        (string_resolve_out, mark_string_resolve_out),
         (ordered_float,  mark_ordered_float),
         (udf,            mark_udf),
         (output_buffers, mark_output_buffers),

--- a/crates/flowlog-build/src/codegen/idb_buffers.rs
+++ b/crates/flowlog-build/src/codegen/idb_buffers.rs
@@ -74,7 +74,7 @@ impl CodeGen {
 
             if idb.output() {
                 if data_type.contains(&DataType::String) {
-                    self.features.mark_string_resolve();
+                    self.features.mark_string_resolve_out();
                 }
 
                 self.features.mark_output_buffers();
@@ -344,7 +344,11 @@ pub fn gen_drain_block(
 
 /// Access column `col_idx` of a buffer row. `base` must evaluate to the
 /// `(tuple, Ts, i32)` triple — produces `<base>.0.<col_idx>` and wraps with
-/// `resolve()` for interned-string columns.
+/// `resolve_out()` for interned-string columns.
+///
+/// Output runs after fixpoint, so interned strings resolve through the flat
+/// snapshot path (`resolve_out`) rather than the concurrent `DashMap`
+/// (`resolve`) used while the dataflow is still interning.
 pub fn field_accessor(
     col_idx: usize,
     data_type: &DataType,
@@ -354,7 +358,7 @@ pub fn field_accessor(
     let idx = Index::from(col_idx);
     let inner = quote! { #base.0.#idx };
     if matches!(data_type, DataType::String) && string_intern {
-        quote! { resolve(#inner) }
+        quote! { resolve_out(#inner) }
     } else {
         inner
     }

--- a/crates/flowlog-compiler/src/imports.rs
+++ b/crates/flowlog-compiler/src/imports.rs
@@ -289,9 +289,14 @@ fn string_intern_imports(f: &Features) -> TokenStream {
     let max_retries = INTERN_MAX_RETRIES;
     let base = quote! {
         use lasso::{ThreadedRodeo, Spur};
+        use rustc_hash::FxBuildHasher;
         use std::sync::LazyLock;
 
-        static INTERNER: LazyLock<ThreadedRodeo> = LazyLock::new(ThreadedRodeo::default);
+        // FxBuildHasher (not lasso's default SipHash): interner keys are
+        // program-controlled, so the per-byte cost of a HashDoS-resistant
+        // hash is pure overhead on every intern/resolve.
+        static INTERNER: LazyLock<ThreadedRodeo<Spur, FxBuildHasher>> =
+            LazyLock::new(|| ThreadedRodeo::with_hasher(FxBuildHasher));
 
         #[inline(always)]
         fn intern(s: &str) -> Spur {

--- a/crates/flowlog-compiler/src/imports.rs
+++ b/crates/flowlog-compiler/src/imports.rs
@@ -319,5 +319,36 @@ fn string_intern_imports(f: &Features) -> TokenStream {
         quote! {}
     };
 
-    quote! { #base #resolve }
+    // Output runs after the dataflow reaches fixpoint, so interned strings
+    // can be resolved through a flat `Spur`-indexed snapshot instead of the
+    // concurrent `DashMap` path (`resolve`), which hashes the key and takes
+    // a read lock on every call. The snapshot is built lazily on first use;
+    // keys interned after it is frozen fall back to `resolve`.
+    let resolve_out = if f.string_resolve_out() {
+        quote! {
+            use lasso::Key as _;
+
+            static RESOLVED: std::sync::OnceLock<Box<[&'static str]>> =
+                std::sync::OnceLock::new();
+
+            #[inline]
+            fn resolve_out(key: Spur) -> &'static str {
+                let table = RESOLVED.get_or_init(|| {
+                    let mut table: Vec<&'static str> = vec![""; INTERNER.len()];
+                    for (k, s) in INTERNER.iter() {
+                        table[k.into_usize()] = s;
+                    }
+                    table.into_boxed_slice()
+                });
+                match table.get(key.into_usize()) {
+                    Some(&s) => s,
+                    None => INTERNER.resolve(&key),
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    quote! { #base #resolve #resolve_out }
 }

--- a/crates/flowlog-compiler/src/io/output.rs
+++ b/crates/flowlog-compiler/src/io/output.rs
@@ -12,10 +12,16 @@
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
 
-use flowlog_build::parser::Relation;
+use flowlog_build::parser::{DataType, Relation};
 use flowlog_build::{field_accessor, gen_drain_block};
 
 use crate::{Compiler, CompilerError};
+
+/// Capacity of the per-IDB output `BufWriter`. Large enough to amortize
+/// write syscalls across the millions of small rows DOOP-scale outputs
+/// produce; only one writer is live at a time (drains run sequentially on
+/// worker 0), so the buffer is cheap.
+const OUTPUT_BUFFER_BYTES: usize = 1 << 20;
 
 impl Compiler {
     /// Per-IDB merge blocks spliced into `main()` after the barrier
@@ -145,7 +151,8 @@ fn gen_file_preamble(file_name: &str, base_dir: &str, is_incremental: bool) -> T
     quote! {
         use std::io::Write as _;
         #out_path
-        let mut out = std::io::BufWriter::new(
+        let mut out = std::io::BufWriter::with_capacity(
+            #OUTPUT_BUFFER_BYTES,
             std::fs::File::create(&out_path)
                 .unwrap_or_else(|e| panic!("failed to create {}: {}", out_path, e)),
         );
@@ -170,7 +177,12 @@ fn gen_stderr_preamble() -> TokenStream {
 }
 
 // =========================================================================
-// Row formatters — emit the `writeln!(out, ...)` that runs per row.
+// Row formatters — emit the per-row writes against the sink.
+//
+// File rows write column bytes directly (`write_all`) rather than through
+// `writeln!`/`core::fmt`: string columns are the bulk of DOOP-scale output
+// and their UTF-8 bytes need no formatting, so we skip the per-row format
+// machinery entirely. Numeric/bool columns still format through `write!`.
 // =========================================================================
 
 fn gen_write_row_file(idb: &Relation, string_intern: bool, is_incremental: bool) -> TokenStream {
@@ -178,26 +190,39 @@ fn gen_write_row_file(idb: &Relation, string_intern: bool, is_incremental: bool)
     if idb.arity() == 0 {
         return quote! {
             let _ = &row;
-            writeln!(out, "True").expect("write failed");
+            out.write_all(b"True\n").expect("write failed");
         };
     }
 
-    let fields = data_field_accessors(idb, string_intern);
     let delim = idb.output_delimiter();
+    let delim_lit = Literal::byte_string(delim.as_bytes());
+
+    let mut stmts: Vec<TokenStream> = Vec::new();
+    for (i, dt) in idb.data_type().iter().enumerate() {
+        if i > 0 {
+            stmts.push(quote! { out.write_all(#delim_lit).expect("write failed"); });
+        }
+        let accessor = field_accessor(i, dt, quote! { row }, string_intern);
+        stmts.push(col_write_stmt(dt, accessor));
+    }
 
     if is_incremental {
         // Incremental lines carry the diff as a signed suffix column.
-        let mut parts = vec!["{}"; idb.arity()];
-        parts.push("{:+}");
-        let fmt = Literal::string(&parts.join(delim.as_str()));
-        quote! {
-            writeln!(out, #fmt #(, #fields )*, row.2).expect("write failed");
-        }
+        stmts.push(quote! { out.write_all(#delim_lit).expect("write failed"); });
+        stmts.push(quote! { write!(out, "{:+}", row.2).expect("write failed"); });
+    }
+
+    stmts.push(quote! { out.write_all(b"\n").expect("write failed"); });
+    quote! { #(#stmts)* }
+}
+
+/// One column's byte write. String columns emit their UTF-8 bytes directly;
+/// other scalar types format through `write!`.
+fn col_write_stmt(dt: &DataType, accessor: TokenStream) -> TokenStream {
+    if matches!(dt, DataType::String) {
+        quote! { out.write_all(#accessor.as_bytes()).expect("write failed"); }
     } else {
-        let fmt = Literal::string(&vec!["{}"; idb.arity()].join(delim.as_str()));
-        quote! {
-            writeln!(out, #fmt #(, #fields )*).expect("write failed");
-        }
+        quote! { write!(out, "{}", #accessor).expect("write failed"); }
     }
 }
 

--- a/crates/flowlog-compiler/src/scaffold.rs
+++ b/crates/flowlog-compiler/src/scaffold.rs
@@ -126,6 +126,9 @@ pub(crate) fn render_cargo_toml(config: &Config, features: &Features) -> String 
                 "0.7",
                 &["multi-threaded", "serialize"],
             ));
+            // Fast, non-cryptographic hasher for the interner (keys are
+            // program-controlled, so SipHash's HashDoS resistance is wasted).
+            deps["rustc-hash"] = "2".into();
         }
         if features.ordered_float() {
             deps["ordered-float"] = value(inline_versioned_dep("5", &["serde"]));

--- a/crates/flowlog-runtime/Cargo.toml
+++ b/crates/flowlog-runtime/Cargo.toml
@@ -19,4 +19,5 @@ differential-dataflow = "0.24"
 ordered-float = { version = "5", features = ["serde"] }
 lasso = { version = "0.7", features = ["multi-threaded", "serialize"] }
 regex = "1"
+rustc-hash = "2"
 serde = { workspace = true }

--- a/crates/flowlog-runtime/src/intern.rs
+++ b/crates/flowlog-runtime/src/intern.rs
@@ -1,16 +1,24 @@
 //! Thread-safe string interning via `lasso::ThreadedRodeo`.
 
 use lasso::{Key, Spur, ThreadedRodeo};
+use rustc_hash::FxBuildHasher;
 use std::sync::{LazyLock, OnceLock};
 
 /// Global string interner shared across all FlowLog engines in the process.
+///
+/// Uses `FxBuildHasher` rather than lasso's default `RandomState` (SipHash):
+/// interner keys are program-controlled (`.dl` literals + input facts), not
+/// adversarial, so the HashDoS resistance of SipHash buys nothing while its
+/// per-byte cost shows up on every `intern` of a (potentially long) string
+/// and every `DashMap` `resolve`.
 ///
 /// **Limitation**: this is a process-local pool. In a distributed DD
 /// deployment (multiple machines), each process gets its own independent
 /// `INTERNER`, so `Spur` values are NOT comparable across machines.
 /// Distributed support would require a global interning protocol or
 /// switching back to `String`-keyed collections.
-pub static INTERNER: LazyLock<ThreadedRodeo> = LazyLock::new(ThreadedRodeo::default);
+pub static INTERNER: LazyLock<ThreadedRodeo<Spur, FxBuildHasher>> =
+    LazyLock::new(|| ThreadedRodeo::with_hasher(FxBuildHasher));
 
 const MAX_RETRIES: usize = 1024;
 

--- a/crates/flowlog-runtime/src/intern.rs
+++ b/crates/flowlog-runtime/src/intern.rs
@@ -1,7 +1,7 @@
 //! Thread-safe string interning via `lasso::ThreadedRodeo`.
 
-use lasso::{Spur, ThreadedRodeo};
-use std::sync::LazyLock;
+use lasso::{Key, Spur, ThreadedRodeo};
+use std::sync::{LazyLock, OnceLock};
 
 /// Global string interner shared across all FlowLog engines in the process.
 ///
@@ -30,4 +30,40 @@ pub fn intern(s: &str) -> Spur {
 #[inline(always)]
 pub fn resolve(key: Spur) -> &'static str {
     INTERNER.resolve(&key)
+}
+
+/// Flat snapshot of the interner (`Spur::into_usize()` → string) used for
+/// O(1) resolution at output/drain time. `Spur` keys are dense in
+/// `[0, len)`, so a plain `Vec` index replaces the concurrent
+/// [`ThreadedRodeo::resolve`] path (which hashes the key and takes a
+/// `DashMap` read lock on every call).
+static RESOLVED: OnceLock<Box<[&'static str]>> = OnceLock::new();
+
+/// Build the flat snapshot from the current interner contents.
+///
+/// `INTERNER` is borrowed from a `static`, so its strings are genuinely
+/// `'static`; the dense `Spur` keying lets us address them by index.
+fn build_snapshot() -> Box<[&'static str]> {
+    let mut table: Vec<&'static str> = vec![""; INTERNER.len()];
+    for (key, string) in INTERNER.iter() {
+        table[key.into_usize()] = string;
+    }
+    table.into_boxed_slice()
+}
+
+/// Resolve a [`Spur`] at output time via a flat index instead of the
+/// concurrent `DashMap` path taken by [`resolve`].
+///
+/// The snapshot is built lazily on first use. Output runs after the
+/// dataflow reaches fixpoint (no concurrent interning), so the snapshot is
+/// complete in batch mode. Keys interned after the snapshot was frozen
+/// (e.g. later epochs in incremental mode) fall outside its range and fall
+/// back to [`resolve`], keeping resolution correct without a rebuild.
+#[inline]
+pub fn resolve_out(key: Spur) -> &'static str {
+    let table = RESOLVED.get_or_init(build_snapshot);
+    match table.get(key.into_usize()) {
+        Some(&string) => string,
+        None => resolve(key),
+    }
 }


### PR DESCRIPTION
A holistic pass over FlowLog's string handling under `--str-intern`. Three changes, each correctness-neutral (output is byte-for-byte identical):

---

## 1. Interned-string `.output` — flat resolver (the big win)

Users reported Soufflé string `.output` is much faster than FlowLog, while `.printsize` is fast. The two differ only at the **sink**, so the gap is entirely drain-time.

**Root cause:** with `--str-intern`, string columns are `lasso::Spur`, and the drain resolved **every cell** through `ThreadedRodeo::resolve` — a `DashMap` lookup that **hashes the key (SipHash) and takes an `RwLock` read guard per call**. `.printsize` never resolves.

Micro-benchmark (56M resolves): `ThreadedRodeo::resolve` **11.7 M/s** vs flat `Vec<&str>` index **828 M/s** (**70×**).

**Fix:** `Spur` keys are dense in `[0,len)`, so resolve at drain time through a flat `Vec<&'static str>` snapshot (`resolve_out`) indexed by key — O(1), no hash, no lock. Built lazily after fixpoint (complete in batch mode; incremental epochs' newer keys bounds-check-fall-back to live `resolve`). Mid-dataflow `resolve` (joins/UDFs) is untouched. Gated by a `string_resolve_out` feature so `.printsize`-only programs pay nothing.

## 2. Direct row writes

File rows write string columns' UTF-8 bytes via `write_all` (skipping `core::fmt`/`writeln!`); numeric/bool columns still format through `write!`. Output `BufWriter` enlarged to 1 MiB to amortize syscalls.

## 3. FxHash interner (free micro-opt)

`ThreadedRodeo` defaulted to `RandomState` (SipHash); the interner's keys are program-controlled, so HashDoS resistance is wasted while per-byte cost is paid on every `intern`/`resolve`. Switched to `rustc_hash::FxBuildHasher`. Isolated interning (real batik strings): **3.6 → 5.6 M/s (~1.5×)**. End-to-end DOOP is ~flat (interning is parallelized and dwarfed by the join analysis), but it's free and helps load-bound workloads + the mid-dataflow resolve path.

---

## Results — DOOP, `--str-intern`, 32 workers (output is byte-identical)

| run | baseline | optimized | speedup |
|---|---|---|---|
| batik output phase (51.9M rows, 8.6 GB → tmpfs) | 11.0s | **5.1s** | **2.15×** |
| batik total → tmpfs | 20.0s | **14.2s** | 1.41× |
| batik total → disk | 33.2s | **17.2s** | **1.93×** |
| luindex output phase (9.6M rows) | ~2.0s | **~1.0s** | ~2.1× |

## Validation

- Output byte-identical (26 luindex files / 9.6M rows diff-clean; batik 51,877,104 rows; DOOP printsize counts identical SipHash vs FxHash).
- `cargo test` (215) ✓ · `clippy --all-targets -- -D warnings` ✓
- End-to-end fixtures: **109/109 compiler-path + 109/109 lib-path** (batch + incremental) ✓

## Not included (deliberately)

- **Parallelizing the drain** across worker cores is the largest remaining win, but a naive version materializes formatted bytes (RSS blowup by the full output size, ~8.6 GB for batik); a memory-frugal streaming-pipeline version is a substantial standalone change. Worth a follow-up.
- Reworking the interner for lower memory (dropping the `Spur→&str` map) needs a different interner — bigger than low-hanging fruit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>