### PR TITLE
chore(ci): switch tests to cargo-nextest; split CI into per-check jobs

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -16,3 +16,7 @@ exclude_globs = [
     "flowlog-runtime/**",
     "flowlog-compiler/**",
 ]
+
+# Run each mutant's tests under nextest (parallel, process-per-test), matching
+# CI's unit-test runner. Requires cargo-nextest on PATH.
+test_tool = "nextest"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,14 @@
+# cargo-nextest configuration.
+#
+# Unit and integration tests run under nextest (parallel, one process per
+# test). Doctests are not run by nextest; CI runs them separately via
+# `cargo test --doc`.
+
+[profile.default]
+# A test still running after 60s is almost certainly hung: fail it (retrying
+# once, in case the stall was transient) rather than stall the whole run.
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+# CI reports every failure in one run instead of stopping at the first.
+[profile.ci]
+fail-fast = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,14 @@ env:
   RUST_BACKTRACE: full
 
 jobs:
-  test:
+  clippy:
+    name: 📎 Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
-      - name: ⚙️ Install protobuf-compiler + bsdmainutils
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler bsdmainutils
+      - name: ⚙️ Install protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: 🦀 Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -34,8 +35,59 @@ jobs:
       - name: 📎 Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: 🧪 Unit tests
-        run: cargo test
+  test:
+    name: 🧪 Unit + integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: ⚙️ Install protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: 🦀 Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: 💾 Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: 📦 Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: 🧪 Unit + integration tests
+        run: cargo nextest run --workspace --profile ci
+
+  doctest:
+    name: 📖 Doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: ⚙️ Install protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: 🦀 Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: 💾 Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: 📖 Doctests
+        run: cargo test --doc --workspace
+
+  fixtures:
+    name: 🏁 End-to-end fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: ⚙️ Install protobuf-compiler + bsdmainutils
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler bsdmainutils
+
+      - name: 🦀 Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: 💾 Cache cargo build
+        uses: Swatinem/rust-cache@v2
 
       - name: 🏁 End-to-end fixture tests
         run: |

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -42,7 +42,7 @@ jobs:
       - name: 🧬 Install cargo-mutants
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mutants
+          tool: cargo-mutants,cargo-nextest
 
       - name: 🧬 Mutation test (shard ${{ matrix.shard }}/8)
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ Every change must pass CI before it can merge:
   `Signed-off-by:` line).
 - **rustfmt**: `cargo +nightly fmt --all --check` (formatting runs on nightly).
 - **clippy**: `cargo clippy --workspace --all-targets -- -D warnings`.
-- **tests**: `cargo test` plus the end-to-end fixture suite (see
-  `tests/README.md`).
+- **tests**: `cargo nextest run --workspace` (unit and integration) and
+  `cargo test --doc --workspace` (doctests, which nextest does not run), plus
+  the end-to-end fixture suite (see `tests/README.md`).
 - Also gated: `cargo-deny` (licenses and advisories), `typos` (spelling), and
   `taplo` (TOML format and lint).

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo
 	@echo "  Dev workflow:"
 	@echo "    make build           cargo build --release --workspace"
-	@echo "    make test            cargo test  --release --workspace"
+	@echo "    make test            cargo nextest run + cargo test --doc"
 	@echo
 	@echo "  End-to-end fixtures:"
 	@echo "    make fixtures [MODE=compiler|lib|both] [J=<n>] [ARGS=<names>]"
@@ -33,7 +33,8 @@ build:
 	cargo build --release --workspace
 
 test:
-	cargo test --release --workspace
+	cargo nextest run --release --workspace
+	cargo test --release --doc --workspace
 
 # End-to-end fixture suite (generated-crate byte-diff tests). MODE selects
 # the lowering path like `oracle`. J sets cross-fixture parallelism (default:

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ runnable.
 
 | Path                        | What it does                                                  | Time       |
 |-----------------------------|---------------------------------------------------------------|------------|
-| `cargo test --workspace`    | Per-crate `#[test]`s — the unit-test layer                    | <15 s warm |
+| `cargo nextest run --workspace` | Per-crate `#[test]`s (nextest); doctests via `cargo test --doc` | <15 s warm |
 | `tests/fixtures/`           | ~95 hand-curated `.dl` programs, byte-diff vs `expected/`     | ~2 min     |
 | `tests/oracle/`             | Real benchmarks, byte-diff vs **Soufflé** reference outputs   | ~30 min    |
 | `tests/lib/`                | Shared bash helpers (sourced by every runner)                 | —          |
@@ -22,8 +22,12 @@ pass.
 
 ## How to run
 
+Unit and integration tests run under [cargo-nextest](https://nexte.st)
+(`cargo install cargo-nextest --locked`); doctests run separately via
+`cargo test --doc`, since nextest does not execute them.
+
 ```bash
-# Unit tests
+# Unit + integration tests (nextest) + doctests
 make test
 
 # Fixtures (no flags, runs all ~95 programs)


### PR DESCRIPTION
Switches unit + integration tests to [cargo-nextest](https://nexte.st) (parallel, process-per-test) and decouples the monolithic `test` job into separate parallel jobs — `clippy`, `test` (nextest), `doctest`, `fixtures` — mirroring Vortex's CI layout.

nextest doesn't run doctests, so those keep a dedicated `cargo test --doc` job. Adds `.config/nextest.toml` (a `ci` profile: fail-fast off, slow-test timeout). Mutation testing runs each mutant under nextest too (`test_tool = "nextest"`). `make test`, `tests/README.md`, and `AGENTS.md` updated to match.

Stacked on #224 (base `feat/const-fold`) — retarget to `main-next` once that merges.

Local: `cargo nextest run --workspace --profile ci` (519 pass) and `cargo test --doc --workspace` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
