### PR TITLE
chore: flowlog-build release v0.3.4, flowlog-cogmpiler release v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-compiler"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "clap",
  "codespan-reporting",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "flowlog-build"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "codespan-reporting",

--- a/flowlog-build/CHANGELOG.md
+++ b/flowlog-build/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.3...flowlog-build-v0.3.4) - 2026-06-18
+
+### Fixed
+
+- *(parser)* reject non-constant ground facts instead of panicking ([#184](https://github.com/flowlog-rs/flowlog/pull/184))
+
+### Other
+
+- add typos spell-check gate
+
 ## [0.3.3](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.2...flowlog-build-v0.3.3) - 2026-06-13
 
 ### Other

--- a/flowlog-build/Cargo.toml
+++ b/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/flowlog-compiler/Cargo.toml
+++ b/flowlog-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-compiler"
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `flowlog-build`: 0.3.3 -> 0.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.3...flowlog-build-v0.3.4) - 2026-06-18

### Fixed

- *(parser)* reject non-constant ground facts instead of panicking ([#184](https://github.com/flowlog-rs/flowlog/pull/184))

### Other

- add typos spell-check gate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).