### PR TITLE
refactor(planner): one source of truth for the fingerprint tag↔variant pairing + factor Collection building (consolidates #153, #154)

### DIFF
--- a/crates/flowlog-build/src/planner/transformation.rs
+++ b/crates/flowlog-build/src/planner/transformation.rs
@@ -218,6 +218,28 @@ fn resolve_fp(fp_map: &HashMap<u64, u64>, fp: u64) -> u64 {
     fp_map.get(&fp).copied().unwrap_or(fp)
 }
 
+/// Build a collection handle from a fingerprint, hierarchical name, and
+/// key/value layout. Centralizes the `Arc<Collection>` boilerplate that every
+/// transformation constructor would otherwise repeat for each input and output.
+fn collection_of(fp: u64, name: &str, layout: &KeyValueLayout) -> Arc<Collection> {
+    Arc::new(Collection::new(
+        fp,
+        name.to_string(),
+        layout.key(),
+        layout.value(),
+    ))
+}
+
+/// Builds a unary [`Transformation`] variant from its input, output, and flow.
+/// Chosen *together* with the variant's fingerprint tag in a single match arm
+/// (see [`Transformation::kv_to_kv`]) so the two can never drift apart.
+type UnaryCtor = fn(Arc<Collection>, Arc<Collection>, TransformationFlow) -> Transformation;
+
+/// Builds a binary (join / antijoin) [`Transformation`] variant. As with
+/// [`UnaryCtor`], picked alongside its fingerprint tag in one match arm.
+type BinaryCtor =
+    fn((Arc<Collection>, Arc<Collection>), Arc<Collection>, TransformationFlow) -> Transformation;
+
 // ========================
 // Constructors
 // ========================
@@ -231,44 +253,20 @@ impl Transformation {
     /// `fp_map` (per rule, threaded in pipeline order) maps info fp →
     /// content fp so inputs resolve to their producers; many info fps
     /// mapping to one content fp is the intended sharing.
+    ///
+    /// The fingerprint `tag` is *not* chosen here: each constructor picks it in
+    /// the same match arm that selects the enum variant, keeping "equal
+    /// fingerprint ⇒ same variant" structurally true rather than convention.
     pub(crate) fn from_info(info: &TransformationInfo, fp_map: &mut HashMap<u64, u64>) -> Self {
-        // Tag mirrors the variant picked below, so equal fingerprints
-        // imply the same variant.
         let (left, right) = info.input_info_fp();
         let left_fp = resolve_fp(fp_map, left);
         let right_fp = right.map(|fp| resolve_fp(fp_map, fp));
-        let tag = match info {
-            TransformationInfo::KVToKV { .. } => {
-                match (info.is_row_input(), info.is_row_output()) {
-                    (true, true) => "row_to_row",
-                    (true, false) => "row_to_kv",
-                    (false, true) => "kv_to_row",
-                    (false, false) => "kv_to_kv",
-                }
-            }
-            TransformationInfo::JoinToKV { .. } => {
-                if info.is_row_output() {
-                    "jn_to_row"
-                } else {
-                    "jn_to_kv"
-                }
-            }
-            TransformationInfo::AntiJoinToKV { .. } => {
-                if info.is_row_output() {
-                    "njn_to_row"
-                } else {
-                    "njn_to_kv"
-                }
-            }
-        };
 
         let tx = match info {
-            TransformationInfo::KVToKV { .. } => Self::kv_to_kv(info, tag, left_fp),
-            TransformationInfo::JoinToKV { .. } => {
-                Self::join(info, tag, left_fp, right_fp.unwrap())
-            }
+            TransformationInfo::KVToKV { .. } => Self::kv_to_kv(info, left_fp),
+            TransformationInfo::JoinToKV { .. } => Self::join(info, left_fp, right_fp.unwrap()),
             TransformationInfo::AntiJoinToKV { .. } => {
-                Self::antijoin(info, tag, left_fp, right_fp.unwrap())
+                Self::antijoin(info, left_fp, right_fp.unwrap())
             }
         };
         fp_map.insert(info.output_info_fp(), tx.output().fingerprint());
@@ -291,7 +289,7 @@ impl Transformation {
     /// - `RowToKv`: Row input → Key-value output (structuring rows into KV pairs)
     /// - `KvToRow`: Key-value input → Row output (flattening KV pairs into rows)
     /// - `KvToKv`: Key-value input → Key-value output (re-keying / re-structuring)
-    fn kv_to_kv(info: &TransformationInfo, tag: &'static str, input_fp: u64) -> Self {
+    fn kv_to_kv(info: &TransformationInfo, input_fp: u64) -> Self {
         trace!("Creating kv_to_kv transformation with info:\n{}", info);
         // Create the transformation flow that defines how data moves through the operation
         let flow = TransformationFlow::kv_to_kv(
@@ -300,47 +298,42 @@ impl Transformation {
             info.kv_predicates(),
         );
 
+        // Pick the fingerprint tag and the enum variant in the *same* arm so
+        // they stay in lockstep (equal fingerprint ⇒ same variant).
+        let (tag, ctor): (&'static str, UnaryCtor) =
+            match (info.is_row_input(), info.is_row_output()) {
+                // Row in, Row out: filtering, projection, or aggregation on flat rows.
+                (true, true) => ("row_to_row", |input, output, flow| Self::RowToRow {
+                    input,
+                    output,
+                    flow,
+                }),
+                // Row in, KV out: structure flat rows into key-value pairs.
+                (true, false) => ("row_to_kv", |input, output, flow| Self::RowToKv {
+                    input,
+                    output,
+                    flow,
+                }),
+                // KV in, Row out: flatten key-value pairs back into rows.
+                (false, true) => ("kv_to_row", |input, output, flow| Self::KvToRow {
+                    input,
+                    output,
+                    flow,
+                }),
+                // KV in, KV out: re-key or re-structure an existing KV layout.
+                (false, false) => ("kv_to_kv", |input, output, flow| Self::KvToKv {
+                    input,
+                    output,
+                    flow,
+                }),
+            };
+
         let output_fp = compute_fp((tag, input_fp, &flow));
 
-        let input = Arc::new(Collection::new(
-            input_fp,
-            info.input_name().0.to_string(),
-            info.input_kv_layout().0.key(),
-            info.input_kv_layout().0.value(),
-        ));
-        let output = Arc::new(Collection::new(
-            output_fp,
-            info.output_name().to_string(),
-            info.output_kv_layout().key(),
-            info.output_kv_layout().value(),
-        ));
+        let input = collection_of(input_fp, info.input_name().0, info.input_kv_layout().0);
+        let output = collection_of(output_fp, info.output_name(), info.output_kv_layout());
 
-        match (info.is_row_input(), info.is_row_output()) {
-            // Row in, Row out: filtering, projection, or aggregation on flat rows.
-            (true, true) => Self::RowToRow {
-                input,
-                output,
-                flow,
-            },
-            // Row in, KV out: structure flat rows into key-value pairs.
-            (true, false) => Self::RowToKv {
-                input,
-                output,
-                flow,
-            },
-            // KV in, Row out: flatten key-value pairs back into rows.
-            (false, true) => Self::KvToRow {
-                input,
-                output,
-                flow,
-            },
-            // KV in, KV out: re-key or re-structure an existing KV layout.
-            (false, false) => Self::KvToKv {
-                input,
-                output,
-                flow,
-            },
-        }
+        ctor(input, output, flow)
     }
 
     /// Creates a join transformation between two collections.
@@ -358,7 +351,7 @@ impl Transformation {
     /// A binary join Transformation variant chosen by the output layout:
     /// - `JnToRow`: Key-value ⋈ Key-value producing a flat row output
     /// - `JnToKv`:  Key-value ⋈ Key-value producing a key-value output
-    fn join(info: &TransformationInfo, tag: &'static str, left_fp: u64, right_fp: u64) -> Self {
+    fn join(info: &TransformationInfo, left_fp: u64, right_fp: u64) -> Self {
         // Create transformation flow that defines how the join operation processes data
         let flow = TransformationFlow::join_to_kv(
             info.input_kv_layout().0,
@@ -367,43 +360,34 @@ impl Transformation {
             info.join_predicates(),
         );
 
+        // Tag and variant chosen together (see `kv_to_kv`).
+        let (tag, ctor): (&'static str, BinaryCtor) = if info.is_row_output() {
+            ("jn_to_row", |input, output, flow| Self::JnToRow {
+                input,
+                output,
+                flow,
+            })
+        } else {
+            ("jn_to_kv", |input, output, flow| Self::JnToKv {
+                input,
+                output,
+                flow,
+            })
+        };
+
         let output_fp = compute_fp((tag, left_fp, right_fp, &flow));
 
         let input = (
-            Arc::new(Collection::new(
-                left_fp,
-                info.input_name().0.to_string(),
-                info.input_kv_layout().0.key(),
-                info.input_kv_layout().0.value(),
-            )),
-            Arc::new(Collection::new(
+            collection_of(left_fp, info.input_name().0, info.input_kv_layout().0),
+            collection_of(
                 right_fp,
-                info.input_name().1.unwrap().to_string(),
-                info.input_kv_layout().1.unwrap().key(),
-                info.input_kv_layout().1.unwrap().value(),
-            )),
+                info.input_name().1.unwrap(),
+                info.input_kv_layout().1.unwrap(),
+            ),
         );
+        let output = collection_of(output_fp, info.output_name(), info.output_kv_layout());
 
-        let output = Arc::new(Collection::new(
-            output_fp,
-            info.output_name().to_string(),
-            info.output_kv_layout().key(),
-            info.output_kv_layout().value(),
-        ));
-
-        if info.is_row_output() {
-            Self::JnToRow {
-                input,
-                output,
-                flow,
-            }
-        } else {
-            Self::JnToKv {
-                input,
-                output,
-                flow,
-            }
-        }
+        ctor(input, output, flow)
     }
 
     /// Creates an antijoin transformation.
@@ -426,7 +410,7 @@ impl Transformation {
     ///
     /// Panics if the left collection is not key-only, as antijoins require the left
     /// collection to contain only keys for filtering purposes.
-    fn antijoin(info: &TransformationInfo, tag: &'static str, left_fp: u64, right_fp: u64) -> Self {
+    fn antijoin(info: &TransformationInfo, left_fp: u64, right_fp: u64) -> Self {
         // Antijoins require the left collection to be key-only (used for filtering)
         assert!(
             info.input_kv_layout().0.value().is_empty(),
@@ -441,43 +425,34 @@ impl Transformation {
             &JoinPredicates::default(), // No predicates for antijoins
         );
 
+        // Tag and variant chosen together (see `kv_to_kv`).
+        let (tag, ctor): (&'static str, BinaryCtor) = if info.is_row_output() {
+            ("njn_to_row", |input, output, flow| Self::NJnToRow {
+                input,
+                output,
+                flow,
+            })
+        } else {
+            ("njn_to_kv", |input, output, flow| Self::NJnToKv {
+                input,
+                output,
+                flow,
+            })
+        };
+
         let output_fp = compute_fp((tag, left_fp, right_fp, &flow));
 
         let input = (
-            Arc::new(Collection::new(
-                left_fp,
-                info.input_name().0.to_string(),
-                info.input_kv_layout().0.key(),
-                info.input_kv_layout().0.value(),
-            )),
-            Arc::new(Collection::new(
+            collection_of(left_fp, info.input_name().0, info.input_kv_layout().0),
+            collection_of(
                 right_fp,
-                info.input_name().1.unwrap().to_string(),
-                info.input_kv_layout().1.unwrap().key(),
-                info.input_kv_layout().1.unwrap().value(),
-            )),
+                info.input_name().1.unwrap(),
+                info.input_kv_layout().1.unwrap(),
+            ),
         );
+        let output = collection_of(output_fp, info.output_name(), info.output_kv_layout());
 
-        let output = Arc::new(Collection::new(
-            output_fp,
-            info.output_name().to_string(),
-            info.output_kv_layout().key(),
-            info.output_kv_layout().value(),
-        ));
-
-        if info.is_row_output() {
-            Self::NJnToRow {
-                input,
-                output,
-                flow,
-            }
-        } else {
-            Self::NJnToKv {
-                input,
-                output,
-                flow,
-            }
-        }
+        ctor(input, output, flow)
     }
 }
 


### PR DESCRIPTION
## Summary

A readability/robustness pass over the content-canonical fingerprint +
arrangement-sharing path introduced by #148 (`Transformation::from_info` →
within-stratum dedup → recursion factoring → cross-stratum prune → codegen
`arranged_map` reuse).

> **Consolidates #153 and #154** (three of us opened overlapping cleanups of the
> same `from_info` within minutes). This PR is the union of the parts that hold
> up; the other two are closed in its favour — see *Relationship to #153/#154*
> below.

## What changed (one file, net −25 lines)

1. **One source of truth for the tag↔variant pairing.** `from_info` decided the
   fingerprint `tag` string in one `match`, while the enum variant was decided
   by a *second* `match` inside `kv_to_kv`/`join`/`antijoin`. The soundness
   property *"equal fingerprint ⇒ same variant"* was held only by convention
   across those two sites — its own comment flagged it (`// Tag mirrors the
   variant picked below`). Each constructor now yields `(tag, ctor)` from a
   **single** match arm, so the tag and the variant it stands for cannot drift;
   `from_info` drops its redundant tag match and just dispatches.
2. **Factor the `Collection` boilerplate.** The 6 hand-rolled
   `Arc::new(Collection::new(fp, name.to_string(), layout.key(), layout.value()))`
   copies collapse into one `collection_of(fp, name, layout)` helper.

### Provably no behaviour change
The tag strings and the `compute_fp` inputs — `(variant tag, resolved input
fps, flow)` — are byte-for-byte unchanged, so every content fingerprint (and
therefore all sharing / dedup / prune decisions and the generated dataflow) is
identical:

- **Generated code content-identical** (sorted, to factor out codegen's
  pre-existing statement-order nondeterminism) for the deterministic programs
  `doop.dl` and `polonius_str.dl` (0 diff).
- **Arrangement counts unchanged**: doop `192`, polonius `56`,
  context-insensitive `~1177–1178` (this program's count already varies ±1
  run-to-run from its `ord()` relations, independent of this change).
- `218` `flowlog-build` unit tests + `111/111` e2e lib fixtures pass; `clippy` clean.

## Relationship to #153 / #154

All three did the same core fix (co-locate the tag with the variant). The
differences, and why this is the union worth keeping:

| | tag↔variant | `Collection` factoring | module docs |
|---|---|---|---|
| #153 | co-located | `collection()` + `binary_collections()` | **added to `planner/mod.rs`** — @HarukiMoriarty flagged: *"optimization tricks should not be put at the crate entry level"* |
| #154 | tag moved into the constructor but still a **separate** match from the variant dispatch — the drift hazard persists, just relocated | `collection_of()` | none |
| **this** | **single `(tag, ctor)` match** — the hazard is structurally gone | `collection_of()` (same as #154) | none (honours the #153 review feedback) |

So this PR takes the only tag↔variant form that actually removes the hazard
(`(tag, ctor)`), keeps #154's `collection_of`, and deliberately omits the
module-entry docs #153 was asked to reconsider.

## Side investigation (no code here): order-independent filter hashing

While in here I also tested the obvious follow-on — making the content
fingerprint hash conjunctive filters order-independently (the closed #145 idea:
hash `flow.content_key()` with key/value positional but constraints/compares/UDF
predicates as sorted multisets) — and **benchmarked it to a negative result**:

- arrangements: context-insensitive (flattened DOOP) `1178 → 1167` (−11);
  **neutral** on every hand-written example (doop, polonius, cspa, csda, galen…).
- results byte-identical on doop@batik (26/26), context-insensitive@batik
  (21/21 row counts), polonius@clap (20/20).
- **but solve time `53.5s → 54.5s` (≈ +1.9%, w16, 5 clean interleaved runs)** on
  context-insensitive, RSS flat — every head sample exceeded every base sample.

Cause: order-independent dedup keeps *one* rule's filter order as the shared
representative and discards the planner's per-rule selectivity ordering (SIP /
pushdown); a less-selective predicate first in the hot `&&` over ~28M tuples
outweighs the saved arrangements. **Conclusion: not worth it — #148's
order-sensitive flow hash is the right call.** Left out of this PR; recording it
so it isn't re-attempted.

## Validation
- `cargo test --release --workspace`: **277 passed, 0 failed**
- e2e lib fixtures: **111/111**
- `clippy`: clean
- real-data parity above on batik (DOOP DaCapo) and clap (polonius)

Base: `main-next`.
