### PR TITLE
perf(planner): share arrangements across rules via content-canonical materialization

### DIFF
--- a/crates/flowlog-build/src/planner/program_planner.rs
+++ b/crates/flowlog-build/src/planner/program_planner.rs
@@ -173,4 +173,121 @@ mod tests {
             "expected 8 non-recursive transformations after prune"
         );
     }
+
+    /// Both rules key `B` on its first column, but at different rhs
+    /// positions (1 vs 0). Lineage fps embed that position; content-canonical
+    /// materialization must share one arrangement.
+    const RHS_ID_SHARING_SRC: &str = "\
+        .decl A(x: int32, y: int32)\n\
+        .decl B(x: int32, y: int32)\n\
+        .decl C(x: int32, y: int32)\n\
+        .decl Out1(x: int32, y: int32)\n\
+        .decl Out2(x: int32, y: int32)\n\
+        .input A(IO=\"file\", filename=\"A.csv\", delimiter=\",\")\n\
+        .input B(IO=\"file\", filename=\"B.csv\", delimiter=\",\")\n\
+        .input C(IO=\"file\", filename=\"C.csv\", delimiter=\",\")\n\
+        .output Out1\n\
+        .output Out2\n\
+        Out1(x, y) :- A(x, z), B(z, y).\n\
+        Out2(x, y) :- B(z, y), C(x, z).\n";
+
+    #[test]
+    fn rhs_id_does_not_split_identical_arrangements() {
+        let pp = analyze(RHS_ID_SHARING_SRC);
+        let b_fp = crate::common::compute_fp("b");
+
+        let b_arrangements: Vec<_> = pp
+            .strata()
+            .iter()
+            .flat_map(|s| s.non_recursive_transformations())
+            .filter(|t| t.is_unary() && t.unary_input().fingerprint() == b_fp)
+            .collect();
+        assert_eq!(
+            b_arrangements.len(),
+            1,
+            "both rules key B on its first column; the arrangement must be shared"
+        );
+
+        // Sharing must be wired in: both joins consume the shared output.
+        let shared_fp = b_arrangements[0].output().fingerprint();
+        let consumers = pp
+            .strata()
+            .iter()
+            .flat_map(|s| s.non_recursive_transformations())
+            .filter(|t| !t.is_unary())
+            .filter(|t| {
+                let (left, right) = t.binary_input();
+                left.fingerprint() == shared_fp || right.fingerprint() == shared_fp
+            })
+            .count();
+        assert_eq!(
+            consumers, 2,
+            "both joins must consume the shared B arrangement"
+        );
+    }
+
+    /// Tripwire against rhs_id-blind hashing: P and Q pair the same
+    /// occurrences to swapped output slots. The positional flow preserves
+    /// the pairing, so the heads must stay distinct (merging makes Q = P).
+    #[test]
+    fn swapped_output_columns_stay_distinct() {
+        let pp = analyze(
+            "\
+            .decl R(k: int32, v: int32)\n\
+            .decl S(k: int32, v: int32)\n\
+            .decl P(a: int32, b: int32)\n\
+            .decl Q(a: int32, b: int32)\n\
+            .input R(IO=\"file\", filename=\"R.csv\", delimiter=\",\")\n\
+            .input S(IO=\"file\", filename=\"S.csv\", delimiter=\",\")\n\
+            .output P\n\
+            .output Q\n\
+            P(a, b) :- R(k, a), S(k, b).\n\
+            Q(a, b) :- R(k, b), S(k, a).\n",
+        );
+
+        let heads: Vec<u64> = pp
+            .strata()
+            .iter()
+            .flat_map(|s| s.idb_to_heads_map().values().flatten().copied())
+            .collect();
+        assert_eq!(heads.len(), 2, "P and Q must each keep their own head");
+        assert_ne!(
+            heads[0], heads[1],
+            "swapped output columns must not collapse into one head"
+        );
+    }
+
+    /// Equal output fingerprint must imply equal content (operation, input
+    /// fps, flow) across all per-rule transformations — otherwise dedup
+    /// would substitute a different transformation.
+    #[test]
+    fn equal_fingerprint_implies_equal_content() {
+        use crate::planner::TransformationFlow;
+
+        for src in [DYCK_SRC, RHS_ID_SHARING_SRC] {
+            let pp = analyze(src);
+            let mut seen: HashMap<u64, (&str, Vec<u64>, TransformationFlow)> = HashMap::new();
+            for stratum in pp.strata() {
+                for planner in stratum.rule_planners() {
+                    for tx in planner.transformations() {
+                        let fp = tx.output().fingerprint();
+                        let content = (
+                            tx.operation_name(),
+                            tx.input_fingerprints(),
+                            tx.flow().clone(),
+                        );
+                        match seen.get(&fp) {
+                            None => {
+                                seen.insert(fp, content);
+                            }
+                            Some(prev) => assert_eq!(
+                                *prev, content,
+                                "fingerprint 0x{fp:016x} maps to two different contents"
+                            ),
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/crates/flowlog-build/src/planner/rule_planner.rs
+++ b/crates/flowlog-build/src/planner/rule_planner.rs
@@ -39,6 +39,10 @@ pub(crate) struct RulePlanner {
     /// Linear list of planned transformation infos for the current rule.
     transformation_infos: Vec<TransformationInfo>,
 
+    /// Materialized transformations with content-canonical fingerprints.
+    /// Empty until [`RulePlanner::materialize`] runs after the post phase.
+    transformations: Vec<Transformation>,
+
     /// Mapping from a fingerprint to its producer indices and optional
     /// list of consumer indices.
     ///
@@ -59,6 +63,7 @@ impl RulePlanner {
         Self {
             rule,
             transformation_infos: Vec::new(),
+            transformations: Vec::new(),
             producer_consumer: HashMap::new(),
         }
     }
@@ -67,6 +72,24 @@ impl RulePlanner {
     #[inline]
     pub(crate) fn transformation_infos(&self) -> &Vec<TransformationInfo> {
         &self.transformation_infos
+    }
+
+    /// Returns the materialized transformations (empty before [`RulePlanner::materialize`]).
+    #[inline]
+    pub(crate) fn transformations(&self) -> &[Transformation] {
+        &self.transformations
+    }
+
+    /// Materialize all infos into [`Transformation`]s with content-canonical
+    /// fingerprints (see [`Transformation::from_info`]). Must run after post,
+    /// in pipeline order so inputs resolve to their producers' fingerprints.
+    pub(crate) fn materialize(&mut self) {
+        let mut fp_map: HashMap<u64, u64> = HashMap::new();
+        self.transformations = self
+            .transformation_infos
+            .iter()
+            .map(|info| Transformation::from_info(info, &mut fp_map))
+            .collect();
     }
 
     /// Returns the original rule.
@@ -83,20 +106,15 @@ impl RulePlanner {
     pub(crate) fn generate_rule_plan_tree_debug_map(&self) -> BTreeMap<u64, (String, Vec<u64>)> {
         let mut debug_info_map: BTreeMap<u64, (String, Vec<u64>)> = BTreeMap::new();
 
-        if self.transformation_infos.is_empty() {
+        if self.transformations.is_empty() {
             return debug_info_map;
         }
 
         let atom_labels = self.rhs_atom_labels();
         let mut referenced_children = BTreeSet::new();
 
-        for info in &self.transformation_infos {
-            let tx = match info {
-                TransformationInfo::KVToKV { .. } => Transformation::kv_to_kv(info),
-                TransformationInfo::JoinToKV { .. } => Transformation::join(info),
-                TransformationInfo::AntiJoinToKV { .. } => Transformation::antijoin(info),
-            };
-            let (label, children) = Self::build_transformation_debug_entry(&tx);
+        for tx in &self.transformations {
+            let (label, children) = Self::build_transformation_debug_entry(tx);
             referenced_children.extend(children.iter().copied());
             debug_info_map.insert(tx.output().fingerprint(), (label, children));
         }
@@ -171,10 +189,10 @@ impl RulePlanner {
 
 impl std::fmt::Display for RulePlanner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Some(last) = self.transformation_infos.last() else {
+        let Some(last) = self.transformations.last() else {
             return writeln!(f, "Plan Tree: (empty)");
         };
-        let root = last.output_info_fp();
+        let root = last.output().fingerprint();
         let debug_map = self.generate_rule_plan_tree_debug_map();
 
         writeln!(f)?;

--- a/crates/flowlog-build/src/planner/stratum_planner.rs
+++ b/crates/flowlog-build/src/planner/stratum_planner.rs
@@ -10,7 +10,7 @@ use crate::parser::{AggregationOperator, FlowLogRule, HeadArg, LoopCondition};
 use crate::profiler::{Profiler, with_profiler};
 use crate::stratifier::Stratifier;
 
-use crate::planner::{PlanError, RulePlanner, Transformation, TransformationInfo};
+use crate::planner::{PlanError, RulePlanner, Transformation};
 
 /// Planner for a single stratum (a group of parallel rules).
 ///
@@ -149,6 +149,13 @@ impl StratumPlanner {
             planner.post(catalog)?;
         }
 
+        // Phase 6: Materialize per-rule transformations, rewriting lineage
+        // (rhs_id-laden) fingerprints to content-canonical ones so identical
+        // operations dedup across rules.
+        for planner in rule_planners.iter_mut() {
+            planner.materialize();
+        }
+
         // Debug info for per-rule plan trees
         rule_planners.iter().for_each(|rp| {
             debug!("{}", rp);
@@ -160,16 +167,24 @@ impl StratumPlanner {
                 profiler.insert_rule(
                     rule_planner.rule().to_string(),
                     rule_planner
-                        .transformation_infos()
+                        .transformations()
                         .iter()
-                        .map(|info| (info.input_info_fp(), info.output_info_fp()))
+                        .map(|tx| {
+                            let inputs = if tx.is_unary() {
+                                (tx.unary_input().fingerprint(), None)
+                            } else {
+                                let (left, right) = tx.binary_input();
+                                (left.fingerprint(), Some(right.fingerprint()))
+                            };
+                            (inputs, tx.output().fingerprint())
+                        })
                         .collect(),
                 );
             }
         });
 
-        // Phase 6: Materialize deduplicated transformations
-        // this phase also do sharing optimization across rules
+        // Phase 7: Cross-rule sharing — dedup the per-rule transformations
+        // by content fingerprint
         let atom_fps: HashSet<u64> = rule_planners
             .iter()
             .flat_map(RulePlanner::rhs_atom_fps)
@@ -188,9 +203,9 @@ impl StratumPlanner {
             atom_fps,
             ..Self::default()
         };
-        stratum_planner.materialize_transformations();
+        stratum_planner.deduplicate_transformations();
 
-        // Phase 7: Recursive split and metadata mappings
+        // Phase 8: Recursive split and metadata mappings
         // this phase to factoring optimizations
         stratum_planner.build_idb_to_heads_map(&catalogs);
         stratum_planner.identify_recursive_transformations(is_recursive);
@@ -306,6 +321,12 @@ impl StratumPlanner {
     pub(crate) fn is_recursive(&self) -> bool {
         self.is_recursive
     }
+
+    /// Test-only: per-rule transformations before cross-rule dedup.
+    #[cfg(test)]
+    pub(crate) fn rule_planners(&self) -> &[RulePlanner] {
+        &self.rule_planners
+    }
 }
 
 impl std::fmt::Display for StratumPlanner {
@@ -369,35 +390,17 @@ impl std::fmt::Display for StratumPlanner {
 // Sharing Optimization
 // =========================================================================
 impl StratumPlanner {
-    /// Deduplicate transformation infos across all rules and build executable transformations.
-    fn materialize_transformations(&mut self) {
-        let unique_infos = self.deduplicate_transformation_infos();
-
-        self.transformations = unique_infos
-            .iter()
-            .map(|&info| match info {
-                TransformationInfo::KVToKV { .. } => Transformation::kv_to_kv(info),
-                TransformationInfo::JoinToKV { .. } => Transformation::join(info),
-                TransformationInfo::AntiJoinToKV { .. } => Transformation::antijoin(info),
-            })
-            .collect();
-    }
-
-    /// Flatten and deduplicate transformation infos from all rules.
-    /// Returns references to unique transformation infos (first occurrence wins).
-    fn deduplicate_transformation_infos(&self) -> Vec<&TransformationInfo> {
+    /// Dedup the per-rule materialized transformations by content
+    /// fingerprint (first occurrence wins; order stays topological).
+    fn deduplicate_transformations(&mut self) {
         let mut seen = HashSet::new();
-        let mut unique_infos = Vec::new();
-
-        for planner in &self.rule_planners {
-            for info in planner.transformation_infos() {
-                if seen.insert(info) {
-                    unique_infos.push(info);
-                }
-            }
-        }
-
-        unique_infos
+        self.transformations = self
+            .rule_planners
+            .iter()
+            .flat_map(|planner| planner.transformations())
+            .filter(|tx| seen.insert(tx.output().fingerprint()))
+            .cloned()
+            .collect();
     }
 }
 
@@ -425,11 +428,10 @@ impl StratumPlanner {
     fn identify_recursive_transformations(&mut self, is_recursive: bool) {
         if !is_recursive {
             // Non-recursive stratum: all transformations are non-recursive
-            self.non_recursive_transformations
-                .extend(self.transformations.iter().cloned());
+            self.non_recursive_transformations = std::mem::take(&mut self.transformations);
             debug!(
                 "Non-recursive stratum: all {} transformations are non-recursive",
-                self.transformations.len()
+                self.non_recursive_transformations.len()
             );
             return;
         }
@@ -462,12 +464,14 @@ impl StratumPlanner {
         }
 
         // Step 3: Separate transformations into non-recursive and recursive vectors
-        for (i, transformation) in self.transformations.iter().enumerate() {
+        for (i, transformation) in std::mem::take(&mut self.transformations)
+            .into_iter()
+            .enumerate()
+        {
             if dynamic_indices.contains(&i) {
-                self.recursive_transformations.push(transformation.clone());
+                self.recursive_transformations.push(transformation);
             } else {
-                self.non_recursive_transformations
-                    .push(transformation.clone());
+                self.non_recursive_transformations.push(transformation);
             }
         }
 
@@ -475,7 +479,7 @@ impl StratumPlanner {
             "Recursive stratum: separated {} non-recursive, {} recursive transformations (total: {})",
             self.non_recursive_transformations.len(),
             self.recursive_transformations.len(),
-            self.transformations.len()
+            self.non_recursive_transformations.len() + self.recursive_transformations.len()
         );
     }
 }
@@ -525,15 +529,15 @@ impl StratumPlanner {
     fn build_idb_to_heads_map(&mut self, catalogs: &[Catalog]) {
         for (rule_idx, catalog) in catalogs.iter().enumerate() {
             let head_idb_fp = catalog.head_idb_fingerprint();
-            let Some(final_info) = self.rule_planners[rule_idx].transformation_infos().last()
-            else {
+            let Some(final_tx) = self.rule_planners[rule_idx].transformations().last() else {
                 continue;
             };
-            let head_fp = final_info.output_info_fp();
-            self.idb_to_heads_map
-                .entry(head_idb_fp)
-                .or_default()
-                .push(head_fp);
+            let head_fp = final_tx.output().fingerprint();
+            // Rules with identical pipelines share one head fp; record it once.
+            let heads = self.idb_to_heads_map.entry(head_idb_fp).or_default();
+            if !heads.contains(&head_fp) {
+                heads.push(head_fp);
+            }
             self.head_to_idb_map.insert(head_fp, head_idb_fp);
         }
     }

--- a/crates/flowlog-build/src/planner/transformation.rs
+++ b/crates/flowlog-build/src/planner/transformation.rs
@@ -4,12 +4,14 @@
 //! through query execution plans. Transformations represent operations like filtering,
 //! projection, joins, and aggregation that convert input collections into output collections.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
 use tracing::trace;
 
 use crate::catalog::JoinPredicates;
+use crate::common::compute_fp;
 use crate::planner::Collection;
 
 mod flow;
@@ -211,10 +213,68 @@ impl Transformation {
     }
 }
 
+/// Lineage fp → content fp; absent entries (name-based atom fps) pass through.
+fn resolve_fp(fp_map: &HashMap<u64, u64>, fp: u64) -> u64 {
+    fp_map.get(&fp).copied().unwrap_or(fp)
+}
+
 // ========================
 // Constructors
 // ========================
 impl Transformation {
+    /// Materialize a [`TransformationInfo`] into a [`Transformation`] whose
+    /// output fingerprint is content-canonical — `hash(variant tag, resolved
+    /// input fps, flow)`, all rhs_id-free — unlike the lineage info
+    /// fingerprints, which embed rule-local atom positions and defeat
+    /// cross-rule sharing.
+    ///
+    /// `fp_map` (per rule, threaded in pipeline order) maps info fp →
+    /// content fp so inputs resolve to their producers; many info fps
+    /// mapping to one content fp is the intended sharing.
+    pub(crate) fn from_info(info: &TransformationInfo, fp_map: &mut HashMap<u64, u64>) -> Self {
+        // Tag mirrors the variant picked below, so equal fingerprints
+        // imply the same variant.
+        let (left, right) = info.input_info_fp();
+        let left_fp = resolve_fp(fp_map, left);
+        let right_fp = right.map(|fp| resolve_fp(fp_map, fp));
+        let tag = match info {
+            TransformationInfo::KVToKV { .. } => {
+                match (info.is_row_input(), info.is_row_output()) {
+                    (true, true) => "row_to_row",
+                    (true, false) => "row_to_kv",
+                    (false, true) => "kv_to_row",
+                    (false, false) => "kv_to_kv",
+                }
+            }
+            TransformationInfo::JoinToKV { .. } => {
+                if info.is_row_output() {
+                    "jn_to_row"
+                } else {
+                    "jn_to_kv"
+                }
+            }
+            TransformationInfo::AntiJoinToKV { .. } => {
+                if info.is_row_output() {
+                    "njn_to_row"
+                } else {
+                    "njn_to_kv"
+                }
+            }
+        };
+
+        let tx = match info {
+            TransformationInfo::KVToKV { .. } => Self::kv_to_kv(info, tag, left_fp),
+            TransformationInfo::JoinToKV { .. } => {
+                Self::join(info, tag, left_fp, right_fp.unwrap())
+            }
+            TransformationInfo::AntiJoinToKV { .. } => {
+                Self::antijoin(info, tag, left_fp, right_fp.unwrap())
+            }
+        };
+        fp_map.insert(info.output_info_fp(), tx.output().fingerprint());
+        tx
+    }
+
     /// Creates a unary transformation from input/output key-value layouts.
     ///
     /// This method analyzes the input and output layouts to determine the specific
@@ -231,7 +291,7 @@ impl Transformation {
     /// - `RowToKv`: Row input → Key-value output (structuring rows into KV pairs)
     /// - `KvToRow`: Key-value input → Row output (flattening KV pairs into rows)
     /// - `KvToKv`: Key-value input → Key-value output (re-keying / re-structuring)
-    pub(crate) fn kv_to_kv(info: &TransformationInfo) -> Self {
+    fn kv_to_kv(info: &TransformationInfo, tag: &'static str, input_fp: u64) -> Self {
         trace!("Creating kv_to_kv transformation with info:\n{}", info);
         // Create the transformation flow that defines how data moves through the operation
         let flow = TransformationFlow::kv_to_kv(
@@ -240,14 +300,16 @@ impl Transformation {
             info.kv_predicates(),
         );
 
+        let output_fp = compute_fp((tag, input_fp, &flow));
+
         let input = Arc::new(Collection::new(
-            info.input_info_fp().0,
+            input_fp,
             info.input_name().0.to_string(),
             info.input_kv_layout().0.key(),
             info.input_kv_layout().0.value(),
         ));
         let output = Arc::new(Collection::new(
-            info.output_info_fp(),
+            output_fp,
             info.output_name().to_string(),
             info.output_kv_layout().key(),
             info.output_kv_layout().value(),
@@ -296,7 +358,7 @@ impl Transformation {
     /// A binary join Transformation variant chosen by the output layout:
     /// - `JnToRow`: Key-value ⋈ Key-value producing a flat row output
     /// - `JnToKv`:  Key-value ⋈ Key-value producing a key-value output
-    pub(crate) fn join(info: &TransformationInfo) -> Self {
+    fn join(info: &TransformationInfo, tag: &'static str, left_fp: u64, right_fp: u64) -> Self {
         // Create transformation flow that defines how the join operation processes data
         let flow = TransformationFlow::join_to_kv(
             info.input_kv_layout().0,
@@ -305,15 +367,17 @@ impl Transformation {
             info.join_predicates(),
         );
 
+        let output_fp = compute_fp((tag, left_fp, right_fp, &flow));
+
         let input = (
             Arc::new(Collection::new(
-                info.input_info_fp().0,
+                left_fp,
                 info.input_name().0.to_string(),
                 info.input_kv_layout().0.key(),
                 info.input_kv_layout().0.value(),
             )),
             Arc::new(Collection::new(
-                info.input_info_fp().1.unwrap(),
+                right_fp,
                 info.input_name().1.unwrap().to_string(),
                 info.input_kv_layout().1.unwrap().key(),
                 info.input_kv_layout().1.unwrap().value(),
@@ -321,7 +385,7 @@ impl Transformation {
         );
 
         let output = Arc::new(Collection::new(
-            info.output_info_fp(),
+            output_fp,
             info.output_name().to_string(),
             info.output_kv_layout().key(),
             info.output_kv_layout().value(),
@@ -362,7 +426,7 @@ impl Transformation {
     ///
     /// Panics if the left collection is not key-only, as antijoins require the left
     /// collection to contain only keys for filtering purposes.
-    pub(crate) fn antijoin(info: &TransformationInfo) -> Self {
+    fn antijoin(info: &TransformationInfo, tag: &'static str, left_fp: u64, right_fp: u64) -> Self {
         // Antijoins require the left collection to be key-only (used for filtering)
         assert!(
             info.input_kv_layout().0.value().is_empty(),
@@ -377,15 +441,17 @@ impl Transformation {
             &JoinPredicates::default(), // No predicates for antijoins
         );
 
+        let output_fp = compute_fp((tag, left_fp, right_fp, &flow));
+
         let input = (
             Arc::new(Collection::new(
-                info.input_info_fp().0,
+                left_fp,
                 info.input_name().0.to_string(),
                 info.input_kv_layout().0.key(),
                 info.input_kv_layout().0.value(),
             )),
             Arc::new(Collection::new(
-                info.input_info_fp().1.unwrap(),
+                right_fp,
                 info.input_name().1.unwrap().to_string(),
                 info.input_kv_layout().1.unwrap().key(),
                 info.input_kv_layout().1.unwrap().value(),
@@ -393,7 +459,7 @@ impl Transformation {
         );
 
         let output = Arc::new(Collection::new(
-            info.output_info_fp(),
+            output_fp,
             info.output_name().to_string(),
             info.output_kv_layout().key(),
             info.output_kv_layout().value(),

--- a/crates/flowlog-build/src/planner/transformation/info.rs
+++ b/crates/flowlog-build/src/planner/transformation/info.rs
@@ -12,8 +12,6 @@
 //! replaced with real ones once they are known. This allows building
 //! a transformation plan before all details are finalized.
 
-use std::hash::{Hash, Hasher};
-
 use crate::catalog::{
     ArithmeticPos, AtomArgumentSignature, ComparisonExprPos, FnCallPredicatePos, JoinPredicates,
     KvPredicates,
@@ -90,10 +88,8 @@ impl KeyValueLayout {
 /// Transformation information, describing how to transform input collection(s)
 /// into an output collection, along with any constraints that must hold.
 ///
-/// `PartialEq`/`Eq`/`Hash` key on `output_info_fp` only — the fingerprint is
-/// the canonical identity. The `*_name` strings carry rule-local variable
-/// aliases that would split semantically-identical infos under a derive,
-/// defeating the dedup in `StratumPlanner::deduplicate_transformation_infos`.
+/// `output_info_fp` is a lineage fingerprint that wires the per-rule
+/// pipeline; materialization rewrites it to a content-canonical one.
 #[derive(Clone, Debug)]
 pub(crate) enum TransformationInfo {
     /// Unary Key-Value to Key-Value transformation (filter, map, projection, etc.).
@@ -169,23 +165,6 @@ pub(crate) enum TransformationInfo {
         /// Output layout (key/value positions) (fake until resolved).
         output_kv_layout: KeyValueLayout,
     },
-}
-
-// ========================
-// Identity (Eq / Hash)
-// ========================
-impl PartialEq for TransformationInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.output_info_fp() == other.output_info_fp()
-    }
-}
-
-impl Eq for TransformationInfo {}
-
-impl Hash for TransformationInfo {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.output_info_fp().hash(state);
-    }
 }
 
 // ========================


### PR DESCRIPTION
## Bug

Planner dedup keys on info fingerprints, which embed the rule-local atom position (`rhs_id`). The same arrangement built by different rules gets different fingerprints, so it's rebuilt once per rule -- hundreds of redundant arrangements on DOOP-scale workloads.

## Fix

Materialize each rule's `TransformationInfos` into `Transformations` right after post, computing the output fingerprint from (variant tag, input fps, flow) -- the flow is positional, so `rhs_id` drops out. A per-rule map (info fp -> content fp) lets downstream inputs resolve to their producers. Stratum dedup then collapses identical operations across rules; everything downstream (idbâheads map, profiler, debug trees) reads the new fingerprints.