### PR TITLE
perf(build): skip deduplication for guaranteed set inputs

### DIFF
--- a/flowlog-build/src/build/pipeline.rs
+++ b/flowlog-build/src/build/pipeline.rs
@@ -97,6 +97,7 @@ fn build_config(builder: &Builder, program: &str) -> Config {
         profile: builder.profile,
         sip: builder.sip,
         str_intern: builder.string_intern,
+        assume_set_inputs: builder.assume_set_inputs,
         udf_file: builder
             .udf_file
             .as_ref()

--- a/flowlog-build/src/codegen/edb_handles.rs
+++ b/flowlog-build/src/codegen/edb_handles.rs
@@ -17,7 +17,11 @@ impl CodeGen {
     /// let (h_<rel>, <rel>) = scope.new_collection::<_, Diff>();
     /// ```
     pub(crate) fn gen_edb_decls(&mut self, profiler: &mut Option<Profiler>) -> Vec<TokenStream> {
-        let normalize = self.dedup_nonrecursive();
+        let normalize = if self.config.assume_set_inputs {
+            quote! {}
+        } else {
+            self.dedup_nonrecursive()
+        };
 
         let edbs = self.program.edbs();
         if edbs.is_empty() {

--- a/flowlog-build/src/lib.rs
+++ b/flowlog-build/src/lib.rs
@@ -113,6 +113,7 @@ pub fn compile<P: AsRef<Path>>(program_path: P) -> io::Result<()> {
 pub struct Builder {
     pub(crate) sip: bool,
     pub(crate) string_intern: bool,
+    pub(crate) assume_set_inputs: bool,
     pub(crate) mode: ExecutionMode,
     pub(crate) profile: bool,
     pub(crate) include_dirs: Vec<PathBuf>,
@@ -130,6 +131,14 @@ impl Builder {
     /// interning is applied at `insert_<rel>` / drain.
     pub fn string_intern(mut self, enabled: bool) -> Self {
         self.string_intern = enabled;
+        self
+    }
+
+    /// Skip the per-input dedup normalize, assuming the driver stages
+    /// set-semantic (already-deduplicated) inputs. Library-mode optimization;
+    /// unsound if inputs may contain duplicates. Defaults to `false`.
+    pub fn assume_set_inputs(mut self, enabled: bool) -> Self {
+        self.assume_set_inputs = enabled;
         self
     }
 

--- a/flowlog-build/src/lib.rs
+++ b/flowlog-build/src/lib.rs
@@ -135,7 +135,7 @@ impl Builder {
     }
 
     /// Skip the per-input dedup normalize, assuming the driver stages
-    /// set-semantic (already-deduplicated) inputs. Library-mode optimization;
+    /// set-semantic (already-deduplicated) inputs.
     /// unsound if inputs may contain duplicates. Defaults to `false`.
     pub fn assume_set_inputs(mut self, enabled: bool) -> Self {
         self.assume_set_inputs = enabled;

--- a/flowlog-common/src/config.rs
+++ b/flowlog-common/src/config.rs
@@ -48,7 +48,7 @@ pub struct Config {
     /// Intern string columns as compact integer keys at load time.
     pub str_intern: bool,
     /// Assume driver-staged inputs are already set-semantic (deduplicated),
-    /// so skip the per-input dedup normalize. Library-mode optimization;
+    /// so skip the per-input dedup normalize.
     /// unsound if the driver may stage duplicate input tuples. Defaults to `false`.
     pub assume_set_inputs: bool,
     /// Path to a Rust source file containing UDF implementations.

--- a/flowlog-common/src/config.rs
+++ b/flowlog-common/src/config.rs
@@ -47,6 +47,10 @@ pub struct Config {
     pub sip: bool,
     /// Intern string columns as compact integer keys at load time.
     pub str_intern: bool,
+    /// Assume driver-staged inputs are already set-semantic (deduplicated),
+    /// so skip the per-input dedup normalize. Library-mode optimization;
+    /// unsound if the driver may stage duplicate input tuples. Defaults to `false`.
+    pub assume_set_inputs: bool,
     /// Path to a Rust source file containing UDF implementations.
     pub udf_file: Option<String>,
     /// Extra search directories for `.include` directives.

--- a/flowlog-compiler/src/cli.rs
+++ b/flowlog-compiler/src/cli.rs
@@ -51,6 +51,13 @@ pub struct Cli {
     #[arg(long)]
     pub str_intern: bool,
 
+    /// Assume input fact sources are already set-semantic (contain no
+    /// duplicate tuples), and skip the per-input dedup normalize. Speeds up
+    /// loading; unsound if any input may contain duplicate rows, so it is
+    /// opt-in and defaults to off.
+    #[arg(long)]
+    pub assume_set_inputs: bool,
+
     /// Path to a Rust source file containing UDF implementations.
     /// Functions declared with `.extern fn` in the Datalog
     /// program must be defined in this file.
@@ -83,6 +90,7 @@ impl Cli {
             profile: self.profile,
             sip: self.sip,
             str_intern: self.str_intern,
+            assume_set_inputs: self.assume_set_inputs,
             udf_file: self.udf_file.clone(),
             include_dirs: self.include_dirs.clone(),
             output_to_stdout: self.output_dir.as_deref() == Some("-"),


### PR DESCRIPTION
Allow callers that already provide set inputs to skip input deduplication through `Builder::assume_set_inputs(bool)`, `--assume-set-inputs`, or the shared `Config`. The option defaults to `false`.

Batch inputs must contain no duplicate tuples. Incremental inputs must keep each tuple's accumulated weight at zero or one after each commit, across all workers; deduplicating each individual update batch alone is insufficient. Violating this contract can produce incorrect results.

Rebased onto `main` and adapted to the current `flowlog_dedup` and `PlanGraph` APIs. Profiling omits the skipped dedup node too, keeping subsequent operator addresses aligned with the generated dataflow. Rule and output deduplication remain enabled.

Validation:

- Workspace tests and doctests with all features and locked dependencies passed.
- Clippy with all targets/features, nightly rustfmt, and spelling checks passed.
- Compiler smoke tests passed for batch and incremental recursive transitive closure, with the option both enabled and disabled, profiling enabled, and two workers. Verified expected relation outputs and presence/absence of the input dedup node.
- Library smoke tests passed for batch and incremental recursive transitive closure using `Builder::assume_set_inputs(true)` and two workers, including insertions and retractions.

GitHub CI has been triggered on the rebased branch. The PR remains draft.
