### PR TITLE
chore: release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @flowlog-rs/committers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @flowlog-rs/committers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "flowlog-build"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-runtime"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "differential-dataflow",
  "lasso",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-test = "0.2"
 
 # Internal crates.
-flowlog-build = { path = "flowlog-build", version = "0.3.4" }
+flowlog-build = { path = "flowlog-build", version = "0.4.0" }
 flowlog-common = { path = "flowlog-common", version = "0.1.0" }
 flowlog-parser = { path = "flowlog-parser", version = "0.1.0" }
 flowlog-profiler = { path = "flowlog-profiler", version = "0.1.0" }

--- a/flowlog-build/CHANGELOG.md
+++ b/flowlog-build/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.4...flowlog-build-v0.4.0) - 2026-07-02
+
+### Other
+
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
+- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
+- support tuple syntax ([#194](https://github.com/flowlog-rs/flowlog/pull/194))
+
 ## [0.3.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.3...flowlog-build-v0.3.4) - 2026-06-18
 
 ### Fixed

--- a/flowlog-build/Cargo.toml
+++ b/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.3.4"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/flowlog-common/CHANGELOG.md
+++ b/flowlog-common/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-common-v0.1.0) - 2026-07-02
+
+### Other
+
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))

--- a/flowlog-parser/CHANGELOG.md
+++ b/flowlog-parser/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-parser-v0.1.0) - 2026-07-02
+
+### Other
+
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))

--- a/flowlog-profiler/CHANGELOG.md
+++ b/flowlog-profiler/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-profiler-v0.1.0) - 2026-07-02
+
+### Other
+
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
+- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))

--- a/flowlog-runtime/CHANGELOG.md
+++ b/flowlog-runtime/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.5...flowlog-runtime-v0.2.6) - 2026-07-02
+
+### Other
+
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
+- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
+
 ## [0.2.5](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.4...flowlog-runtime-v0.2.5) - 2026-06-13
 
 ### Other

--- a/flowlog-runtime/Cargo.toml
+++ b/flowlog-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flowlog-runtime"
 # The runtime releases on its own cadence — generated code depends on it
 # by published version, so any additive change ships as an independent bump.
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `flowlog-runtime`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `flowlog-common`: 0.1.0
* `flowlog-parser`: 0.1.0
* `flowlog-profiler`: 0.1.0
* `flowlog-build`: 0.3.4 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `flowlog-build` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum flowlog_build::ExecutionMode, previously in file /tmp/.tmpVgOfG0/flowlog-build/src/common/config.rs:10
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-runtime`

<blockquote>

## [0.2.6](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.5...flowlog-runtime-v0.2.6) - 2026-07-02

### Other

- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
</blockquote>

## `flowlog-common`

<blockquote>

## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-common-v0.1.0) - 2026-07-02

### Other

- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
</blockquote>

## `flowlog-parser`

<blockquote>

## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-parser-v0.1.0) - 2026-07-02

### Other

- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
</blockquote>

## `flowlog-profiler`

<blockquote>

## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-profiler-v0.1.0) - 2026-07-02

### Other

- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
</blockquote>

## `flowlog-build`

<blockquote>

## [0.4.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.4...flowlog-build-v0.4.0) - 2026-07-02

### Other

- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
- support tuple syntax ([#194](https://github.com/flowlog-rs/flowlog/pull/194))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).