### PR TITLE
perf: share content-identical arrangements across rules (codegen CSE)

### DIFF
--- a/crates/flowlog-build/src/codegen/flow/non_recursive.rs
+++ b/crates/flowlog-build/src/codegen/flow/non_recursive.rs
@@ -40,18 +40,21 @@ impl CodeGen {
         let mut flows = Vec::new();
         let global_fp_to_ident = self.global_fp_to_ident.clone();
         let mut outer_arranged = mem::take(&mut self.outer_arranged);
+        let mut outer_sem_arranged = mem::take(&mut self.outer_sem_arranged);
 
         for transformation in stratum.non_recursive_transformations() {
             flows.push(self.gen_transformation(
                 &global_fp_to_ident,
                 transformation,
                 &mut outer_arranged,
+                &mut outer_sem_arranged,
                 stratum,
                 profiler,
             )?);
         }
 
         self.outer_arranged = outer_arranged;
+        self.outer_sem_arranged = outer_sem_arranged;
 
         trace!("Generated static flows:\n{}\n", quote! { #(#flows)* });
         Ok(flows)

--- a/crates/flowlog-build/src/codegen/flow/recursive.rs
+++ b/crates/flowlog-build/src/codegen/flow/recursive.rs
@@ -113,11 +113,22 @@ impl CodeGen {
         current.extend(recursive_bindings.clone());
 
         // --- Rule transformations -------------------------------------------
+        // Per-block semantic arrangement cache: idents created here live inside
+        // this `iterative(|inner| …)` closure, so sharing must be scoped to the
+        // block (a fresh map per recursive scope, never shared across blocks).
+        let mut recursive_sem_arranged: HashMap<u64, (Ident, Ident)> = HashMap::new();
         let flow_stmts: Vec<TokenStream> = stratum
             .recursive_transformations()
             .iter()
             .map(|tx| {
-                self.gen_transformation(&current, tx, &mut recursive_arranged, stratum, profiler)
+                self.gen_transformation(
+                    &current,
+                    tx,
+                    &mut recursive_arranged,
+                    &mut recursive_sem_arranged,
+                    stratum,
+                    profiler,
+                )
             })
             .collect::<Result<_, _>>()?;
 

--- a/crates/flowlog-build/src/codegen/flow/transformation.rs
+++ b/crates/flowlog-build/src/codegen/flow/transformation.rs
@@ -17,8 +17,47 @@ use crate::codegen::arg::{
 };
 use crate::codegen::ident::find_local_ident;
 use crate::codegen::{CodeGen, CodegenError, data_type_tokens};
+use crate::common::compute_fp;
 use crate::planner::{StratumPlanner, Transformation};
 use crate::profiler::{Profiler, with_profiler};
+
+/// Canonical content key for arrangement sharing.
+///
+/// Returns a fingerprint of the exact generated `build` tokens — with the
+/// output ident neutralized — plus whether the arrangement is key-only. Two
+/// transformations collide on this key iff they emit byte-identical code, which
+/// is exactly when their collections (and the arranged traces built from them)
+/// are identical, so sharing on a collision is always sound.
+///
+/// Why hash the *rendered code* rather than `(input_fp, flow, is_k_only)`:
+/// codegen is the canonical normal form of a `TransformationFlow`. Two flows
+/// that differ only in codegen-irrelevant ways (e.g. the order of `compares` /
+/// `fn_call_preds` `Vec`s) render to the same code but hash differently, so a
+/// key over `flow` *over-splits* and misses content-identical arrangements
+/// reached via different rule paths. Hashing the code collapses exactly those.
+///
+/// Type safety: input idents derive from input fingerprints, each naming one
+/// typed collection, so identical code implies identical input types — there is
+/// no risk of merging e.g. a `Spur`-keyed arrangement with an `i32`-keyed one.
+///
+/// Normalization contract: `out` is the only output-fingerprint-derived ident
+/// appearing in `build` (it is the let-binding target, and the only such ident
+/// on any RHS — including the dedup re-binding `let out = out …`). It is
+/// replaced by a placeholder via exact token match: `proc_macro2`'s
+/// `to_string()` space-separates tokens, so matching whole tokens (never
+/// substrings) avoids corrupting idents that share a digit prefix. If codegen
+/// ever embeds another output-derived ident in `build`, extend this to
+/// neutralize it too, or content-identical arrangements will silently un-share.
+fn arrangement_share_key(out: &Ident, only_key: bool, build: &TokenStream) -> u64 {
+    let out_str = out.to_string();
+    let normalized = build
+        .to_string()
+        .split_whitespace()
+        .map(|tok| if tok == out_str { "OUT" } else { tok })
+        .collect::<Vec<_>>()
+        .join(" ");
+    compute_fp((normalized, only_key))
+}
 
 impl CodeGen {
     /// Generate differential dataflow pipelines for a single transformation.
@@ -31,6 +70,7 @@ impl CodeGen {
         local_fp_to_ident: &HashMap<u64, Ident>,
         transformation: &Transformation,
         arranged_map: &mut HashMap<u64, Ident>,
+        sem_cache: &mut HashMap<u64, (Ident, Ident)>,
         stratum: &StratumPlanner,
         profiler: &mut Option<Profiler>,
     ) -> Result<TokenStream, CodegenError> {
@@ -213,18 +253,16 @@ impl CodeGen {
                         .flat_map(|#row_pat: #row_ty| { #flat_map_body });
                 };
 
-                // Arrangement registration
-                let arrange_stmt = self.register_arrangement(
+                // Share the arrangement when an identical-content one already
+                // exists in scope; otherwise emit the projection + arrange.
+                Ok(self.emit_shared_arrangement(
                     arranged_map,
+                    sem_cache,
                     output.fingerprint(),
                     &out,
                     output.is_k_only(),
-                );
-
-                Ok(quote! {
-                    #transformation
-                    #arrange_stmt
-                })
+                    transformation,
+                ))
             }
 
             // KV -> Row
@@ -361,18 +399,14 @@ impl CodeGen {
                     #out_dedup_expr
                 };
 
-                // Arrangement registration
-                let arrange_stmt = self.register_arrangement(
+                Ok(self.emit_shared_arrangement(
                     arranged_map,
+                    sem_cache,
                     output.fingerprint(),
                     &out,
                     output.is_k_only(),
-                );
-
-                Ok(quote! {
-                    #transformation
-                    #arrange_stmt
-                })
+                    transformation,
+                ))
             }
 
             // Join: Key-value ⋈ Key-value -> Row
@@ -501,17 +535,14 @@ impl CodeGen {
                         .join_core(#r.clone(), |#jn_k, #jn_lv, #jn_rv| { #join_body });
                 };
 
-                let arrange_stmt = self.register_arrangement(
+                Ok(self.emit_shared_arrangement(
                     arranged_map,
+                    sem_cache,
                     output.fingerprint(),
                     &out,
                     output.is_k_only(),
-                );
-
-                Ok(quote! {
-                    #transformation
-                    #arrange_stmt
-                })
+                    transformation,
+                ))
             }
 
             // Antijoin: Key-value ¬ Key-only to Row
@@ -657,17 +688,14 @@ impl CodeGen {
                             #final_normalize;
                 };
 
-                let arrange_stmt = self.register_arrangement(
+                Ok(self.emit_shared_arrangement(
                     arranged_map,
+                    sem_cache,
                     output.fingerprint(),
                     &out,
                     output.is_k_only(),
-                );
-
-                Ok(quote! {
-                    #transformation
-                    #arrange_stmt
-                })
+                    transformation,
+                ))
             }
         }
     }
@@ -712,21 +740,48 @@ impl CodeGen {
         (pos, neg)
     }
 
-    fn register_arrangement(
+    /// Emit a projected/joined collection together with its arrangement,
+    /// sharing the sorted trace whenever a content-identical arrangement already
+    /// exists in this scope.
+    ///
+    /// The share key is a fingerprint of the *exact generated build tokens*
+    /// (with the output ident neutralized) plus whether the arrangement is
+    /// key-only — see [`arrangement_share_key`]. Two transformations share iff
+    /// they emit byte-identical code, which is precisely the condition under
+    /// which their collections (and arranged traces) are identical. This is
+    /// tighter than the planner's lineage fingerprint *and* than an
+    /// input+flow fingerprint (both over-split content-identical arrangements
+    /// reached via different rule paths). On a hit the duplicate projection is
+    /// **not** recomputed: `out` is aliased to the canonical collection (a cheap
+    /// dataflow-handle clone) and its fingerprint is pointed at the shared trace
+    /// (join sites `.clone()` the refcounted arrangement handle). On a miss the
+    /// `build` tokens are emitted, the collection is arranged, and both idents
+    /// are recorded as the canonical for this key.
+    fn emit_shared_arrangement(
         &mut self,
         arranged_map: &mut HashMap<u64, Ident>,
+        sem_cache: &mut HashMap<u64, (Ident, Ident)>,
         fingerprint: u64,
-        collection_ident: &Ident,
+        out: &Ident,
         only_key: bool,
+        build: TokenStream,
     ) -> TokenStream {
-        let arrangement_ident = format_ident!("{}_arr", collection_ident);
-        arranged_map.insert(fingerprint, arrangement_ident.clone());
-
-        if only_key {
-            quote! { let #arrangement_ident = #collection_ident.clone().arrange_by_self(); }
-        } else {
-            quote! { let #arrangement_ident = #collection_ident.clone().arrange_by_key(); }
+        let share_key = arrangement_share_key(out, only_key, &build);
+        if let Some((canon_coll, canon_arr)) = sem_cache.get(&share_key).cloned() {
+            arranged_map.insert(fingerprint, canon_arr);
+            return quote! { let #out = #canon_coll.clone(); };
         }
+
+        let arr_ident = format_ident!("{}_arr", out);
+        arranged_map.insert(fingerprint, arr_ident.clone());
+        sem_cache.insert(share_key, (out.clone(), arr_ident.clone()));
+
+        let arrange = if only_key {
+            quote! { let #arr_ident = #out.clone().arrange_by_self(); }
+        } else {
+            quote! { let #arr_ident = #out.clone().arrange_by_key(); }
+        };
+        quote! { #build #arrange }
     }
 }
 

--- a/crates/flowlog-build/src/codegen/mod.rs
+++ b/crates/flowlog-build/src/codegen/mod.rs
@@ -58,6 +58,14 @@ pub struct CodeGen {
     /// across strata so a later stratum can reuse an arrangement built by an
     /// earlier stratum's prelude. Reset at the start of every `generate`.
     pub(crate) outer_arranged: HashMap<u64, Ident>,
+
+    /// Semantic arrangement cache for the non-recursive (outer) scope:
+    /// content `share_key` → `(collection_ident, arr_ident)` of the canonical
+    /// arrangement. Two transformations producing identical content reuse the
+    /// canonical's projected collection and sorted trace instead of rebuilding
+    /// them, even when their lineage-bearing output fingerprints differ. Same
+    /// lifetime as `outer_arranged`.
+    pub(crate) outer_sem_arranged: HashMap<u64, (Ident, Ident)>,
 }
 
 impl CodeGen {
@@ -69,6 +77,7 @@ impl CodeGen {
             global_fp_to_type: HashMap::new(),
             features: Features::default(),
             outer_arranged: HashMap::new(),
+            outer_sem_arranged: HashMap::new(),
         };
         cg.make_global_data_type_map();
         cg
@@ -87,6 +96,7 @@ impl CodeGen {
         self.make_global_ident_map();
         self.features.reset();
         self.outer_arranged.clear();
+        self.outer_sem_arranged.clear();
         self.collect_parts(program_planner.strata(), profiler)
     }
 }


### PR DESCRIPTION
## What

A codegen-level arrangement-sharing (CSE) pass: when two rules build a
content-identical arrangement, the second reuses the first's projected
collection and sorted trace instead of rebuilding them.

## Why

The planner dedups arrangements by their **lineage-bearing** output fingerprint,
which encodes rule-variable *slot positions*. So the same relation arranged the
same way in two differently-shaped rules produces two separate arrangements even
though the generated dataflow code is identical. On context-insensitive DOOP
this leaves ~100 redundant arrangements per program.

## Example

Two rules that both need `Edge` arranged by its first column:

```datalog
Reach(x, y) :- Seed(x),    Edge(x, y).   // Edge is the 2nd body atom
Step(x, y)  :- Edge(x, y), Live(x).      // Edge is the 1st body atom
```

Both compile to the same operator — `edge.arrange_by_key()`, keyed on column 0.
But the planner's lineage fingerprint encodes each variable's **rule-slot
position** (`Edge` is the 2nd atom in `Reach`, the 1st in `Step`), so it treats
them as distinct and builds the arrangement **twice**. With this PR they collide
on the generated-code fingerprint, so `Edge` is sorted **once** and the second
rule reuses the trace (a cheap dataflow-handle clone).

## How

`emit_shared_arrangement` keys a per-scope cache on `arrangement_share_key` =
fingerprint of the **generated build tokens** (output ident neutralized) plus
key-only-ness. On a hit it emits `let out = canonical.clone();` (a cheap
dataflow-handle clone) and points the output fingerprint at the already-built
shared trace.

Hashing the rendered code is the tightest *safe* key — codegen is the canonical
normal form of a `TransformationFlow`. It captures content-identical
arrangements that an `(input, flow)` key over-splits (e.g. joins differing only
in codegen-irrelevant `Vec` ordering), while only ever merging byte-identical —
hence type-identical — code. An audit confirmed it reaches the content-optimal
arrangement count (0 missed, 0 over-merge) on both `doop.dl` and
`context-insensitive`.

## Results — baseline vs this PR (32 workers, interleaved, str-intern)

**context-insensitive** — peak RSS win scales with problem size:

| app | VarPointsTo | peak RSS | wall |
|-----|------------:|---------:|-----:|
| avrora  |  2.5M | **−10.0%** | −2.6% |
| xalan   |  2.4M | **−11.1%** | −6.6% |
| luindex |  5.4M |  **−8.7%** | −4.2% |
| h2      | 22.7M | **−15.5%** | −6.3% |
| batik   | 28.2M | **−16.0%** | −1.2% |

(batik and h2 each save ~2.1 GiB of peak RSS.)

**doop.dl** — flat (within noise) on all apps; it has few shareable arrangements.

## Correctness

- `doop.dl`: outputs **byte-exact** vs baseline on all apps.
- `context-insensitive`: identical per-relation counts and `confirm_benign`
  **residual 0** — i.e. it differs only by the pre-existing benign `ord()`
  heap-merge representative renaming, which the baseline itself exhibits
  run-to-run under string interning.
- `cargo clippy -p flowlog-build`: 0 warnings; `cargo test -p flowlog-build`: 271 pass.

