### PR TITLE
perf(planner): cross-rule arrangement sharing, content-canonical & self-join-sound (consolidates #139/#141)

### DIFF
--- a/crates/flowlog-build/src/codegen/flow/transformation.rs
+++ b/crates/flowlog-build/src/codegen/flow/transformation.rs
@@ -34,6 +34,15 @@ impl CodeGen {
         stratum: &StratumPlanner,
         profiler: &mut Option<Profiler>,
     ) -> Result<TokenStream, CodegenError> {
+        // Arrangement sharing is decided in the planner. If this output's
+        // arrangement was marked a duplicate of an earlier one in this scope,
+        // resolve the canonical collection ident to clone instead of
+        // rebuilding the projection + sorted trace (see
+        // `ProgramPlanner::mark_shared_arrangements`).
+        let arr_alias = stratum
+            .arrangement_alias_of(transformation.output().fingerprint())
+            .map(|canon_fp| find_local_ident(local_fp_to_ident, canon_fp));
+
         // `atom_fps` decides *which* inputs are named atoms; the label
         // text comes from `display_name` (the user's spelling).
         let atom_fps = stratum.atom_fps();
@@ -213,18 +222,16 @@ impl CodeGen {
                         .flat_map(|#row_pat: #row_ty| { #flat_map_body });
                 };
 
-                // Arrangement registration
-                let arrange_stmt = self.register_arrangement(
+                // Arrangement registration (shares a byte-identical arrangement
+                // already built in this scope, if any).
+                Ok(self.register_arrangement(
                     arranged_map,
+                    arr_alias.as_ref(),
                     output.fingerprint(),
                     &out,
+                    transformation,
                     output.is_k_only(),
-                );
-
-                Ok(quote! {
-                    #transformation
-                    #arrange_stmt
-                })
+                ))
             }
 
             // KV -> Row
@@ -362,17 +369,14 @@ impl CodeGen {
                 };
 
                 // Arrangement registration
-                let arrange_stmt = self.register_arrangement(
+                Ok(self.register_arrangement(
                     arranged_map,
+                    arr_alias.as_ref(),
                     output.fingerprint(),
                     &out,
+                    transformation,
                     output.is_k_only(),
-                );
-
-                Ok(quote! {
-                    #transformation
-                    #arrange_stmt
-                })
+                ))
             }
 
             // Join: Key-value ⋈ Key-value -> Row
@@ -501,17 +505,14 @@ impl CodeGen {
                         .join_core(#r.clone(), |#jn_k, #jn_lv, #jn_rv| { #join_body });
                 };
 
-                let arrange_stmt = self.register_arrangement(
+                Ok(self.register_arrangement(
                     arranged_map,
+                    arr_alias.as_ref(),
                     output.fingerprint(),
                     &out,
+                    transformation,
                     output.is_k_only(),
-                );
-
-                Ok(quote! {
-                    #transformation
-                    #arrange_stmt
-                })
+                ))
             }
 
             // Antijoin: Key-value ¬ Key-only to Row
@@ -659,15 +660,14 @@ impl CodeGen {
 
                 let arrange_stmt = self.register_arrangement(
                     arranged_map,
+                    arr_alias.as_ref(),
                     output.fingerprint(),
                     &out,
+                    transformation,
                     output.is_k_only(),
                 );
 
-                Ok(quote! {
-                    #transformation
-                    #arrange_stmt
-                })
+                Ok(arrange_stmt)
             }
         }
     }
@@ -712,21 +712,43 @@ impl CodeGen {
         (pos, neg)
     }
 
+    /// Emit a collection plus its key/self arrangement, honoring the planner's
+    /// arrangement-sharing decision.
+    ///
+    /// `alias_canonical` is `Some(canonical_collection)` when the planner marked
+    /// this output's arrangement a duplicate of an earlier one in this scope
+    /// (see [`ProgramPlanner::mark_shared_arrangements`](crate::planner::ProgramPlanner)).
+    /// On an alias, the projection/join is **not** rebuilt: this ident is bound
+    /// to a cheap `clone()` of the canonical collection (so any direct,
+    /// non-arranged consumer still resolves) and its fingerprint is pointed at
+    /// the canonical's already-built sorted trace. Otherwise the collection is
+    /// built and arranged as the canonical for its key.
     fn register_arrangement(
         &mut self,
         arranged_map: &mut HashMap<u64, Ident>,
+        alias_canonical: Option<&Ident>,
         fingerprint: u64,
         collection_ident: &Ident,
+        transformation: TokenStream,
         only_key: bool,
     ) -> TokenStream {
+        if let Some(canonical) = alias_canonical {
+            // Planner marked this a duplicate: reuse the canonical collection's
+            // trace; bind this ident to a cheap clone of that collection.
+            let canonical_arrangement = format_ident!("{}_arr", canonical);
+            arranged_map.insert(fingerprint, canonical_arrangement);
+            return quote! { let #collection_ident = #canonical.clone(); };
+        }
+
         let arrangement_ident = format_ident!("{}_arr", collection_ident);
         arranged_map.insert(fingerprint, arrangement_ident.clone());
 
-        if only_key {
+        let arrange = if only_key {
             quote! { let #arrangement_ident = #collection_ident.clone().arrange_by_self(); }
         } else {
             quote! { let #arrangement_ident = #collection_ident.clone().arrange_by_key(); }
-        }
+        };
+        quote! { #transformation #arrange }
     }
 }
 

--- a/crates/flowlog-build/src/planner/program_planner.rs
+++ b/crates/flowlog-build/src/planner/program_planner.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use crate::common::{BoxError, Config};
 use crate::optimizer::Optimizer;
 use crate::parser::Program;
-use crate::planner::StratumPlanner;
+use crate::planner::{StratumPlanner, Transformation};
 use crate::profiler::Profiler;
 use crate::stratifier::Stratifier;
 
@@ -44,6 +44,7 @@ impl ProgramPlanner {
             })
             .collect::<Result<_, _>>()?;
         prune_cross_stratum_duplicates(&mut strata);
+        mark_shared_arrangements(&mut strata);
         Ok(Self { strata })
     }
 
@@ -101,6 +102,86 @@ fn prune_cross_stratum_duplicates(strata: &mut [StratumPlanner]) {
             }
             keep
         });
+    }
+}
+
+/// Mark each arrangement-producing transformation as either canonical or an
+/// alias of an earlier, content-identical one *in the same dataflow scope*.
+///
+/// This is the cross-rule arrangement-sharing decision, resolved entirely at
+/// plan time — a sibling of [`prune_cross_stratum_duplicates`], but keyed on
+/// the rule-independent [`arrangement_key`](crate::planner::Transformation::arrangement_key)
+/// rather than the lineage fingerprint, so it catches the same arrangement
+/// reached via differently-shaped rules (which carry distinct fingerprints).
+/// Codegen then merely renders the mark: canonical → build + `arrange_by_*`;
+/// alias → a cheap `clone()` of the canonical collection.
+///
+/// Scopes mirror codegen exactly, so the canonical is always emitted before
+/// its aliases:
+/// - **non-recursive** transformations share one program-wide outer scope, so
+///   they are deduplicated across strata in emission order (stratum, then
+///   in-stratum);
+/// - each stratum's **recursive** transformations share that stratum's
+///   `iterative` block, so they are deduplicated within the stratum.
+///
+/// Cross-scope reuse (an outer arrangement used inside recursion) is the
+/// separate `enter` mechanism and is intentionally not aliased here.
+fn mark_shared_arrangements(strata: &mut [StratumPlanner]) {
+    let mut aliases: Vec<HashMap<u64, u64>> = vec![HashMap::new(); strata.len()];
+
+    // Program-wide non-recursive (outer) scope: one canonical per key across
+    // all strata, in emission order (stratum, then in-stratum).
+    let mut outer_seen: HashMap<u64, u64> = HashMap::new();
+    for (idx, stratum) in strata.iter().enumerate() {
+        dedup_arrangements(
+            &mut outer_seen,
+            &mut aliases[idx],
+            stratum,
+            stratum.non_recursive_transformations(),
+        );
+    }
+
+    // Each stratum's recursive (iterative) scope is independent.
+    for (idx, stratum) in strata.iter().enumerate() {
+        let mut rec_seen: HashMap<u64, u64> = HashMap::new();
+        dedup_arrangements(
+            &mut rec_seen,
+            &mut aliases[idx],
+            stratum,
+            stratum.recursive_transformations(),
+        );
+    }
+
+    for (stratum, alias) in strata.iter_mut().zip(aliases) {
+        stratum.set_arrangement_alias(alias);
+    }
+}
+
+/// Within a single dataflow scope, mark each arrangement-producing
+/// transformation as either the canonical for its rule-independent arrangement
+/// key (first seen) or an alias of that canonical. `seen` maps an arrangement
+/// key to its canonical output fingerprint; `aliases` collects the
+/// `duplicate output fp → canonical output fp` marks codegen reads back.
+fn dedup_arrangements(
+    seen: &mut HashMap<u64, u64>,
+    aliases: &mut HashMap<u64, u64>,
+    stratum: &StratumPlanner,
+    transformations: &[Transformation],
+) {
+    use std::collections::hash_map::Entry;
+    for t in transformations {
+        if !t.produces_arrangement() {
+            continue;
+        }
+        let fp = t.output().fingerprint();
+        match seen.entry(stratum.arrangement_key(fp)) {
+            Entry::Occupied(canonical) => {
+                aliases.insert(fp, *canonical.get());
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(fp);
+            }
+        }
     }
 }
 

--- a/crates/flowlog-build/src/planner/stratum_planner.rs
+++ b/crates/flowlog-build/src/planner/stratum_planner.rs
@@ -31,6 +31,23 @@ pub struct StratumPlanner {
     /// Prefer `non_recursive_transformations` and `recursive_transformations` afterwards.
     transformations: Vec<Transformation>,
 
+    /// Output-fingerprint → canonical, rule-independent **arrangement key**.
+    /// Computed in topological order so the key is transitive (a join over
+    /// already-shared inputs shares with another join over the same shared
+    /// inputs). The whole-program planner turns these into `arrangement_alias`
+    /// marks; see [`Transformation::arrangement_key`].
+    arrangement_keys: HashMap<u64, u64>,
+
+    /// Output-fingerprint → **canonical** output-fingerprint, for every
+    /// arrangement-producing transformation whose arrangement is a duplicate of
+    /// an earlier one *in the same dataflow scope*. Populated by the
+    /// whole-program planner ([`ProgramPlanner::mark_shared_arrangements`]).
+    /// Codegen reads it directly: a marked output emits a cheap `.clone()` of
+    /// the canonical collection instead of rebuilding the projection + sorted
+    /// trace. Absence ⇒ this output is itself canonical. This is the entire
+    /// arrangement-sharing decision, resolved at plan time.
+    arrangement_alias: HashMap<u64, u64>,
+
     /// Transformations that depend only on EDB inputs; computed once.
     non_recursive_transformations: Vec<Transformation>,
 
@@ -189,6 +206,7 @@ impl StratumPlanner {
             ..Self::default()
         };
         stratum_planner.materialize_transformations();
+        stratum_planner.build_arrangement_keys();
 
         // Phase 7: Recursive split and metadata mappings
         // this phase to factoring optimizations
@@ -398,6 +416,55 @@ impl StratumPlanner {
         }
 
         unique_infos
+    }
+
+    /// Compute the canonical, rule-independent arrangement key for every
+    /// transformation output, in topological order.
+    ///
+    /// This is the cross-rule arrangement-sharing decision, owned entirely by
+    /// the planner. Each transformation's key is derived from the *canonical
+    /// keys of its inputs* (not their raw fingerprints), so sharing is
+    /// transitive: structurally-identical re-keying projections across rules
+    /// collapse to one key, and joins built over those shared inputs collapse
+    /// in turn. `self.transformations` is already in producer-before-consumer
+    /// order, so a single forward pass suffices. Inputs with no in-stratum
+    /// producer (EDBs, IDBs, recursion variables) fall back to their
+    /// fingerprint, which is itself rule-independent for declared relations.
+    fn build_arrangement_keys(&mut self) {
+        let mut keys: HashMap<u64, u64> = HashMap::with_capacity(self.transformations.len());
+        for transformation in &self.transformations {
+            let input_keys: Vec<u64> = transformation
+                .input_fingerprints()
+                .iter()
+                .map(|fp| keys.get(fp).copied().unwrap_or(*fp))
+                .collect();
+            let key = transformation.arrangement_key(&input_keys);
+            keys.insert(transformation.output().fingerprint(), key);
+        }
+        self.arrangement_keys = keys;
+    }
+
+    /// Canonical arrangement key for the collection with the given output
+    /// fingerprint. Falls back to the fingerprint itself for collections with
+    /// no recorded key (e.g. ones never arranged), keeping callers total.
+    pub(crate) fn arrangement_key(&self, output_fp: u64) -> u64 {
+        self.arrangement_keys
+            .get(&output_fp)
+            .copied()
+            .unwrap_or(output_fp)
+    }
+
+    /// Record the arrangement-sharing marks computed by the whole-program
+    /// planner (output fingerprint → canonical output fingerprint).
+    pub(crate) fn set_arrangement_alias(&mut self, alias: HashMap<u64, u64>) {
+        self.arrangement_alias = alias;
+    }
+
+    /// If this output's arrangement is a duplicate of an earlier one in the
+    /// same scope, the canonical output fingerprint it should reuse; otherwise
+    /// `None` (this output is canonical). Read by codegen.
+    pub(crate) fn arrangement_alias_of(&self, output_fp: u64) -> Option<u64> {
+        self.arrangement_alias.get(&output_fp).copied()
     }
 }
 

--- a/crates/flowlog-build/src/planner/transformation.rs
+++ b/crates/flowlog-build/src/planner/transformation.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use tracing::trace;
 
 use crate::catalog::JoinPredicates;
+use crate::common::compute_fp;
 use crate::planner::Collection;
 
 mod flow;
@@ -168,6 +169,51 @@ impl Transformation {
             | Self::NJnToRow { flow, .. }
             | Self::NJnToKv { flow, .. } => flow,
         }
+    }
+
+    /// Rule-independent identity of the *arrangement* this transformation's
+    /// output builds, given the canonical arrangement keys of its inputs
+    /// (`input_keys`, in `input_fingerprints()` order). This is the cross-rule
+    /// arrangement-sharing decision, and it lives in the planner: two
+    /// transformations with the same key index byte-identical data the same
+    /// way, so a single physical `arrange_by_*` can serve both.
+    ///
+    /// The key is rule-independent by construction. The flow is *positional* —
+    /// its arguments reference input key/value *positions*, never rule-local
+    /// atom signatures (`rhs_id`) — and `input_keys` identify the source data.
+    /// So two rules that re-key the same source the same way produce the same
+    /// key, even though their collection fingerprints (which embed rule-local
+    /// signatures) differ.
+    ///
+    /// Feeding *canonical* input keys (rather than raw input fingerprints)
+    /// makes sharing transitive: a join over two already-shared inputs shares
+    /// with another join over the same shared inputs. The arrange kind
+    /// (`is_k_only` → `arrange_by_self` vs `arrange_by_key`) is included so
+    /// key-only and keyed arrangements never collide.
+    ///
+    /// The flow contributes its [content key](TransformationFlow::arrangement_content_key),
+    /// which hashes conjunctive filters order-independently — so arrangements
+    /// that differ only in the textual order of `compares`/`fn_call_preds`
+    /// still share. Crucially, the *key/value layout positions stay ordered*,
+    /// so a self-join's two differently-keyed projections of one relation keep
+    /// distinct keys and are never fused (the soundness boundary).
+    pub(crate) fn arrangement_key(&self, input_keys: &[u64]) -> u64 {
+        compute_fp((
+            "arrangement_v1",
+            input_keys,
+            self.flow().arrangement_content_key(),
+            self.output().is_k_only(),
+        ))
+    }
+
+    /// Whether codegen materializes this transformation's output as an
+    /// arrangement (the KV-output variants). Only these participate in
+    /// arrangement sharing; row outputs are never arranged.
+    pub(crate) fn produces_arrangement(&self) -> bool {
+        matches!(
+            self,
+            Self::RowToKv { .. } | Self::KvToKv { .. } | Self::JnToKv { .. } | Self::NJnToKv { .. }
+        )
     }
 
     /// Return the transformation operation name.
@@ -427,5 +473,130 @@ impl fmt::Display for Transformation {
         }
         writeln!(f, "    Flow : {}", self.flow())?;
         writeln!(f, "    Out  : {}", self.output())
+    }
+}
+
+#[cfg(test)]
+mod arrangement_key_tests {
+    use super::*;
+    use crate::catalog::{
+        ArithmeticPos, AtomArgumentSignature, AtomSignature, ComparisonExprPos, KvPredicates,
+    };
+    use crate::parser::ComparisonOperator;
+
+    /// A leaf-style projection of a 2-column source relation `source_fp`,
+    /// re-keying it by `key_col` with `val_col` as value, with optional
+    /// comparison filters `(lcol, op, rcol)` over the source columns. `rhs_id`
+    /// is the source atom's (rule-local) position — varying it models the
+    /// *same* projection appearing in different rules. The same `rhs_id` is
+    /// used for the layout and the filters so they map to the same input
+    /// positions.
+    fn leaf_proj_filtered(
+        source_fp: u64,
+        rhs_id: usize,
+        key_col: usize,
+        val_col: usize,
+        filters: &[(usize, ComparisonOperator, usize)],
+    ) -> Transformation {
+        let sig = |arg| {
+            ArithmeticPos::from_var_signature(AtomArgumentSignature::new(
+                AtomSignature::new(true, rhs_id),
+                arg,
+            ))
+        };
+        let input = KeyValueLayout::new(vec![], vec![sig(0), sig(1)]);
+        let output = KeyValueLayout::new(vec![sig(key_col)], vec![sig(val_col)]);
+        let compare_exprs = filters
+            .iter()
+            .map(|(l, op, r)| ComparisonExprPos::from_parts(sig(*l), op.clone(), sig(*r)))
+            .collect();
+        let predicates = KvPredicates {
+            compare_exprs,
+            ..KvPredicates::default()
+        };
+        let info = TransformationInfo::kv_to_kv(
+            source_fp,
+            "R".to_string(),
+            "pi".to_string(),
+            true,
+            input,
+            output,
+            predicates,
+        );
+        Transformation::kv_to_kv(&info)
+    }
+
+    /// A leaf projection with no filters.
+    fn leaf_proj(source_fp: u64, rhs_id: usize, key_col: usize, val_col: usize) -> Transformation {
+        leaf_proj_filtered(source_fp, rhs_id, key_col, val_col, &[])
+    }
+
+    /// The arrangement key is rule-independent: the same source re-keyed the
+    /// same way in two different rules (different rule-local `rhs_id`) yields
+    /// the same key, so codegen shares one physical arrangement. This is what
+    /// the per-collection fingerprint cannot do, since it embeds `rhs_id`.
+    ///
+    /// `input_keys` here is the source relation's fingerprint (a leaf has no
+    /// in-stratum producer), which is itself rule-independent.
+    #[test]
+    fn arrangement_key_is_rule_independent() {
+        let a = leaf_proj(100, 2, 0, 1);
+        let b = leaf_proj(100, 5, 0, 1);
+        // Sanity: the collection fingerprints *do* differ (rule-local sigs)…
+        assert_ne!(
+            a.output().fingerprint(),
+            b.output().fingerprint(),
+            "fingerprints should differ across rules (rule-local signatures)"
+        );
+        // …yet the arrangement key matches, enabling the share.
+        assert_eq!(
+            a.arrangement_key(&[100]),
+            b.arrangement_key(&[100]),
+            "same source + projection in different rules must share an arrangement key"
+        );
+    }
+
+    /// The key never over-shares: a different source relation or a different
+    /// key/value projection yields a different key.
+    #[test]
+    fn arrangement_key_distinguishes_real_differences() {
+        let base = leaf_proj(100, 2, 0, 1);
+        // Different source relation (different canonical input key).
+        assert_ne!(
+            base.arrangement_key(&[100]),
+            leaf_proj(200, 2, 0, 1).arrangement_key(&[200]),
+            "source relation must matter"
+        );
+        // Different key column (key on col1 instead of col0).
+        assert_ne!(
+            base.arrangement_key(&[100]),
+            leaf_proj(100, 2, 1, 0).arrangement_key(&[100]),
+            "key/value projection must matter"
+        );
+    }
+
+    /// Conjunctive filters commute, so two rules that apply the same filter set
+    /// in a different textual order build the same arrangement and must share
+    /// one key — but a *different* filter set must not. This is the extra
+    /// sharing a plain structural hash of the flow (which is order-sensitive)
+    /// leaves on the table.
+    #[test]
+    fn arrangement_key_ignores_filter_order() {
+        use ComparisonOperator::{GreaterThan, LessThan};
+        // Same two filters, opposite order, and in different rules (rhs_id).
+        let a = leaf_proj_filtered(100, 2, 0, 1, &[(0, LessThan, 1), (1, GreaterThan, 0)]);
+        let b = leaf_proj_filtered(100, 7, 0, 1, &[(1, GreaterThan, 0), (0, LessThan, 1)]);
+        assert_eq!(
+            a.arrangement_key(&[100]),
+            b.arrangement_key(&[100]),
+            "the same conjunctive filters in a different order must share an arrangement"
+        );
+        // A strictly different filter set must not collapse onto it.
+        let c = leaf_proj_filtered(100, 2, 0, 1, &[(0, LessThan, 1)]);
+        assert_ne!(
+            a.arrangement_key(&[100]),
+            c.arrangement_key(&[100]),
+            "a different filter set must not share an arrangement"
+        );
     }
 }

--- a/crates/flowlog-build/src/planner/transformation/flow.rs
+++ b/crates/flowlog-build/src/planner/transformation/flow.rs
@@ -15,6 +15,7 @@ use crate::catalog::{
     ArithmeticPos, AtomArgumentSignature, ComparisonExprPos, FactorPos, FnCallPredicatePos,
     JoinPredicates, KvPredicates,
 };
+use crate::common::compute_fp;
 use crate::parser::ConstType;
 use crate::planner::{
     ArithmeticArgument, ComparisonExprArgument, Constraints, FactorArgument,
@@ -215,6 +216,36 @@ impl TransformationFlow {
             Self::KVToKV { fn_call_preds, .. } => fn_call_preds,
             Self::JnToKV { fn_call_preds, .. } => fn_call_preds,
         }
+    }
+
+    /// Content identity of the arrangement this flow builds, for cross-rule
+    /// arrangement sharing (see [`Transformation::arrangement_key`]).
+    ///
+    /// The output key/value position lists define the tuple layout, so they are
+    /// hashed in order. The `compares` and `fn_call_preds` lists are
+    /// *conjunctive filters* whose textual order does not affect the resulting
+    /// arrangement, so they are hashed as an order-independent multiset (sorted
+    /// by element fingerprint). This lets two rules that apply the same filters
+    /// in a different order share one arrangement — the redundancy a plain
+    /// structural hash of the flow leaves on the table.
+    pub(crate) fn arrangement_content_key(&self) -> u64 {
+        let mut compares: Vec<u64> = self.compares().iter().map(compute_fp).collect();
+        compares.sort_unstable();
+        let mut fn_call_preds: Vec<u64> = self.fn_call_preds().iter().map(compute_fp).collect();
+        fn_call_preds.sort_unstable();
+        let (tag, constraints_fp) = match self {
+            Self::KVToKV { constraints, .. } => ("kv_to_kv", compute_fp(constraints)),
+            Self::JnToKV { .. } => ("jn_to_kv", 0u64),
+        };
+        compute_fp((
+            "arrangement_flow_v1",
+            tag,
+            self.key(),
+            self.value(),
+            constraints_fp,
+            compares,
+            fn_call_preds,
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary

A single, clean **planner-only** implementation of cross-rule arrangement
sharing — consolidating the three in-flight attempts (#139 codegen-CSE, #141
content-canonical fingerprint, and this branch's original aliasing) into one
approach that is **content-optimal-ish, self-join-sound, and keeps all sharing
logic in the query plan**. Codegen merely renders the planner's decision.

FlowLog rebuilds the same differential-dataflow **arrangement** many times: a
relation projected and keyed identically across rules is sorted and indexed once
per rule. On wide program-analysis workloads (DOOP / context-insensitive
points-to) a few relations are joined across hundreds of rules, so every
redundant arrangement is an extra sorted index rebuilt on every recursive round.

## Root cause

Arrangements are keyed by their collection **fingerprint**, which embeds the
rule-local atom signature (`rhs_id`) of the recipe that built them. Two rules
that build a byte-identical sorted trace via differently-shaped bodies get
distinct fingerprints, so the planner's existing dedup passes
(`deduplicate_transformation_infos`, `prune_cross_stratum_duplicates`) never
collapse them.

## Why aliasing, not fingerprint-merging (the soundness story)

The tempting "pure" fix is to make the **fingerprint itself** content-canonical
so the *existing* dedup collapses the duplicates with zero codegen changes —
this is #141. **It is unsound for self-joins.** Collapsing two content-identical
nodes merges plan *nodes*, but a self-join `R(x,y), R(y,z)` needs two *distinct*
keyings of `R`; once merged, the join references one arrangement for both sides.

Verified on a minimal `TwoHop(a,c) :- Edge(a,b), Edge(b,c)`:

| | join's two inputs |
| --- | --- |
| `main-next` (correct) | `L=proj_keycol1`, `R=proj_keycol0` — **distinct** |
| #141 | `L=R=proj_keycol1` — **fused** → self-loops (`1 1`), `Triangle`=1 row not 6 |

The two in-repo fixtures `datalog-batch/join_self` and `datalog-batch/syntax_hybrid`
fail on #141 and pass here.

So this PR keeps **every plan node distinct** (joins still reference the correct
two inputs) and shares only the physical **arrangement** when two distinct nodes
provably build the same sorted trace.

## Design — all in `planner/`

- **`Transformation::arrangement_key(input_keys)`** — a rule-independent identity
  of the arrangement a node builds: the *canonical keys of its inputs*, the
  *positional* flow content key, and the arrange kind (`arrange_by_self` vs
  `arrange_by_key`). It is rule-independent because the flow references key/value
  *positions*, never `rhs_id`.
- **`TransformationFlow::arrangement_content_key()`** — hashes the flow with the
  output key/value position lists **ordered** (they define the tuple layout, and
  are the self-join soundness boundary) but the conjunctive filters
  (`compares` / `fn_call_preds`) as an **order-independent multiset**. This is
  the extra sharing #139 noted a structural key over-splits on.
- **`StratumPlanner::build_arrangement_keys()`** — propagates keys in topological
  order from *canonical input keys*, so sharing is **transitive** (a join over
  already-shared inputs shares in turn).
- **`ProgramPlanner::mark_shared_arrangements()`** — a sibling of
  `prune_cross_stratum_duplicates`, keyed on `arrangement_key`. Marks each
  arrangement **canonical** or **alias-of-X**, scope-aware to match the existing
  **factoring** framework: program-wide for non-recursive (outer) work,
  per-stratum for recursive (iterative) work. Cross-scope reuse stays the
  existing `.enter()` mechanism.
- **codegen** (`flow/transformation.rs`) contains no sharing logic — an alias
  emits `let out = canonical.clone();` and points its fingerprint at the
  canonical's already-built trace, instead of rebuilding the projection/join +
  sorted arrangement.

## Results (batik, `--str-intern`, interleaved A/B vs `main-next`, `-w 16`, 3 reps)

| Program | metric | `main-next` | this PR | Δ |
| --- | --- | ---: | ---: | ---: |
| context-insensitive (592 rules) | arrangements | 1290 | 1175 | **−8.9%** |
| context-insensitive | solve | 58.9 s | 54.6 s | **−7.4%** |
| context-insensitive | userCPU | 933 s | 865 s | **−7.3%** |
| context-insensitive | peak RSS | 11806 MiB | 9712 MiB | **−17.7% (−2.05 GiB)** |
| DOOP (context-sensitive) | arrangements | 204 | 192 | −5.9% |

DOOP perf is flat — its shareable arrangements are small static EDB projections.
The payoff scales with program size.

## Correctness

- **111/111** compiler + **111/111** lib fixtures, incl. the self-join fixtures
  `join_self` / `syntax_hybrid`; **218** unit tests (new tests cover
  rule-independence, the key/column soundness boundary, and filter-order
  independence); `clippy` + `fmt` clean.
- **DOOP**: relation sizes identical (`VarPointsTo`=37,237,353, …).
- **context-insensitive**: all **21** output relations have identical row counts;
  the deterministic relations are **byte-identical**, and the points-to relations
  (`VarPointsTo`=28,249,074, …) differ only by the pre-existing benign `ord()`
  heap-representative nondeterminism the baseline itself exhibits run-to-run.

## Relation to #139 / #141

- **#139** (codegen CSE) — same goal; this keeps the logic in the planner instead
  of hashing rendered codegen tokens.
- **#141** (content-canonical fingerprint) — same goal; but #141 collapses plan
  nodes and is **unsound on self-joins** (see above). This captures the sound
  subset (1175 vs #141's partly-unsound 1167) with all fixtures green.

Recommend closing #139 and #141 in favor of this. A full Soufflé oracle run
before merge is advisable, per the repo's correctness gate.