### PR TITLE
perf(batch): park instead of busy-spin when draining to fixpoint

### DIFF
--- a/flowlog-build/src/codegen/profile.rs
+++ b/flowlog-build/src/codegen/profile.rs
@@ -280,11 +280,39 @@ impl CodeGen {
     /// Emits the batch run loop (`worker` and `index` in scope): steps the
     /// dataflow to fixpoint, periodically flushing metrics when profiled.
     pub(crate) fn gen_batch_step_loop(&self) -> TokenStream {
-        self.gen_flush_loop(
-            quote! { worker.step() },
-            quote! {},
-            self.gen_metrics_write_batch(),
-        )
+        let step = quote! {{
+            let more = if __flowlog_idle_steps < __FLOWLOG_SPIN_BEFORE_PARK {
+                worker.step()
+            } else {
+                worker.step_or_park(Some(__FLOWLOG_PARK_TIMEOUT))
+            };
+            if more {
+                if __flowlog_activations.borrow().empty_for()
+                    == Some(std::time::Duration::ZERO)
+                {
+                    __flowlog_idle_steps = 0;
+                } else if __flowlog_idle_steps < __FLOWLOG_SPIN_BEFORE_PARK {
+                    __flowlog_idle_steps += 1;
+                }
+            }
+            more
+        }};
+        let step_loop = self.gen_flush_loop(step, quote! {}, self.gen_metrics_write_batch());
+
+        quote! {
+            {
+                // Spin briefly after scheduled work to avoid a park/wake round
+                // trip at progress barriers. Once idle, park with a bounded
+                // timeout so workers stop consuming a core while profiling can
+                // still flush on schedule.
+                const __FLOWLOG_SPIN_BEFORE_PARK: u64 = 4096;
+                const __FLOWLOG_PARK_TIMEOUT: std::time::Duration =
+                    std::time::Duration::from_millis(1);
+                let __flowlog_activations = worker.activations();
+                let mut __flowlog_idle_steps = 0u64;
+                #step_loop
+            }
+        }
     }
 
     /// Emits the incremental commit step loop (`worker`, `probe`,


### PR DESCRIPTION
## TL;DR

Batch programs currently drain their Timely dataflow with `worker.step()`.
Workers with no pending scheduler activity busy-spin while waiting at progress
barriers, consuming a core without advancing the computation.

This PR uses an adaptive batch-only drain:

- After scheduler activity, keep using `worker.step()` for up to 4096
  consecutive idle steps. This avoids park/wake latency on active and
  short-fixpoint runs.
- Once the worker has stayed idle for that window, use
  `worker.step_or_park(Some(1ms))`.
- New scheduler activity resets the spin window.

Incremental mode is unchanged.

## Current implementation

The policy now lives in the shared batch step-loop generator, so both the
compiler and `flowlog-build` library paths use it. It also preserves periodic
profile-metric flushes added on `main-next`.

The activation handle is captured once outside the loop. The active path still
has a predictable threshold branch and an `empty_for()` check, but it no longer
clones the activation `Rc` on every scheduler step.

## Performance

### Large recursive workloads

Adaptive spin-then-park retains the large CPU reduction that motivated the PR:

| program / dataset / workers | baseline wall / CPU | adaptive wall / CPU |
|---|---:|---:|
| ctx / xalan / w16 | 36.5 s / 581 s | 36.4 s / 200 s |
| ctx / xalan / w32 | 38.2 s / 1210 s | 37.0 s / 389 s |
| ctx / h2o / w32 | 388 s / 12367 s | 377.6 s / 2206 s |

That is 66-82% less total CPU with flat or better wall time in the target
workloads.

### Shorter DOOP matrix

Across the reported 33 cells (11 DaCapo suites at w8/w16/w32):

- Mean CPU: -10.4%.
- Mean wall: +1.7%.
- Repeated measurements of the noisy larger w32 cases showed a residual
  3-5% wall increase, paired with roughly 14-20% lower CPU.

This is a CPU/energy versus latency tradeoff, not an unconditional wall-time
win.

### Deep, narrow recursion

After rebasing onto current `main-next`, I also measured a deliberately narrow
recursion:

```souffle
.decl Reach(x: int32)
Reach(0).
Reach(x + 1) :- Reach(x), x < 500000.
.printsize Reach
```

At w1 over 15 paired warm runs:

- Baseline median: 312.866 ms.
- Adaptive median: 314.283 ms (+0.45%).
- The means differed by -0.25%, so the effect is within run-to-run noise.

At w8, paired warm runs were also flat (adaptive medians were about 0.8-0.9%
lower for both wall and CPU). Instrumentation observed roughly 25 million
scheduler calls per worker but only 24-42 park calls. Progress traffic therefore
keeps this workload on the spin path: the adaptive branch does not materially
hurt latency, but it also does not reclaim much CPU in this particular shape.

## Correctness and validation

Changing the worker scheduling policy does not change the Datalog fixpoint.
The original branch passed the compiler-mode Souffle oracle suite and produced
identical relation results in the benchmark matrix.

The rebased commit additionally passes:

- `cargo +nightly fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- Compiler fixtures: `recursive_tc`, `recursive_intermediate`
- Library fixtures: `recursive_tc`, `recursive_intermediate`
- A profiled generated run with a 1 ms metrics-flush interval

The commit is signed off and the incremental drain remains unchanged.
