### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-compiler"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "codespan-reporting",


### PR DESCRIPTION



## 🤖 New release

* `flowlog-runtime`: 0.2.3 -> 0.2.4
* `flowlog-build`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-runtime`

<blockquote>

## [0.2.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.3...flowlog-runtime-v0.2.4) - 2026-06-12

### Other

- faster, leaner string `.output` (combines #135 + #136) ([#137](https://github.com/flowlog-rs/flowlog/pull/137))
- release flowlog-runtime v0.2.3, flowlog-build v0.3.1, flowlog-compiler v0.4.1 ([#133](https://github.com/flowlog-rs/flowlog/pull/133))
</blockquote>

## `flowlog-build`

<blockquote>

## [0.3.2](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.1...flowlog-build-v0.3.2) - 2026-06-12

### Other

- *(planner)* share arrangements across rules via content-canonical materialization ([#148](https://github.com/flowlog-rs/flowlog/pull/148))
- faster, leaner string `.output` (combines #135 + #136) ([#137](https://github.com/flowlog-rs/flowlog/pull/137))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).