### PR TITLE
perf(planner): canonical fingerprint rehash — content-based sharing a…

### DIFF
--- a/crates/flowlog-build/src/planner/program_planner.rs
+++ b/crates/flowlog-build/src/planner/program_planner.rs
@@ -173,4 +173,84 @@ mod tests {
             "expected 8 non-recursive transformations after prune"
         );
     }
+
+    /// `P` and `Q` join the same relations on the same key but emit the
+    /// columns in swapped order: `P = (R.a, S.b)`, `Q = (S.a, R.b)`. Their
+    /// final transformations differ only in output-column *pairing* — every
+    /// signature multiset is identical. A fingerprint blind to that pairing
+    /// merges them and Q silently becomes P (wrong results). The two rules'
+    /// head fingerprints must therefore stay distinct.
+    const SWAPPED_COLUMNS_SRC: &str = "\
+        .decl R(k: int32, v: int32)\n\
+        .input R(IO=\"file\", filename=\"R.csv\", delimiter=\",\")\n\
+        .decl S(k: int32, v: int32)\n\
+        .input S(IO=\"file\", filename=\"S.csv\", delimiter=\",\")\n\
+        .decl P(a: int32, b: int32)\n\
+        .printsize P\n\
+        .decl Q(a: int32, b: int32)\n\
+        .printsize Q\n\
+        P(a, b) :- R(k, a), S(k, b).\n\
+        Q(a, b) :- R(k, b), S(k, a).\n";
+
+    /// Both rules consume `Edge` keyed on its first column, but `Edge` sits
+    /// at a different body position (2nd atom in `Reach`, 1st in `Step`), so
+    /// the lineage fingerprints differ (`rhs_id`) while the positional flows
+    /// are identical. The canonical rehash makes the fingerprints collide and
+    /// the stratum dedup shares the premap instead of building it twice.
+    const SLOT_POSITION_SRC: &str = "\
+        .decl Seed(x: int32)\n\
+        .input Seed(IO=\"file\", filename=\"Seed.csv\", delimiter=\",\")\n\
+        .decl Live(x: int32)\n\
+        .input Live(IO=\"file\", filename=\"Live.csv\", delimiter=\",\")\n\
+        .decl Edge(x: int32, y: int32)\n\
+        .input Edge(IO=\"file\", filename=\"Edge.csv\", delimiter=\",\")\n\
+        .decl Reach(x: int32, y: int32)\n\
+        .printsize Reach\n\
+        .decl Step(x: int32, y: int32)\n\
+        .printsize Step\n\
+        Reach(x, y) :- Seed(x), Edge(x, y).\n\
+        Step(x, y) :- Edge(x, y), Live(x).\n";
+
+    #[test]
+    fn canonical_rehash_shares_slot_position_duplicates() {
+        let pp = analyze(SLOT_POSITION_SRC);
+
+        // Content-optimality: no two surviving transformations in the program
+        // describe the same operator over the same inputs. Without the
+        // canonical rehash this fails — each rule builds its own `Edge`
+        // premap with a distinct lineage fingerprint but identical content.
+        let mut seen = std::collections::HashSet::new();
+        for stratum in pp.strata() {
+            for t in stratum
+                .non_recursive_transformations()
+                .iter()
+                .chain(stratum.recursive_transformations())
+            {
+                assert!(
+                    seen.insert((t.input_fingerprints(), t.flow(), t.operation_name())),
+                    "content-identical transformations were not shared:\n{t}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn swapped_output_columns_stay_distinct() {
+        let pp = analyze(SWAPPED_COLUMNS_SRC);
+
+        let mut head_fps: Vec<u64> = Vec::new();
+        for stratum in pp.strata() {
+            for fps in stratum.idb_to_heads_map().values() {
+                head_fps.extend(fps);
+            }
+        }
+        head_fps.sort_unstable();
+        head_fps.dedup();
+        assert_eq!(
+            head_fps.len(),
+            2,
+            "P and Q compute different relations but share a head fingerprint \
+             — the fingerprint is blind to output-column pairing (miscompile)"
+        );
+    }
 }

--- a/crates/flowlog-build/src/planner/rule_planner.rs
+++ b/crates/flowlog-build/src/planner/rule_planner.rs
@@ -21,7 +21,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write as _;
 
 use crate::parser::{Atom, FlowLogRule, Predicate};
-use crate::planner::{Transformation, TransformationInfo};
+use crate::planner::{PlanError, Transformation, TransformationInfo};
 
 mod common; // small utilities shared by planner phases
 mod core; // core join, plus fixed-point of semijoin/pushdown and projection removal
@@ -73,6 +73,75 @@ impl RulePlanner {
     #[inline]
     pub(crate) fn rule(&self) -> &FlowLogRule {
         &self.rule
+    }
+
+    /// Rehash all transformation fingerprints to canonical, content-based
+    /// values.
+    ///
+    /// Lineage fingerprints hash rule-local atom positions (`rhs_id`), so the
+    /// same collection consumed the same way in two differently-shaped rules
+    /// hashes apart and defeats every fingerprint-keyed sharing layer. After
+    /// this pass, fingerprint equality means content equality: the canonical
+    /// hash is a pure function of content, so identical chains in other rules
+    /// (or other strata) arrive at identical fingerprints with no
+    /// coordination, and the existing dedup/prune/codegen machinery shares
+    /// them with no further changes. Layouts keep their `rhs_id`s — only the
+    /// fingerprints change.
+    ///
+    /// Two phases, so the planner is never left half-rewritten:
+    /// 1. Read-only walk in transformation order (producers precede
+    ///    consumers) computing `old → canonical` for every output, resolving
+    ///    each info's inputs through the map built so far. A consumed
+    ///    fingerprint that some info produces but is not yet mapped is a
+    ///    forward reference — error out before mutating anything, as it
+    ///    would otherwise leave a dangling (stale) input fingerprint.
+    /// 2. Mechanical substitution of every fingerprint field through the
+    ///    completed map; relation leaves pass through unchanged.
+    ///
+    /// Does NOT consult `producer_consumer`: that map is last rebuilt during
+    /// fuse and `post` re-fingerprints the head-aligning transformations
+    /// afterwards without maintaining it, so its keys are stale by now.
+    pub(crate) fn rehash_fingerprints(&mut self) -> Result<(), PlanError> {
+        let produced: HashSet<u64> = self
+            .transformation_infos
+            .iter()
+            .map(TransformationInfo::output_info_fp)
+            .collect();
+
+        // Phase 1: pure bottom-up canonical computation + forward-ref check.
+        let mut remap: HashMap<u64, u64> = HashMap::new();
+        for info in &self.transformation_infos {
+            let (left, right) = info.input_info_fp();
+            for fp in std::iter::once(left).chain(right) {
+                if produced.contains(&fp) && !remap.contains_key(&fp) {
+                    return Err(PlanError::internal(format!(
+                        "rehash_fingerprints: rule `{}` consumes 0x{fp:016x} \
+                         before its producer (non-topological transformation \
+                         order)",
+                        self.rule
+                    )));
+                }
+            }
+            remap.insert(info.output_info_fp(), info.canonical_fp(&remap));
+        }
+
+        // Phase 2: substitute every fingerprint through the completed map.
+        for info in self.transformation_infos.iter_mut() {
+            info.remap_fps(&remap);
+        }
+
+        // Self-consistency (debug): the stored fingerprint must remain
+        // reproducible from the info's current fields — inputs are canonical
+        // now, so an identity resolve must yield the stored value. Catches
+        // any later phase clobbering a canonical fp with the lineage formula
+        // (`update_output_fake_sig`).
+        debug_assert!(
+            self.transformation_infos
+                .iter()
+                .all(|info| info.canonical_fp(&HashMap::new()) == info.output_info_fp()),
+            "rehash_fingerprints: canonical fingerprint not reproducible from final state"
+        );
+        Ok(())
     }
 }
 

--- a/crates/flowlog-build/src/planner/stratum_planner.rs
+++ b/crates/flowlog-build/src/planner/stratum_planner.rs
@@ -149,6 +149,22 @@ impl StratumPlanner {
             planner.post(catalog)?;
         }
 
+        // Phase 5.5: Canonical fingerprint rehash
+        // Lineage fingerprints encode rule-local atom positions (`rhs_id`),
+        // so content-identical transformations from differently-shaped rules
+        // hash apart and defeat sharing. Rehash every fingerprint bottom-up
+        // into a content-based value (the materialized operator over resolved
+        // inputs). The hash is a pure function of content, so per-rule walks
+        // need no coordination: equal content collides across rules and
+        // strata automatically, and the profiler below, the dedup in
+        // `materialize_transformations`, the cross-stratum prune, and
+        // codegen's fp-keyed arrangement reuse all share with no further
+        // changes. Must run after `post` (the last lineage-fingerprint
+        // mutation) and before any fingerprint reader.
+        for planner in rule_planners.iter_mut() {
+            planner.rehash_fingerprints()?;
+        }
+
         // Debug info for per-rule plan trees
         rule_planners.iter().for_each(|rp| {
             debug!("{}", rp);
@@ -385,14 +401,31 @@ impl StratumPlanner {
 
     /// Flatten and deduplicate transformation infos from all rules.
     /// Returns references to unique transformation infos (first occurrence wins).
+    ///
+    /// Fingerprints are canonical (content-based) after the Phase 5.5 rehash,
+    /// so this collapses content-identical transformations across rules even
+    /// when their rule shapes differ. The debug guard asserts the rehash's
+    /// soundness contract: equal fingerprint implies equal content.
     fn deduplicate_transformation_infos(&self) -> Vec<&TransformationInfo> {
-        let mut seen = HashSet::new();
+        use std::collections::hash_map::Entry;
+
+        let mut seen: HashMap<u64, &TransformationInfo> = HashMap::new();
         let mut unique_infos = Vec::new();
 
         for planner in &self.rule_planners {
             for info in planner.transformation_infos() {
-                if seen.insert(info) {
-                    unique_infos.push(info);
+                match seen.entry(info.output_info_fp()) {
+                    Entry::Vacant(slot) => {
+                        slot.insert(info);
+                        unique_infos.push(info);
+                    }
+                    Entry::Occupied(slot) => debug_assert!(
+                        info.content_eq(slot.get()),
+                        "fingerprint 0x{:016x} covers two different transformations:\n{}\nvs\n{}",
+                        info.output_info_fp(),
+                        info,
+                        slot.get(),
+                    ),
                 }
             }
         }

--- a/crates/flowlog-build/src/planner/transformation/info.rs
+++ b/crates/flowlog-build/src/planner/transformation/info.rs
@@ -12,6 +12,7 @@
 //! replaced with real ones once they are known. This allows building
 //! a transformation plan before all details are finalized.
 
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use crate::catalog::{
@@ -21,6 +22,7 @@ use crate::catalog::{
 use crate::common::compute_fp;
 use crate::parser::ConstType;
 
+use super::Transformation;
 use crate::planner::{Collection, PlanError};
 
 /// Key/Value layout of a collection: which positions form the key-value.
@@ -706,6 +708,12 @@ impl TransformationInfo {
     /// Recompute the (fake) output fingerprint using the current resolved fields.
     ///
     /// Call this after all relevant inputs/layouts/constraints are up-to-date.
+    ///
+    /// Pre-rehash only: this computes the *lineage* fingerprint (hashes the
+    /// rule-coordinate layouts, including `rhs_id`s). Calling it after
+    /// `RulePlanner::rehash_fingerprints` would clobber the canonical
+    /// (content-based) fingerprint and silently break sharing — the debug
+    /// assertion at the end of the rehash guards against that.
     pub(crate) fn update_output_fake_sig(&mut self) {
         match self {
             Self::KVToKV {
@@ -769,6 +777,92 @@ impl TransformationInfo {
                     right_input_kv_layout,
                     output_kv_layout,
                 ));
+            }
+        }
+    }
+}
+
+// ========================
+// Canonical rehash (content-based fingerprints)
+// ========================
+impl TransformationInfo {
+    /// Lower this info through the real materialization constructors. The
+    /// canonical identity below hashes this form, so "equal key" means
+    /// "materializes to the same operator" by construction — any future
+    /// change to the constructors is reflected in the key automatically.
+    fn materialize(&self) -> Transformation {
+        match self {
+            Self::KVToKV { .. } => Transformation::kv_to_kv(self),
+            Self::JoinToKV { .. } => Transformation::join(self),
+            Self::AntiJoinToKV { .. } => Transformation::antijoin(self),
+        }
+    }
+
+    /// Canonical (content-based) output fingerprint: the materialized
+    /// operator (variant + positional flow) over the input fingerprints
+    /// resolved through `remap`. Pure — does not mutate `self`.
+    ///
+    /// The positional flow is the load-bearing piece: lowering erases the
+    /// rule-local atom coordinates (`AtomArgumentSignature`'s `rhs_id`) that
+    /// the lineage fingerprint hashes — while *preserving* the
+    /// occurrence→output-slot pairing that `rhs_id` also carries (hashing
+    /// layouts with `rhs_id` merely blinded merges swapped-column rules; see
+    /// `swapped_output_columns_stay_distinct`). Layouts keep their `rhs_id`s
+    /// for inspection — only fingerprints change.
+    pub(crate) fn canonical_fp(&self, remap: &HashMap<u64, u64>) -> u64 {
+        let tx = self.materialize();
+        let inputs: Vec<u64> = tx
+            .input_fingerprints()
+            .into_iter()
+            .map(|fp| remap.get(&fp).copied().unwrap_or(fp))
+            .collect();
+        compute_fp(("canonical", tx.operation_name(), inputs, tx.flow()))
+    }
+
+    /// True when two infos materialize to the same operator over the same
+    /// inputs. Debug guard for `deduplicate_transformation_infos`: equal
+    /// fingerprints must never cover different content (would indicate the
+    /// canonical hash is under-specified, or a 64-bit collision).
+    pub(crate) fn content_eq(&self, other: &Self) -> bool {
+        let (a, b) = (self.materialize(), other.materialize());
+        a.operation_name() == b.operation_name()
+            && a.input_fingerprints() == b.input_fingerprints()
+            && a.flow() == b.flow()
+    }
+
+    /// Substitute every fingerprint field — inputs and output uniformly —
+    /// through `remap`; fingerprints absent from the map (relation leaves)
+    /// pass through unchanged. The mechanical half of the two-phase rehash.
+    pub(crate) fn remap_fps(&mut self, remap: &HashMap<u64, u64>) {
+        let resolve = |fp: &mut u64| {
+            if let Some(&canon) = remap.get(fp) {
+                *fp = canon;
+            }
+        };
+        match self {
+            Self::KVToKV {
+                input_info_fp,
+                output_info_fp,
+                ..
+            } => {
+                resolve(input_info_fp);
+                resolve(output_info_fp);
+            }
+            Self::JoinToKV {
+                left_input_info_fp,
+                right_input_info_fp,
+                output_info_fp,
+                ..
+            }
+            | Self::AntiJoinToKV {
+                left_input_info_fp,
+                right_input_info_fp,
+                output_info_fp,
+                ..
+            } => {
+                resolve(left_input_info_fp);
+                resolve(right_input_info_fp);
+                resolve(output_info_fp);
             }
         }
     }


### PR DESCRIPTION
…cross rule shapes

Lineage fingerprints hash rule-local atom positions (AtomArgumentSignature's rhs_id), so content-identical transformations from differently-shaped rules hash apart and defeat every fingerprint-keyed sharing layer (within-stratum dedup, cross-stratum prune, codegen arrangement reuse).

Add Phase 5.5 to stratum planning: directly after post (the last lineage- fingerprint mutation) and before any fingerprint reader, rehash every transformation fingerprint bottom-up into a content-based canonical value. The key is the materialized operator — variant + positional flow via the real Transformation constructors — over input fingerprints resolved through a per-rule remap, so 'equal key' means 'materializes identically' by construction. Two phases (pure compute, then mechanical substitution) keep the planner from ever being half-rewritten; a forward-reference check turns non-topological orders into loud errors instead of dangling fingerprints.

Layouts keep their rhs_ids (planning still needs occurrence coordinates); only fingerprint identity changes, and only at the boundary where its meaning shifts from 'which plan node' to 'which dataflow collection'.

Guards: dedup debug-asserts fp-equal => content-equal; rehash debug-asserts canonical fps stay reproducible from final state; new tests pin both directions (slot-position duplicates now share; swapped-output-column rules must stay distinct — the probe that empirically disproved naive rhs_id-blind hashing, which passes all unit tests yet miscompiles that pattern).