### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-compiler"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "codespan-reporting",


### PR DESCRIPTION



## 🤖 New release

* `flowlog-runtime`: 0.2.4 -> 0.2.5
* `flowlog-build`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-runtime`

<blockquote>

## [0.2.5](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.4...flowlog-runtime-v0.2.5) - 2026-06-13

### Other

- flatten workspace — move crates from crates/ to repo root
</blockquote>

## `flowlog-build`

<blockquote>

## [0.3.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.2...flowlog-build-v0.3.3) - 2026-06-13

### Other

- flatten workspace — move crates from crates/ to repo root
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).