### PR TITLE
perf(codegen): emit in-place filter/map_in_place for type-preserving row transforms

### DIFF
--- a/flowlog-build/src/codegen/flow/transformation.rs
+++ b/flowlog-build/src/codegen/flow/transformation.rs
@@ -23,6 +23,7 @@ use crate::codegen::arg::compute_kv_param_tokens;
 use crate::codegen::arg::row_pattern_and_fields;
 use crate::codegen::data_type_tokens;
 use crate::codegen::ident::find_local_ident;
+use crate::codegen::row_is_copy;
 use crate::planner::ArithmeticArgument;
 use crate::planner::FactorArgument;
 use crate::planner::StratumPlanner;
@@ -110,18 +111,29 @@ impl CodeGen {
                     build_row_constraints_predicate(flow.constraints(), &row_fields, si)?;
                 let pred = combine_predicates(vec![cmp_pred, cst_pred]);
 
-                // Identity row projection with no predicate: alias the input; the
-                // `flat_map(|row| once(row))` is a no-op, so no `Map` operator is emitted.
-                let is_identity = pred.is_none()
-                    && flow.key().is_empty()
-                    && is_identity_row_projection(flow.value(), input.arity().1);
+                // Cheapest operator that fits, in-place forms first:
+                //   identity, no predicate → alias        (no operator)
+                //   identity + predicate   → filter       (drop rows in the input buffer)
+                //   same-typed rewrite     → map_in_place (overwrite them there)
+                //   anything else          → flat_map     (rebuild each row)
+                // In-place forms need a `Copy` row (fields are copied out via
+                // `*row`); `map_in_place` also needs the projection to keep
+                // every column's type, so `*row = <projection>` typechecks.
+                let key_free = flow.key().is_empty();
+                let identity_projection =
+                    key_free && is_identity_row_projection(flow.value(), input.arity().1);
+                let row_copy = row_is_copy(&itype, si);
+                let type_preserving = !identity_projection
+                    && key_free
+                    && row_copy
+                    && self.row_projection_preserves_type(flow.value(), &input_type)?;
+                let is_identity = pred.is_none() && identity_projection;
 
                 with_profiler(profiler, |profiler| {
                     if is_identity {
-                        // Copy rule `B :- A`: the identity `flat_map` is elided,
-                        // so no operator is emitted — but still register a 0-op
-                        // alias node so downstream references to this relation's
-                        // fingerprint resolve in the profiler model.
+                        // Copy rule `B :- A`: no operator is emitted — but still
+                        // register a 0-op alias node so downstream references to
+                        // this relation's fingerprint resolve in the profiler model.
                         profiler.identity_alias_operator(
                             transformation_name,
                             vec![inp.to_string()],
@@ -138,15 +150,30 @@ impl CodeGen {
                     }
                 });
 
-                let flat_map_body = flat_map_body_tokens(pred, out_val);
-
-                if is_identity {
-                    Ok(quote! { let #out = #inp.clone(); })
-                } else {
-                    Ok(quote! {
+                match pred {
+                    // Identity, no predicate: alias the input.
+                    None if identity_projection => Ok(quote! { let #out = #inp.clone(); }),
+                    // Identity + predicate: retain surviving rows in place.
+                    Some(p) if identity_projection && row_copy => Ok(quote! {
                         let #out = #inp.clone()
-                            .flat_map(|#row_pat: #row_ty| { #flat_map_body });
-                    })
+                            .filter(|&#row_pat: &#row_ty| #p);
+                    }),
+                    // Same-typed rewrite, no predicate: overwrite rows in place.
+                    None if type_preserving => Ok(quote! {
+                        let #out = #inp.clone()
+                            .map_in_place(|row: &mut #row_ty| {
+                                let #row_pat = *row;
+                                *row = #out_val;
+                            });
+                    }),
+                    // General projection: rebuild each row.
+                    pred => {
+                        let body = flat_map_body_tokens(pred, out_val);
+                        Ok(quote! {
+                            let #out = #inp.clone()
+                                .flat_map(|#row_pat: #row_ty| { #body });
+                        })
+                    }
                 }
             }
 
@@ -694,18 +721,27 @@ impl CodeGen {
             // i32 diff — no conversion needed
             quote! {}
         };
-        let neg = if self.config.is_batch() {
-            // Batch: fixed -1 weight (no retractions possible)
+        let neg = if self.config.is_datalog_batch() {
+            // Fixed -1 weight (no retractions possible); the Present → i32
+            // diff-type change forces rebuilding the triple.
             quote! {
                 .inner
                 .flat_map(move |(x, t, _)| std::iter::once((x, t.clone(), -1i32)))
                 .as_collection()
             }
-        } else {
-            // Incremental: negate the actual diff
+        } else if self.config.is_batch() {
+            // ExtendBatch: i32 diff, always 1 — overwrite to -1 in the
+            // input buffer instead of rebuilding each triple.
             quote! {
                 .inner
-                .flat_map(move |(x, t, d)| std::iter::once((x, t.clone(), -d)))
+                .map_in_place(|(_, _, d)| *d = -1i32)
+                .as_collection()
+            }
+        } else {
+            // Incremental: negate the actual diff in place.
+            quote! {
+                .inner
+                .map_in_place(|(_, _, d)| *d = -*d)
                 .as_collection()
             }
         };

--- a/flowlog-build/src/codegen/mod.rs
+++ b/flowlog-build/src/codegen/mod.rs
@@ -34,6 +34,7 @@ pub use idb_buffers::field_accessor;
 pub use idb_buffers::gen_drain_block;
 use proc_macro2::Ident;
 pub use ty::data::data_type_tokens;
+pub(crate) use ty::data::row_is_copy;
 // Intra-crate shortcuts used by build/ (library mode).
 pub(crate) use ty::data::{tuple_tokens, user_tuple_tokens};
 

--- a/flowlog-build/src/codegen/ty/data.rs
+++ b/flowlog-build/src/codegen/ty/data.rs
@@ -195,6 +195,26 @@ impl CodeGen {
             }
         }
     }
+
+    /// `true` iff every projected column re-derives its positional input
+    /// column type — the output row then has the same Rust tuple type as
+    /// the input row, the type precondition for an in-place rewrite.
+    pub(crate) fn row_projection_preserves_type(
+        &self,
+        args: &[ArithmeticArgument],
+        input_type: &KvTypes,
+    ) -> Result<bool, CodegenError> {
+        let row = &input_type.1;
+        if args.len() != row.len() {
+            return Ok(false);
+        }
+        for (arg, expected) in args.iter().zip(row) {
+            if self.infer_expr_type(arg, input_type, None)? != *expected {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
 }
 
 fn slot(tp: &KvTypes, is_key: bool) -> &[DataType] {
@@ -238,6 +258,16 @@ pub(crate) fn user_column_tokens(dt: &DataType) -> TokenStream {
         // A tuple column is a nested tuple of its fields' user types.
         DataType::FixedTuple(fields) => user_tuple_tokens(fields),
     }
+}
+
+/// `true` iff every column lowers to a `Copy` Rust type (see
+/// [`internal_column_tokens`]): a raw `String` leaf is the only non-`Copy`
+/// lowering, and interning replaces those with `Spur` keys.
+pub(crate) fn row_is_copy(types: &[DataType], string_intern: bool) -> bool {
+    string_intern
+        || !types
+            .iter()
+            .any(|dt| dt.any_leaf(&|l| matches!(l, DataType::String)))
 }
 
 fn internal_column_tokens(dt: &DataType, string_intern: bool) -> TokenStream {


### PR DESCRIPTION
## What

RowToRow lowers every projection to a `flat_map`, which drains each input buffer and rebuilds surviving rows into a fresh one. When the row is `Copy` and the operator cannot change the tuple type, timely can do the work inside the input buffer instead. This adds a codegen-time peephole ladder:

| shape | emitted operator |
|---|---|
| identity projection, no predicate | alias (pre-existing elision) |
| identity projection + predicate | `filter` — `retain`s survivors in the input container and forwards that same container |
| type-preserving rewrite (permutation / same-type arithmetic), no predicate | `map_in_place` — overwrites rows where they sit |
| everything else | `flat_map` (unchanged) |

The antijoin weight conversions get the same treatment: the ExtendBatch and incremental `neg` arms only rewrite the `i32` diff, so they now mutate it in place (also dropping the timestamp clone); the DatalogBatch arms keep `flat_map` because the `Present → i32` diff-type change forces rebuilding the triple.

## Gates

Decided once at codegen time, everything else falls through to `flat_map`:

- `row_is_copy` — the emitted closures destructure by value out of a reference (`let (x0, …) = *row`), so every column must lower to a `Copy` type. A raw `String` leaf is the only non-`Copy` lowering; `--str-intern` replaces those with `Spur`.
- `row_projection_preserves_type` — each projected column re-derives its positional input type, so `*row = out_val` typechecks.

Equi-join fusion's (#219) shadow-column premap changes arity, so it structurally never hits the new arms.

## Why in-place

In timely 0.30, `filter` is `data.retain(&mut predicate); session.give_container(data)` and `map_in_place` forwards the mutated input container — zero allocation, zero per-row reconstruction, vs. `flat_map`'s drain + push into a fresh buffer. In interned programs (DOOP included) nearly every column is a `Copy` symbol id, so guarded copy rules and head permutations — common RowToRow shapes — all qualify.

## Validation

- Binary-mode fixture suite: all 124 pass (datalog-batch, datalog-inc, extend-batch); library-mode suite: all 124 pass. `flowlog-build` unit tests and clippy clean.
- `compare_gt` now emits `.filter(|&(x0, x1): &(i32, i32)| (x1) > (50))`; a permutation/same-type-arithmetic scratch program emits `.map_in_place(...)` with byte-identical results.
- extend-batch has no antijoin fixture, so that arm was checked with a scratch `Out(x) :- A(x), !B(x)` program: emits `.map_in_place(|(_, _, d)| *d = -1i32)`, correct output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
