### PR TITLE
[w3] Fuse spanning equalities into join keys (11–16× on DOOP type-object analyses; byte-exact; beats Souffle)

### DIFF
--- a/flowlog-build/src/catalog/arithmetic.rs
+++ b/flowlog-build/src/catalog/arithmetic.rs
@@ -256,6 +256,16 @@ impl ArithmeticPos {
         &self.rest
     }
 
+    /// Whether this position is a bare variable reference (no arithmetic tail and
+    /// no derivation on the initial factor). Such a position is a plain column of
+    /// its atom and can be selected by index; anything else (a tuple projection,
+    /// builtin, UDF call, constant, …) is a *computed* value that must be
+    /// materialized rather than selected.
+    #[inline]
+    pub(crate) fn is_plain_var(&self) -> bool {
+        self.rest.is_empty() && self.init.as_var_signature().is_some()
+    }
+
     /// Returns a vector of all variable signatures referenced in this expression, in order.
     pub(crate) fn signatures(&self) -> Vec<&AtomArgumentSignature> {
         let mut sigs = self.init.signatures();

--- a/flowlog-build/src/catalog/rule.rs
+++ b/flowlog-build/src/catalog/rule.rs
@@ -8,7 +8,7 @@ use crate::catalog::{
     FnCallPredicatePos,
 };
 use crate::common::{SECTION_BAR, SUBSECTION_BAR};
-use crate::parser::{ComparisonExpr, FlowLogRule, FnCall, HeadArg, Predicate};
+use crate::parser::{Arithmetic, ComparisonExpr, ComparisonOperator, FlowLogRule, FnCall, HeadArg, Predicate};
 use tracing::debug;
 
 // Implementation modules
@@ -411,6 +411,62 @@ impl Catalog {
             &left_var_signatures,
             &right_var_signatures,
         ))
+    }
+
+    /// Equi-join fusion: for each equality comparison `L = R` whose left side is
+    /// fully grounded in positive atom `lhs_idx` and right side in `rhs_idx` (or
+    /// vice-versa), return the `(lhs_key, rhs_key)` computed-key pair so the
+    /// caller can key the join on `L == R` (a hash join) instead of a cross-join
+    /// plus a post-join filter.
+    ///
+    /// Only `=` comparisons qualify, and only *spanning* ones (empty superset —
+    /// not evaluable against any single atom yet). Fresh-variable equalities
+    /// (`z = g(x)`) are desugared to bindings upstream, so `comparison_predicates`
+    /// only ever holds equalities between two already-grounded expressions, which
+    /// is exactly what is safe to fuse into a join key.
+    pub(crate) fn equijoin_keys_for_pair(
+        &self,
+        lhs_idx: usize,
+        rhs_idx: usize,
+    ) -> Vec<(ArithmeticPos, ArithmeticPos)> {
+        // Resolve every variable of `arith` to its signature in positive atom
+        // `atom_idx`; returns None if any variable is absent from that atom (so
+        // the side does not live wholly inside `atom_idx`).
+        let resolve = |arith: &Arithmetic, atom_idx: usize| -> Option<ArithmeticPos> {
+            let mut sigs = Vec::new();
+            for v in arith.vars() {
+                let sig = self
+                    .argument_presence_in_positive_atom_map
+                    .get(v)
+                    .and_then(|row| row.get(atom_idx).copied().flatten())?;
+                sigs.push(sig);
+            }
+            Some(ArithmeticPos::from_arithmetic(arith, &sigs))
+        };
+
+        let mut out = Vec::new();
+        for (comp_id, comp) in self.comparison_predicates.iter().enumerate() {
+            if *comp.operator() != ComparisonOperator::Equal {
+                continue;
+            }
+            // Skip comparisons already coverable by a single atom (within-atom
+            // filters / already-joined) — only genuine cross-atom equalities.
+            if !self.comparison_supersets[comp_id].is_empty() {
+                continue;
+            }
+            if let (Some(l), Some(r)) =
+                (resolve(comp.left(), lhs_idx), resolve(comp.right(), rhs_idx))
+            {
+                out.push((l, r));
+            } else if let (Some(l), Some(r)) =
+                (resolve(comp.left(), rhs_idx), resolve(comp.right(), lhs_idx))
+            {
+                // left lives in the rhs atom, right in the lhs atom: swap so that
+                // the first element always keys `lhs_idx`.
+                out.push((r, l));
+            }
+        }
+        out
     }
 
     // === FnCall Predicates ===

--- a/flowlog-build/src/planner/rule_planner/core.rs
+++ b/flowlog-build/src/planner/rule_planner/core.rs
@@ -116,22 +116,44 @@ impl RulePlanner {
         )?;
 
         // Partition arguments into join keys and payload values
-        let (lhs_keys, lhs_vals, rhs_keys, rhs_vals) = Self::partition_shared_keys(
+        let (mut lhs_keys, lhs_vals, mut rhs_keys, rhs_vals) = Self::partition_shared_keys(
             catalog,
             left_atom_argument_signatures,
             right_atom_argument_signatures,
         );
-        fn labelled<'a>(
-            positions: &'a [ArithmeticPos],
-            catalog: &'a Catalog,
-        ) -> Vec<(&'a ArithmeticPos, &'a String)> {
+
+        // Equi-join fusion (see `Catalog::equijoin_keys_for_pair`): when the two
+        // atoms share no bare variable — which would otherwise force an empty-key
+        // cross-join plus a post-join filter, i.e. an O(|L|·|R|) blow-up — key the
+        // join on a spanning equality `L == R` computed from the two sides, where
+        // `L` is grounded wholly in one atom and `R` in the other. This turns e.g.
+        // the DOOP `ContextResponse` join `hctx.0 == hctxValue` (a tuple
+        // projection) or an arithmetic `x + 1 == y + 2` into a real hash join.
+        //
+        // The companion layout change in `fuse.rs`/`transformation/info.rs`
+        // (`refactor_output_key_value_layout`) carries the *computed* key
+        // `ArithmeticPos` through to the input-arrangement reshape so it
+        // materializes the derived key instead of collapsing to the base column.
+        // Fresh-variable equalities (`z = g(x)`) are desugared to bindings before
+        // planning, so only both-sides-grounded equalities ever reach here — the
+        // only ones safe to fuse. The join closure keeps the equality as a
+        // redundant residual, so correctness holds even for unforeseen shapes.
+        const ENABLE_EQUIJOIN_FUSION: bool = true;
+        let mut fused_equijoin = false;
+        if ENABLE_EQUIJOIN_FUSION && lhs_keys.is_empty() {
+            for (l, r) in catalog.equijoin_keys_for_pair(lhs_idx, rhs_idx) {
+                lhs_keys.push(l);
+                rhs_keys.push(r);
+                fused_equijoin = true;
+            }
+        }
+
+        fn labelled(positions: &[ArithmeticPos], catalog: &Catalog) -> Vec<String> {
             positions
                 .iter()
-                .map(|pos| {
-                    (
-                        pos,
-                        catalog.signature_to_argument_str(pos.init().as_var_signature().unwrap()),
-                    )
+                .map(|pos| match pos.init().as_var_signature() {
+                    Some(sig) => catalog.signature_to_argument_str(sig).clone(),
+                    None => pos.to_string(),
                 })
                 .collect()
         }
@@ -139,19 +161,38 @@ impl RulePlanner {
         trace!("Join LHS values: {:?}", labelled(&lhs_vals, catalog));
         trace!("Join RHS values: {:?}", labelled(&rhs_vals, catalog));
 
-        // Construct output argument list: keys + LHS values + RHS values
-        let new_arguments_list: Vec<AtomArgumentSignature> = lhs_keys
-            .iter()
-            .chain(lhs_vals.iter())
-            .chain(rhs_vals.iter())
-            .map(|pos| *pos.init().as_var_signature().unwrap())
-            .collect();
+        // Construct output argument list. A fused equi-join keys on a spanning
+        // equality whose sides may be computed (e.g. `hctx.0`) and are not
+        // necessarily distinct output columns, so the join emits just the two
+        // payloads (the base variables already live in the values); a plain
+        // shared-variable join instead emits its single shared key once.
+        let new_arguments_list: Vec<AtomArgumentSignature> = if fused_equijoin {
+            lhs_vals
+                .iter()
+                .chain(rhs_vals.iter())
+                .map(|pos| *pos.init().as_var_signature().unwrap())
+                .collect()
+        } else {
+            lhs_keys
+                .iter()
+                .chain(lhs_vals.iter())
+                .chain(rhs_vals.iter())
+                .map(|pos| *pos.init().as_var_signature().unwrap())
+                .collect()
+        };
 
         // Create the join transformation with proper key-value layouts
         let lhs_name = catalog.positive_atom_name(lhs_idx)?.to_string();
         let rhs_name = catalog.positive_atom_name(rhs_idx)?.to_string();
         let lhs_key_names = Self::attrs_from_positions(&lhs_keys, catalog);
         let new_name = Self::join_name(&lhs_name, &rhs_name, &lhs_key_names);
+        // The joined output keeps a shared-variable key (if any); a fused
+        // equi-join produces an unkeyed payload (re-keyed later as needed).
+        let output_key = if fused_equijoin {
+            Vec::new()
+        } else {
+            lhs_keys.clone()
+        };
         let tx = TransformationInfo::join_to_kv(
             lhs_pos_fp,
             lhs_name,
@@ -161,7 +202,7 @@ impl RulePlanner {
             KeyValueLayout::new(lhs_keys.clone(), lhs_vals.clone()),
             KeyValueLayout::new(rhs_keys.clone(), rhs_vals.clone()),
             KeyValueLayout::new(
-                lhs_keys,
+                output_key,
                 lhs_vals.iter().chain(rhs_vals.iter()).cloned().collect(),
             ),
             JoinPredicates::default(),
@@ -279,6 +320,73 @@ mod tests {
         assert!(
             catalog.is_planned(),
             "catalog should be flagged planned after a complete 2-atom join"
+        );
+    }
+
+    /// `Out(x, y) :- A(x), B(y), x + 1 = y + 2.` — the two atoms share no
+    /// bare variable, so a name-only join key search finds nothing and would
+    /// emit an empty-key cross-join with `x+1 = y+2` as a post-filter (an
+    /// O(|A|·|B|) blow-up). Equi-join fusion must instead key the join on the
+    /// spanning equality: the LHS input keyed on the *computed* `x + 1`, the
+    /// RHS on `y + 2`. This is the general form of the DOOP tuple-projection
+    /// join (`hctx.0 = hctxValue`) that the fusion was built to accelerate.
+    #[test]
+    fn core_fuses_spanning_computed_equality_into_join_key() {
+        let (mut planner, mut catalog) = test_setup(
+            "\
+            .decl A(x: int32)\n\
+            .decl B(y: int32)\n\
+            .decl Out(x: int32, y: int32)\n\
+            .input A(IO=\"file\", filename=\"A.csv\", delimiter=\",\")\n\
+            .input B(IO=\"file\", filename=\"B.csv\", delimiter=\",\")\n\
+            .output Out\n\
+            Out(x, y) :- A(x), B(y), x + 1 = y + 2.\n",
+        );
+        planner.prepare(&mut catalog).expect("prepare");
+
+        let x_in_a = catalog.positive_atom_argument_signature(0)[0];
+        let y_in_b = catalog.positive_atom_argument_signature(1)[0];
+
+        planner.core(&mut catalog, (0, 1)).expect("core");
+
+        let join = planner
+            .transformation_infos()
+            .iter()
+            .find(|t| matches!(t, TransformationInfo::JoinToKV { .. }))
+            .expect("JoinToKV transformation missing");
+
+        let (left, right) = join.input_kv_layout();
+        let right = right.expect("JoinToKV has a right input layout");
+
+        // The join must be keyed (not an empty-key cross product) …
+        assert_eq!(left.key().len(), 1, "LHS keyed on the fused equality");
+        assert_eq!(right.key().len(), 1, "RHS keyed on the fused equality");
+
+        // … and each key must be a *computed* expression (`x+1`, `y+2`),
+        // not a bare column — that is the whole point of the fusion.
+        assert!(
+            !left.key()[0].is_plain_var(),
+            "LHS join key must be the computed `x + 1`, not a bare variable"
+        );
+        assert!(
+            !right.key()[0].is_plain_var(),
+            "RHS join key must be the computed `y + 2`, not a bare variable"
+        );
+
+        // The computed keys must be rooted at the correct source variables.
+        assert!(
+            left.key()[0].signatures().contains(&&x_in_a),
+            "LHS key `x + 1` must reference `x` from A"
+        );
+        assert!(
+            right.key()[0].signatures().contains(&&y_in_b),
+            "RHS key `y + 2` must reference `y` from B"
+        );
+
+        assert_eq!(
+            catalog.positive_atom_number(),
+            1,
+            "two atoms must collapse into one after the fused join"
         );
     }
 }

--- a/flowlog-build/src/planner/rule_planner/fuse.rs
+++ b/flowlog-build/src/planner/rule_planner/fuse.rs
@@ -25,11 +25,17 @@ use crate::parser::ConstType;
 use crate::planner::{KeyValueLayout, PlanError, TransformationInfo};
 
 /// Ordered consumer indices alongside their key/value index selections.
-/// (minimum consumer id, consumer ids, key indices, value indices)
-type ConsumerLayout = (usize, Vec<usize>, Vec<usize>, Vec<usize>);
+/// (minimum consumer id, consumer ids, key indices, value indices, key positions)
+///
+/// `key positions` carries the consumer's full key layout (the join input
+/// `ArithmeticPos` list). For a plain-variable key it is redundant with
+/// `key indices`; for a *computed* key (e.g. a tuple projection `hctx.0` or a
+/// builtin `ord(x)`), it preserves the expression so the producer reshape can
+/// materialize the derived value instead of collapsing to the base column.
+type ConsumerLayout = (usize, Vec<usize>, Vec<usize>, Vec<usize>, Vec<ArithmeticPos>);
 /// Assigned producer indices with their consumers and key/value index selections.
-/// (assigned producer ids, consumer ids, key indices, value indices)
-type LayoutAssignment = (Vec<usize>, Vec<usize>, Vec<usize>, Vec<usize>);
+/// (assigned producer ids, consumer ids, key indices, value indices, key positions)
+type LayoutAssignment = (Vec<usize>, Vec<usize>, Vec<usize>, Vec<usize>, Vec<ArithmeticPos>);
 
 // =========================================================================
 // Fusion
@@ -206,7 +212,8 @@ impl RulePlanner {
             let producer_consumer_assignments =
                 Self::assign_layout_to_producer(tx_fp, &producer_indices, &consumer_layouts)?;
 
-            for (producers, consumers, key_indices, value_indices) in producer_consumer_assignments
+            for (producers, consumers, key_indices, value_indices, key_positions) in
+                producer_consumer_assignments
             {
                 trace!(
                     "[fuse_kv_layout] fuse at producer fp {:#018x} -> consumers {:?}; key ids: {:?}, value ids: {:?}",
@@ -217,7 +224,11 @@ impl RulePlanner {
                 for producer_idx in producers {
                     new_output_fp = {
                         let producer_tx = &mut self.transformation_infos[producer_idx];
-                        producer_tx.refactor_output_key_value_layout(&key_indices, &value_indices);
+                        producer_tx.refactor_output_key_value_layout(
+                            &key_indices,
+                            &value_indices,
+                            &key_positions,
+                        );
                         producer_tx.update_output_fake_sig();
                         producer_tx.output_info_fp()
                     };
@@ -510,9 +521,31 @@ impl RulePlanner {
         consumer_indices: &[usize],
         input_fp: u64,
     ) -> Result<Vec<ConsumerLayout>, PlanError> {
-        // Map from (key indices, value indices) to consumer ids
-        let mut layouts: BTreeMap<(Vec<usize>, Vec<usize>), Vec<usize>> = BTreeMap::new();
+        // Group key: (key indices, value indices, per-key-slot computed signature).
+        // The computed signature distinguishes consumers that share the same base
+        // argument ids but derive different keys from them (e.g. `hctx.0` vs
+        // `hctx.1`, both rooted at `hctx`), which must NOT share one arrangement.
+        type GroupKey = (Vec<usize>, Vec<usize>, Vec<String>);
+        // Map from group key to consumer ids.
+        let mut layouts: BTreeMap<GroupKey, Vec<usize>> = BTreeMap::new();
+        // Map from group key to the representative key positions (for reshape).
+        let mut group_key_positions: BTreeMap<GroupKey, Vec<ArithmeticPos>> = BTreeMap::new();
         let mut real_key_value_layout = None;
+
+        // Per-key-slot signature: empty for a plain column (index-selectable),
+        // the rendered expression for a computed key (must be materialized).
+        let key_signature = |positions: &[ArithmeticPos]| -> Vec<String> {
+            positions
+                .iter()
+                .map(|p| {
+                    if p.is_plain_var() {
+                        String::new()
+                    } else {
+                        p.to_string()
+                    }
+                })
+                .collect()
+        };
 
         // First pass: only join and antijoin contribute real key/value layout requirements.
         for &consumer_idx in consumer_indices {
@@ -555,10 +588,16 @@ impl RulePlanner {
                 }
                 let (key_indices, value_indices) =
                     matched_layout.extract_argument_ids_from_layout();
-                layouts
-                    .entry((key_indices, value_indices))
-                    .or_default()
-                    .push(consumer_idx);
+                let key_positions = matched_layout.key().to_vec();
+                let group: GroupKey = (
+                    key_indices,
+                    value_indices,
+                    key_signature(&key_positions),
+                );
+                group_key_positions
+                    .entry(group.clone())
+                    .or_insert(key_positions);
+                layouts.entry(group).or_default().push(consumer_idx);
             }
         }
 
@@ -585,26 +624,27 @@ impl RulePlanner {
             let atom_id = consumer_tx.input_kv_layout().0.extract_atom_id()?;
             consumer_tx.update_input_layout(Self::remap_atom_kv_layout(&layout, atom_id));
 
-            // Group this consumer under the same (key, value) indices as the joins.
-            let (key_indices, value_indices) = layouts.keys().next().cloned().ok_or_else(|| {
+            // Group this consumer under the same key as the joins (first group).
+            let group = layouts.keys().next().cloned().ok_or_else(|| {
                 PlanError::internal(format!(
                     "collect_consumer_layout_indices: consumer idx {consumer_idx} missing join/antijoin layout keys for producer fp {input_fp:#018x}"
                 ))
             })?;
-            layouts
-                .entry((key_indices, value_indices))
-                .or_default()
-                .push(consumer_idx);
+            layouts.entry(group).or_default().push(consumer_idx);
         }
 
         let mut consumer_collection: Vec<ConsumerLayout> = layouts
             .into_iter()
-            .map(|((key_ids, value_ids), mut consumers)| {
+            .map(|((key_ids, value_ids, sig), mut consumers)| {
                 consumers.sort_unstable();
-                (consumers[0], consumers, key_ids, value_ids)
+                let key_positions = group_key_positions
+                    .get(&(key_ids.clone(), value_ids.clone(), sig))
+                    .cloned()
+                    .unwrap_or_default();
+                (consumers[0], consumers, key_ids, value_ids, key_positions)
             })
             .collect();
-        consumer_collection.sort_by_key(|(first_consumer, _, _, _)| *first_consumer);
+        consumer_collection.sort_by_key(|(first_consumer, ..)| *first_consumer);
         Ok(consumer_collection)
     }
 
@@ -630,7 +670,7 @@ impl RulePlanner {
 
         let mut assignments = Vec::with_capacity(consumer_layouts.len());
 
-        for (first_consumer, consumers, key_ids, value_ids) in consumer_layouts {
+        for (first_consumer, consumers, key_ids, value_ids, key_positions) in consumer_layouts {
             // Feasibility check above guarantees at least one producer candidate.
             let producer_idx = available.pop_front().ok_or_else(|| {
                 PlanError::internal(
@@ -649,6 +689,7 @@ impl RulePlanner {
                 consumers.clone(),
                 key_ids.clone(),
                 value_ids.clone(),
+                key_positions.clone(),
             ));
         }
 
@@ -656,7 +697,7 @@ impl RulePlanner {
         // Randomly assign also works, for simplify code we just push to the first one.
         if !available.is_empty() {
             match assignments.first_mut() {
-                Some((producer_ids, _, _, _)) => {
+                Some((producer_ids, ..)) => {
                     producer_ids.extend(available);
                     producer_ids.sort_unstable();
                 }

--- a/flowlog-build/src/planner/transformation/info.rs
+++ b/flowlog-build/src/planner/transformation/info.rs
@@ -570,10 +570,20 @@ impl TransformationInfo {
     ///
     /// Necessary when the actual key/value split is known, e.g., after downstream
     /// join operators determine the key-value layout.
+    ///
+    /// `real_key_positions` carries the downstream consumer's full key layout,
+    /// slot-aligned with `real_key_indices`. When a key slot is a *computed*
+    /// expression (a tuple projection like `hctx.0`, or a builtin/UDF call) the
+    /// column-selection by index would collapse it to its base variable and drop
+    /// the derivation — the exact cause of an empty-key cross-join. For those
+    /// slots the computed position is installed directly, so the reshape (a
+    /// `RowToKv`) materializes the derived key. Plain-variable slots keep the
+    /// index-selection path, preserving any producer-side column rewriting.
     pub(crate) fn refactor_output_key_value_layout(
         &mut self,
         real_key_indices: &[usize],
         real_value_indices: &[usize],
+        real_key_positions: &[ArithmeticPos],
     ) {
         match self {
             Self::KVToKV {
@@ -598,24 +608,31 @@ impl TransformationInfo {
                     .cloned()
                     .collect();
 
-                let remap = |indices: &[usize]| -> Vec<ArithmeticPos> {
-                    indices
-                        .iter()
-                        .map(|idx| {
-                            all_positions.get(*idx).cloned().unwrap_or_else(|| {
-                                panic!(
-                                    "Planner error: 0x{:016x} output layout index {} out of bounds (len {})",
-                                    output_info_fp,
-                                    idx,
-                                    all_positions.len()
-                                )
-                            })
-                        })
-                        .collect()
+                let pick = |idx: usize| -> ArithmeticPos {
+                    all_positions.get(idx).cloned().unwrap_or_else(|| {
+                        panic!(
+                            "Planner error: 0x{:016x} output layout index {} out of bounds (len {})",
+                            output_info_fp,
+                            idx,
+                            all_positions.len()
+                        )
+                    })
                 };
 
-                *output_kv_layout =
-                    KeyValueLayout::new(remap(real_key_indices), remap(real_value_indices));
+                // Keys: install computed positions verbatim; select plain vars by index.
+                let new_key: Vec<ArithmeticPos> = real_key_indices
+                    .iter()
+                    .enumerate()
+                    .map(|(slot, idx)| match real_key_positions.get(slot) {
+                        Some(pos) if !pos.is_plain_var() => pos.clone(),
+                        _ => pick(*idx),
+                    })
+                    .collect();
+
+                let new_value: Vec<ArithmeticPos> =
+                    real_value_indices.iter().map(|idx| pick(*idx)).collect();
+
+                *output_kv_layout = KeyValueLayout::new(new_key, new_value);
             }
         }
     }


### PR DESCRIPTION
## TL;DR

When two body atoms share no bare variable, the planner emitted an **empty-key cross-join + post-join filter** — an `O(|L|·|R|)` blow-up. This PR **fuses a spanning equality `L == R` into the join key** (a real hash join), where `L` is grounded wholly in one atom and `R` in the other. It covers tuple-projection keys (the DOOP `hctx.0 == hctxValue`) and arithmetic keys (`x + 1 == y + 2`).

On the DOOP standalone suite this makes the three type-object analyses **11–16× faster**, is **byte-exact on all 19 families**, and makes **FlowLog beat Souffle on every family** (previously it lost these three by 6.5–7×).

## The problem

FlowLog keys a join only on variables that appear **by name** in both atoms. A join expressed as a cross-atom equality — e.g. DOOP's `hctx = (hctxValue,), Value_DeclaringType(hctxValue, type)`, which desugars to `Value_DeclaringType(hctx.0, type)` — has no shared name, so it became a cross product with `hctx.0 == hctxValue` as a residual filter. On `luindex` that single rule dominated runtime (single-worker cross product; the other 31 workers idle).

## The fix

- **`catalog::equijoin_keys_for_pair`** — resolves each *spanning* `=` comparison (empty superset) to a computed `(lhs_key, rhs_key)` `ArithmeticPos` pair; `ArithmeticPos::is_plain_var` separates column selection from a computed key.
- **`planner::apply_join`** — keys the join on the fused equality instead of producing an empty-key cross product.
- **layout propagation (`fuse.rs` + `transformation/info.rs`)** — `refactor_output_key_value_layout` carries the *computed* key through to the input-arrangement reshape so it **materializes** the derived value (`hctx.0`) instead of collapsing to the base column (`hctx`). This is the crux: FlowLog's arrangements are column-selection based, so the projection has to be materialized as the key.

**Safety / generality.** Fresh-variable equalities (`z = g(x)`) are desugared to bindings *before* planning, so only both-sides-grounded equalities ever reach the fusion — exactly the ones safe to key on. The generated join closure keeps the equality as a redundant residual, so correctness holds for any shape. The change reuses existing machinery (comparison/superset analysis, the per-join-rebuilt variable-presence map, variable-lifetime pruning), so it generalizes to multi-atom join orders, composite keys, and keys whose base variable is not in the head. Positive-join only; antijoins are untouched.

Verified with a new planner unit test + 6 synthetic end-to-end tests (tuple projection; arithmetic on both sides; fresh-var *not* fused; base-var-not-in-head; non-adjacent 3-atom join; composite multi-key). **All 301 workspace tests pass.**

## Benchmark configuration

| | |
|---|---|
| **Machine** | AMD EPYC 7763, 64 cores, 503 GB RAM |
| **Programs / data** | DOOP standalone (`flowlog-rs/doop-flowlog`, `verify/standalone`), 19 context families |
| **Primary dataset** | `luindex` facts (130 files, 713 MB); plus `lusearch`, `avrora`, `sunflow`, `pmd` (0.7–1.3 GB) for the cross-dataset runs |
| **FlowLog** | base `nemo/tuple` (32cbc00) + this PR; `--mode datalog-batch`, `--str-intern`, `-w 32` |
| **Souffle** | 2.5, compiled `souffle -c -j 32`, run `-j 32` |
| **Correctness oracle** | byte-exact after canonicalization (bracket/space normalize + `LC_ALL=C sort`), compared by `sha256` |

Notes: FlowLog's generated crate was built at `opt-level 1` (dependencies incl. Differential Dataflow / timely stay at `opt-level 3`) purely to keep the ~29k-line generated function's LLVM compile tractable — a **conservative handicap** for FlowLog in the vs-Souffle numbers. Determinism was validated (run1 == run2) with the ord-determinism fix in place.

## Correctness (FlowLog vs Souffle)

- **All 19 DOOP families byte-exact** vs the Souffle/baseline reference on `luindex`. **Zero regressions.**
- **Cross-dataset:** the three fixed programs across **4 more datasets** (`lusearch`, `avrora`, `sunflow`, `pmd`) are **byte-exact vs Souffle** — **15/15** combos including `luindex`. Two non-target programs on `sunflow` (`context-insensitive`, `1-object-sensitive+heap`) are also byte-exact — **no regression** where the fusion doesn't fire.

## Performance

**The three type-object analyses (`luindex`, `-w32` / `-j32`):**

| Family | Baseline FL | **Fused FL** | Souffle | Speedup vs base | Fused vs Souffle |
|---|---|---|---|---|---|
| 1-object-1-type-sensitive+heap | 708 s | **44.6 s** | 110 s | **15.9×** | **2.5× faster** |
| 2-type-object-sensitive+heap | 724 s | **44.3 s** | 106 s | **16.3×** | **2.4× faster** |
| 2-type-object-sensitive+2-heap | 958 s | **87.0 s** | 138 s | **11.0×** | **1.6× faster** |

**The other 16 families:** all **1.0–1.6× faster** than baseline (never slower) and all beat Souffle. Across the full suite FlowLog now wins **1.4×–5.3×** vs Souffle.

**Cross-dataset (fused FlowLog vs Souffle, `-w32` / `-j32`; every cell byte-exact):**

| Dataset | 1obj-1type+heap | 2type-obj+heap | 2type-obj+2heap |
|---|---|---|---|
| luindex | 44.6 s (**2.5×**) | 44.3 s (**2.4×**) | 87.0 s (**1.6×**) |
| lusearch | 48.5 s (**2.0×**) | 40.4 s (**2.4×**) | 74.9 s (**1.7×**) |
| avrora | 46.8 s (**1.3×**) | 35.3 s (**1.6×**) | 66.3 s (**1.2×**) |
| sunflow | 51.6 s (**1.7×**) | 40.6 s (**2.1×**) | 79.7 s (**1.4×**) |
| pmd | 63.4 s (**1.7×**) | 46.7 s (**2.3×**) | 81.6 s (**1.5×**) |

Speedup vs Souffle; **15/15 byte-exact**, FlowLog **1.2–2.5×** across all. `jython` (1.8 GB, reflection-heavy) was **excluded**: the deep context-sensitive configs are intractable on **both** engines (FlowLog ~450/503 GB RAM, Souffle >4 h, neither wrote a `VarPointsTo` — a dataset limit, not a fusion issue).

## Implications

- Removes a pathological cross-join class from FlowLog's planner: any join expressible as a cross-atom equality (tuple field, arithmetic, builtin) is now a hash join.
- With this change FlowLog is **faster than Souffle on all 19 DOOP standalone families** while remaining **byte-exact** — including the three type-object analyses it previously lost by 6.5–7×.
- Peak RSS is higher than Souffle (arrangement-heavy), unchanged by this PR.

## Scope / reproduction

This PR is the **planner change only** (5 files, `flowlog-build`). Reproducing the DOOP run on `nemo/tuple` additionally needs two environment patches kept out of this focused PR: tuple-typed EDB ingest, and the ord-determinism port (#208); plus the generated-crate `opt-level` override above. The fusion itself is independent of those and builds/tests clean on stock `nemo/tuple`.

