### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "flowlog-build"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-runtime"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "differential-dataflow",
  "lasso",

--- a/flowlog-build/CHANGELOG.md
+++ b/flowlog-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.2...flowlog-build-v0.3.3) - 2026-06-13
+
+### Other
+
+- flatten workspace — move crates from crates/ to repo root
+
 ## [0.3.2](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.1...flowlog-build-v0.3.2) - 2026-06-12
 
 ### Other

--- a/flowlog-build/Cargo.toml
+++ b/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/flowlog-compiler/Cargo.toml
+++ b/flowlog-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-compiler"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/flowlog-runtime/CHANGELOG.md
+++ b/flowlog-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.4...flowlog-runtime-v0.2.5) - 2026-06-13
+
+### Other
+
+- flatten workspace — move crates from crates/ to repo root
+
 ## [0.2.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.3...flowlog-runtime-v0.2.4) - 2026-06-12
 
 ### Other

--- a/flowlog-runtime/Cargo.toml
+++ b/flowlog-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flowlog-runtime"
 # The runtime releases on its own cadence — generated code depends on it
 # by published version, so any additive change ships as an independent bump.
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `flowlog-runtime`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `flowlog-build`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-runtime`

<blockquote>

## [0.2.5](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.4...flowlog-runtime-v0.2.5) - 2026-06-13

### Other

- flatten workspace — move crates from crates/ to repo root
</blockquote>

## `flowlog-build`

<blockquote>

## [0.3.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.2...flowlog-build-v0.3.3) - 2026-06-13

### Other

- flatten workspace — move crates from crates/ to repo root
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).