### PR TITLE
fix(profiler): count a fused union as one operator, not k-1

### DIFF
--- a/flowlog-build/src/codegen/flow/non_recursive.rs
+++ b/flowlog-build/src/codegen/flow/non_recursive.rs
@@ -95,12 +95,18 @@ impl CodeGen {
 
             // Fold into the existing binding rather than shadowing it.
             let already_bound = bound_fps.contains(idb_fp);
+            // `concat_count` is the number of Timely union operators emitted,
+            // which the profiler advances its predicted address range by. An
+            // n-ary `concatenate` is a *single* Timely operator regardless of
+            // arity, so every union below is exactly one operator (a lone head
+            // is zero) — not `k-1`, which is what a chain of binary `concat`s
+            // used to cost before the fusion.
             let (concat_expr, concat_count) = if already_bound {
                 // Base = existing binding; union in every per-head collection
                 // via one operator.
                 (
                     quote! { #output.concatenate([ #( #outs.clone() ),* ]) },
-                    outs.len() as u32,
+                    1,
                 )
             } else if tail.is_empty() {
                 // Single head: no union operator at all.
@@ -109,7 +115,7 @@ impl CodeGen {
                 // Base = first head; union in the rest via one operator.
                 (
                     quote! { #head.clone().concatenate([ #( #tail.clone() ),* ]) },
-                    outs.len() as u32 - 1,
+                    1,
                 )
             };
 

--- a/flowlog-build/src/codegen/flow/recursive.rs
+++ b/flowlog-build/src/codegen/flow/recursive.rs
@@ -291,7 +291,12 @@ impl CodeGen {
 
             with_profiler(profiler, |profiler| {
                 let source_names: Vec<String> = sources.iter().map(|id| id.to_string()).collect();
-                let concat_count = (sources.len() as u32).saturating_sub(1);
+                // `union_expr` emits a single n-ary `concatenate` (one Timely
+                // operator) when there is a tail to merge, or a plain clone (no
+                // operator) for a lone source — so the profiler must advance by
+                // 1 or 0, not `k-1`, to keep its predicted address range in
+                // lockstep with the emitted dataflow.
+                let concat_count = u32::from(!tail.is_empty());
                 profiler.concat_dedup_operator(
                     self.display_name(*idb_fp),
                     source_names,


### PR DESCRIPTION
## Problem

Running the profiler (`flowlog-compiler -P`) on `main-next-for-sasy` produces a **wrong plan graph** whenever a rule head has **≥3 sources** (the exact case the concat-fusion optimizes).

`#205 (perf/concat-fusion)` replaced each chain of `k-1` binary `.concat()`s with one n‑ary `Collection::concatenate` — a **single** Timely `Concatenate` operator regardless of arity. But the profiler was still told the union costs `k-1` operators via `concat_count`:

- `Profiler::concat_dedup_operator` advances the predicted timely‑address range by `concat_count + dedup` (`Addr::advance`).
- So for every `k≥3` head union it reserved **`k-2` phantom operator addresses**, shifting the predicted address of every downstream operator.

The baked `ops.json` then no longer lines up with the real dataflow, and `flowlog-visualizer` reports `"… addr not found in time log"` for the tail of the plan. (No test exercises `-P`, so this slipped through.)

## Root cause

`concat_count` is meant to be *the number of Timely union operators emitted*. Fusion changed the emitted operator count (`k-1` → `1`) but not the value handed to the profiler:

- `flow/non_recursive.rs`: `outs.len()` / `outs.len() - 1`
- `flow/recursive.rs`: `sources.len() - 1`

## Fix

Set `concat_count` to the **actual** operator count of the fused union: `1` for any `concatenate` (any arity), `0` for a lone‑head passthrough — at both fused sites. Only the value passed to the profiler changes; the emitted dataflow (`concat_expr` / `union_expr`) is untouched, so **non‑profiling builds are byte‑identical** (verified: `concat_count` is used only inside the `with_profiler` closure).

## Validation (`-P`, end‑to‑end: compile → run → `flowlog-visualizer`)

- 3‑way non‑recursive head union: **1 phantom `addr not found` → 0** after the fix; the `concat & dedup` node drops from 5 predicted addresses (2 phantom concat + 3 dedup) to 4, matching the single actual `Concatenate` + 3 dedup.
- `k=3` recursive‑scope union: node now predicts **1** concat operator, matching the single actual recursive `Concatenate`.
- Output/decision parity unaffected (functional‑neutral change).

## Scope note

This PR fixes only the concat‑fusion regression. The profiler has other **pre‑existing** address‑model gaps unrelated to this change (e.g. identity‑projection elision still predicts the elided head `Map`s; recursive‑loop/semijoin‑arrange operator accounting), which show up as additional visualizer mismatches on programs that use those features. Those are out of scope here and worth a separate follow‑up (ideally with a `-P` regression test, which is currently missing).