### PR TITLE
fix(parser): reject non-constant ground facts instead of panicking

### DIFF
--- a/flowlog-build/src/parser/logic/rule.rs
+++ b/flowlog-build/src/parser/logic/rule.rs
@@ -173,25 +173,29 @@ impl FlowLogRule {
 
     /// Extract constants from a fact's head.
     ///
-    /// Panics if any head argument is not a simple constant.
-    #[must_use]
-    pub(crate) fn extract_constants_from_head(&self) -> Vec<ConstType> {
+    /// Returns [`ParseError::GroundRuleNotConst`] if any head argument is not a
+    /// simple constant — e.g. an unbound variable (`k(E).`), an aggregation, or
+    /// a non-constant arithmetic expression. Such a head names no ground tuple,
+    /// so it is rejected here rather than panicking downstream.
+    pub(crate) fn extract_constants_from_head(&self) -> Result<Vec<ConstType>, ParseError> {
         let args = self.head.head_arguments();
         let mut out = Vec::with_capacity(args.len());
+        let not_const = || ParseError::GroundRuleNotConst {
+            span: self.head.span(),
+        };
         for arg in args {
             let HeadArg::Arith(arith) = arg else {
-                panic!("Fact head must contain only constants: {self}");
+                return Err(not_const());
             };
             let Factor::Const(c) = arith.init() else {
-                panic!("Fact head must contain only constants: {self}");
+                return Err(not_const());
             };
-            assert!(
-                arith.is_const(),
-                "Fact head must contain only constants: {self}"
-            );
+            if !arith.is_const() {
+                return Err(not_const());
+            }
             out.push(c.clone());
         }
-        out
+        Ok(out)
     }
 
     /// Expand a multi-head / multi-body rule into one rule per
@@ -381,31 +385,35 @@ mod tests {
             ],
         );
         let r = FlowLogRule::new(head, vec![]);
-        let c = r.extract_constants_from_head();
+        let c = r.extract_constants_from_head().expect("all-const head");
         assert_eq!(c, vec![ConstType::Int(42), ConstType::Text("hello".into())]);
     }
 
-    #[test]
-    #[should_panic(expected = "Fact head must contain only constants")]
-    fn extract_constants_panics_on_var() {
-        let head = head_named(
-            "invalid",
-            vec![head_const(ConstType::Int(1)), HeadArg::Var("X".into())],
+    // A head argument that is not a bare constant — a variable, an aggregation,
+    // or an arithmetic expression with operators — must yield
+    // `GroundRuleNotConst`, not a panic.
+    fn assert_head_arg_rejected(invalid: HeadArg) {
+        let head = head_named("invalid", vec![head_const(ConstType::Int(1)), invalid]);
+        let err = FlowLogRule::new(head, vec![])
+            .extract_constants_from_head()
+            .expect_err("non-constant head arg must be rejected");
+        assert!(
+            matches!(err, ParseError::GroundRuleNotConst { .. }),
+            "expected GroundRuleNotConst, got {err:?}"
         );
-        let _ = FlowLogRule::new(head, vec![]).extract_constants_from_head();
     }
 
     #[test]
-    #[should_panic(expected = "Fact head must contain only constants")]
-    fn extract_constants_panics_on_aggregation() {
+    fn extract_constants_rejects_var() {
+        assert_head_arg_rejected(HeadArg::Var("X".into()));
+    }
+
+    #[test]
+    fn extract_constants_rejects_aggregation() {
         let agg = Aggregation::new(
             AggregationOperator::Sum,
             Arithmetic::new(Factor::Var("X".into()), vec![]),
         );
-        let head = head_named(
-            "invalid",
-            vec![head_const(ConstType::Int(1)), HeadArg::Aggregation(agg)],
-        );
-        let _ = FlowLogRule::new(head, vec![]).extract_constants_from_head();
+        assert_head_arg_rejected(HeadArg::Aggregation(agg));
     }
 }

--- a/flowlog-build/src/parser/program.rs
+++ b/flowlog-build/src/parser/program.rs
@@ -929,7 +929,7 @@ impl Program {
             ..Self::default()
         };
         for fact in raw_facts {
-            program.extract_fact(fact);
+            program.extract_fact(fact)?;
         }
 
         program.validate_relation_references()?;
@@ -1268,11 +1268,12 @@ impl Program {
 
     /// Insert a ground-tuple fact into `self.facts`, preserving the head
     /// span so the typechecker can cite the offending source position.
-    fn extract_fact(&mut self, fact_rule: FlowLogRule) {
+    fn extract_fact(&mut self, fact_rule: FlowLogRule) -> Result<(), ParseError> {
         let rel_name = fact_rule.head().name().to_string();
         let span = fact_rule.head().span();
-        let tuple = fact_rule.extract_constants_from_head();
+        let tuple = fact_rule.extract_constants_from_head()?;
         self.facts.entry(rel_name).or_default().push((span, tuple));
+        Ok(())
     }
 }
 

--- a/flowlog-build/tests/errors/parser/ground_fact_not_const.dl
+++ b/flowlog-build/tests/errors/parser/ground_fact_not_const.dl
@@ -1,0 +1,2 @@
+.decl k(x: number)
+k(E).

--- a/flowlog-build/tests/parser_errors.rs
+++ b/flowlog-build/tests/parser_errors.rs
@@ -91,6 +91,18 @@ fn undeclared_in_fact() {
     );
 }
 
+// A ground fact whose head holds a variable (`k(E).`) names no tuple. It must
+// be a clean parse error, not a panic. Regression for the fuzz-found crash in
+// https://github.com/flowlog-rs/flowlog/issues/182.
+#[test]
+fn ground_fact_not_const() {
+    assert_err!(
+        parse("ground_fact_not_const.dl", true),
+        ParseError::GroundRuleNotConst { .. },
+        ["not a constant fact"]
+    );
+}
+
 #[test]
 fn non_nullary_loop_condition() {
     assert_err!(


### PR DESCRIPTION
## What

Fuzzing the Datalog parser found a crash on the 5-byte input `k(E).` (issue #182). It parses as a *ground fact* whose head argument `E` is a variable, and `FlowLogRule::extract_constants_from_head` was written to `panic!` on any non-constant head argument — so malformed user input crashed the parser instead of returning a clean error.

## Root cause

The grammar accepts `atom .` as a `fact` and permits *variables* in atom arguments, but the semantics require a fact head to be a **ground tuple** (constants only). The direct-fact path (`Rule::fact` → `raw_facts` → `extract_fact` → `extract_constants_from_head`) never validated groundness — it guarded the precondition with a `panic!` ("this can't happen"). The sibling **desugar** path already returns `ParseError::GroundRuleNotConst` for the equivalent case, so the correct error and handling already existed; only this path was unconverted.

## Fix

- `extract_constants_from_head` now returns `Result<Vec<ConstType>, ParseError>`, yielding the existing `ParseError::GroundRuleNotConst` for a variable, aggregation, or operator-bearing arithmetic head argument — instead of panicking.
- `extract_fact` returns `Result<(), ParseError>`; the `raw_facts` loop propagates with `?`.
- The two `#[should_panic]` unit tests were flipped to assert `Err(GroundRuleNotConst)` (they were locking in the wrong contract).
- Added a regression fixture + `parser_errors::ground_fact_not_const` test so `k(E).` is permanently covered by a rust test, not only by fuzzing.

No behavior change for valid programs: this only converts an internal panic into an already-rendered user-facing parse error.

## Verification

- `cargo clippy -p flowlog-build --all-targets -- -D warnings` — clean
- full `flowlog-build` test suite (218 unit + integration) — green, incl. the new `ground_fact_not_const`

Fixes #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)