### PR TITLE
refactor(planner): co-locate variant tags + factor collection-building in Transformation::from_info

### DIFF
--- a/crates/flowlog-build/src/planner/transformation.rs
+++ b/crates/flowlog-build/src/planner/transformation.rs
@@ -218,6 +218,13 @@ fn resolve_fp(fp_map: &HashMap<u64, u64>, fp: u64) -> u64 {
     fp_map.get(&fp).copied().unwrap_or(fp)
 }
 
+/// Build a collection from a fingerprint, hierarchical name, and key/value
+/// layout. Centralizes the `Arc<Collection>` boilerplate that every
+/// transformation constructor would otherwise repeat per input and output.
+fn collection_of(fp: u64, name: &str, layout: &KeyValueLayout) -> Arc<Collection> {
+    Arc::new(Collection::new(fp, name.to_string(), layout.key(), layout.value()))
+}
+
 // ========================
 // Constructors
 // ========================
@@ -232,45 +239,25 @@ impl Transformation {
     /// content fp so inputs resolve to their producers; many info fps
     /// mapping to one content fp is the intended sharing.
     pub(crate) fn from_info(info: &TransformationInfo, fp_map: &mut HashMap<u64, u64>) -> Self {
-        // Tag mirrors the variant picked below, so equal fingerprints
-        // imply the same variant.
+        // Resolve each input's lineage fp to its producer's content fp; an
+        // absent entry is a name-based atom fp and passes through unchanged.
         let (left, right) = info.input_info_fp();
         let left_fp = resolve_fp(fp_map, left);
         let right_fp = right.map(|fp| resolve_fp(fp_map, fp));
-        let tag = match info {
-            TransformationInfo::KVToKV { .. } => {
-                match (info.is_row_input(), info.is_row_output()) {
-                    (true, true) => "row_to_row",
-                    (true, false) => "row_to_kv",
-                    (false, true) => "kv_to_row",
-                    (false, false) => "kv_to_kv",
-                }
-            }
-            TransformationInfo::JoinToKV { .. } => {
-                if info.is_row_output() {
-                    "jn_to_row"
-                } else {
-                    "jn_to_kv"
-                }
-            }
+
+        // Each constructor seeds its content fp with a variant tag — so equal
+        // fingerprints imply the same operator variant — and wires its inputs
+        // to the resolved fps above.
+        let tx = match info {
+            TransformationInfo::KVToKV { .. } => Self::kv_to_kv(info, left_fp),
+            TransformationInfo::JoinToKV { .. } => Self::join(info, left_fp, right_fp.unwrap()),
             TransformationInfo::AntiJoinToKV { .. } => {
-                if info.is_row_output() {
-                    "njn_to_row"
-                } else {
-                    "njn_to_kv"
-                }
+                Self::antijoin(info, left_fp, right_fp.unwrap())
             }
         };
 
-        let tx = match info {
-            TransformationInfo::KVToKV { .. } => Self::kv_to_kv(info, tag, left_fp),
-            TransformationInfo::JoinToKV { .. } => {
-                Self::join(info, tag, left_fp, right_fp.unwrap())
-            }
-            TransformationInfo::AntiJoinToKV { .. } => {
-                Self::antijoin(info, tag, left_fp, right_fp.unwrap())
-            }
-        };
+        // Map this info's lineage output fp → content output fp so later
+        // operators in the same rule resolve their inputs to this producer.
         fp_map.insert(info.output_info_fp(), tx.output().fingerprint());
         tx
     }
@@ -291,7 +278,7 @@ impl Transformation {
     /// - `RowToKv`: Row input → Key-value output (structuring rows into KV pairs)
     /// - `KvToRow`: Key-value input → Row output (flattening KV pairs into rows)
     /// - `KvToKv`: Key-value input → Key-value output (re-keying / re-structuring)
-    fn kv_to_kv(info: &TransformationInfo, tag: &'static str, input_fp: u64) -> Self {
+    fn kv_to_kv(info: &TransformationInfo, input_fp: u64) -> Self {
         trace!("Creating kv_to_kv transformation with info:\n{}", info);
         // Create the transformation flow that defines how data moves through the operation
         let flow = TransformationFlow::kv_to_kv(
@@ -300,20 +287,18 @@ impl Transformation {
             info.kv_predicates(),
         );
 
+        // Variant tag seeds the content fp so a row/kv shape difference can
+        // never collapse two otherwise-identical flows onto one arrangement.
+        let tag = match (info.is_row_input(), info.is_row_output()) {
+            (true, true) => "row_to_row",
+            (true, false) => "row_to_kv",
+            (false, true) => "kv_to_row",
+            (false, false) => "kv_to_kv",
+        };
         let output_fp = compute_fp((tag, input_fp, &flow));
 
-        let input = Arc::new(Collection::new(
-            input_fp,
-            info.input_name().0.to_string(),
-            info.input_kv_layout().0.key(),
-            info.input_kv_layout().0.value(),
-        ));
-        let output = Arc::new(Collection::new(
-            output_fp,
-            info.output_name().to_string(),
-            info.output_kv_layout().key(),
-            info.output_kv_layout().value(),
-        ));
+        let input = collection_of(input_fp, info.input_name().0, info.input_kv_layout().0);
+        let output = collection_of(output_fp, info.output_name(), info.output_kv_layout());
 
         match (info.is_row_input(), info.is_row_output()) {
             // Row in, Row out: filtering, projection, or aggregation on flat rows.
@@ -358,7 +343,7 @@ impl Transformation {
     /// A binary join Transformation variant chosen by the output layout:
     /// - `JnToRow`: Key-value ⋈ Key-value producing a flat row output
     /// - `JnToKv`:  Key-value ⋈ Key-value producing a key-value output
-    fn join(info: &TransformationInfo, tag: &'static str, left_fp: u64, right_fp: u64) -> Self {
+    fn join(info: &TransformationInfo, left_fp: u64, right_fp: u64) -> Self {
         // Create transformation flow that defines how the join operation processes data
         let flow = TransformationFlow::join_to_kv(
             info.input_kv_layout().0,
@@ -367,29 +352,24 @@ impl Transformation {
             info.join_predicates(),
         );
 
+        // Variant tag (see `kv_to_kv`) keeps a row-output join distinct from a
+        // kv-output one with the same inputs and flow.
+        let tag = if info.is_row_output() {
+            "jn_to_row"
+        } else {
+            "jn_to_kv"
+        };
         let output_fp = compute_fp((tag, left_fp, right_fp, &flow));
 
         let input = (
-            Arc::new(Collection::new(
-                left_fp,
-                info.input_name().0.to_string(),
-                info.input_kv_layout().0.key(),
-                info.input_kv_layout().0.value(),
-            )),
-            Arc::new(Collection::new(
+            collection_of(left_fp, info.input_name().0, info.input_kv_layout().0),
+            collection_of(
                 right_fp,
-                info.input_name().1.unwrap().to_string(),
-                info.input_kv_layout().1.unwrap().key(),
-                info.input_kv_layout().1.unwrap().value(),
-            )),
+                info.input_name().1.unwrap(),
+                info.input_kv_layout().1.unwrap(),
+            ),
         );
-
-        let output = Arc::new(Collection::new(
-            output_fp,
-            info.output_name().to_string(),
-            info.output_kv_layout().key(),
-            info.output_kv_layout().value(),
-        ));
+        let output = collection_of(output_fp, info.output_name(), info.output_kv_layout());
 
         if info.is_row_output() {
             Self::JnToRow {
@@ -426,7 +406,7 @@ impl Transformation {
     ///
     /// Panics if the left collection is not key-only, as antijoins require the left
     /// collection to contain only keys for filtering purposes.
-    fn antijoin(info: &TransformationInfo, tag: &'static str, left_fp: u64, right_fp: u64) -> Self {
+    fn antijoin(info: &TransformationInfo, left_fp: u64, right_fp: u64) -> Self {
         // Antijoins require the left collection to be key-only (used for filtering)
         assert!(
             info.input_kv_layout().0.value().is_empty(),
@@ -441,29 +421,24 @@ impl Transformation {
             &JoinPredicates::default(), // No predicates for antijoins
         );
 
+        // Variant tag (see `kv_to_kv`) keeps a row-output antijoin distinct
+        // from a kv-output one with the same inputs and flow.
+        let tag = if info.is_row_output() {
+            "njn_to_row"
+        } else {
+            "njn_to_kv"
+        };
         let output_fp = compute_fp((tag, left_fp, right_fp, &flow));
 
         let input = (
-            Arc::new(Collection::new(
-                left_fp,
-                info.input_name().0.to_string(),
-                info.input_kv_layout().0.key(),
-                info.input_kv_layout().0.value(),
-            )),
-            Arc::new(Collection::new(
+            collection_of(left_fp, info.input_name().0, info.input_kv_layout().0),
+            collection_of(
                 right_fp,
-                info.input_name().1.unwrap().to_string(),
-                info.input_kv_layout().1.unwrap().key(),
-                info.input_kv_layout().1.unwrap().value(),
-            )),
+                info.input_name().1.unwrap(),
+                info.input_kv_layout().1.unwrap(),
+            ),
         );
-
-        let output = Arc::new(Collection::new(
-            output_fp,
-            info.output_name().to_string(),
-            info.output_kv_layout().key(),
-            info.output_kv_layout().value(),
-        ));
+        let output = collection_of(output_fp, info.output_name(), info.output_kv_layout());
 
         if info.is_row_output() {
             Self::NJnToRow {


### PR DESCRIPTION
## What

A behavior-preserving cleanup of the content-canonical materialization added in #148
(`Transformation::from_info` + the `kv_to_kv` / `join` / `antijoin` constructors).

Two things were awkward in the merged version:

1. **Tag/variant sync hazard.** `from_info` computed each operator's variant tag in a
   `match` over the `TransformationInfo` variant, then dispatched in a *second* `match`
   over the same variant right below it. The two had to stay in lock-step — the code even
   comments "*tag mirrors the variant picked below*". Parallel switches over the same thing
   are exactly the kind of coupling that rots.
2. **Repeated collection boilerplate.** Each constructor open-coded the same 4-line
   `Arc::new(Collection::new(fp, name.to_string(), layout.key(), layout.value()))` for every
   input and output (6 copies total).

## Change

- Each variant tag now lives **inside the constructor that builds that variant**, next to
  the variant it seeds. `from_info` reduces to: resolve inputs → dispatch → record the
  lineage→content fp mapping.
- Collection construction is factored into a small `collection_of(fp, name, layout)` helper.
- Comments tightened to explain the lineage-fp → content-fp resolution and why the tag
  exists (so a row/kv shape difference can't collapse two otherwise-identical flows onto
  one arrangement).

Net **−25 lines**, no new types, clippy clean.

## No behavior change

The tag strings (`row_to_row`, `jn_to_kv`, …) and the `compute_fp` tuple shapes are
preserved byte-for-byte, so content fingerprints — and therefore cross-rule arrangement
sharing — are identical. Verified:

| check | result |
|---|---|
| `cargo test -p flowlog-build` | **218 passed** (incl. `equal_fingerprint_implies_equal_content`, rhs_id sharing, swapped-columns tripwire, dyck prune) |
| arrangement counts (generated `arrange_by_*`) | **polonius 56, context-insensitive 1177, doop 192** — unchanged vs `main-next` |
| ci@tomcat output | **21/21 relations identical to Souffle** (`VarPointsTo`=3,066,514) |
| clippy | clean |

> Note: the generated `main.rs` differs run-to-run regardless of this change (planner join
> ordering is HashMap-iteration dependent), so the regression signal is the **arrangement
> count + output parity**, both of which are stable and unchanged.

## Why it's worth doing

Separate phase-breakdown profiling (FlowLog vs Souffle on polonius/ci/doop) showed that
graph-construction (spinup), peak RSS, and arrangement teardown all scale with the number
of arrangements the planner emits — so `from_info` is the hot path for keeping that count
down. Keeping it small and free of sync hazards is worth the tidy-up.