### PR TITLE
perf(compiler): emit opt-level 2 + panic=abort profile in generated crates

### DIFF
--- a/flowlog-compiler/src/scaffold.rs
+++ b/flowlog-compiler/src/scaffold.rs
@@ -118,6 +118,19 @@ pub(crate) fn render_cargo_toml(crate_name: &str, config: &Config, features: &Fe
     // it from any enclosing cargo workspace when it's built inside one.
     doc["workspace"] = Item::Table(Table::new());
 
+    // Build the emitted crate at opt-level 2 without unwinding: both
+    // measured runtime-neutral on the generated dataflow code while
+    // cutting `cargo build --release` about 3x on large programs.
+    {
+        let mut profile = Table::new();
+        profile.set_implicit(true);
+        doc["profile"] = Item::Table(profile);
+        doc["profile"]["release"] = Item::Table(Table::new());
+        let release = doc["profile"]["release"].as_table_mut().unwrap();
+        release["opt-level"] = value(2);
+        release["panic"] = "abort".into();
+    }
+
     doc["dependencies"] = Item::Table(Table::new());
     {
         let deps = doc["dependencies"].as_table_mut().unwrap();


### PR DESCRIPTION
## What

Emit a `[profile.release]` section into every generated crate's `Cargo.toml`:

```toml
[profile.release]
opt-level = 2
panic = "abort"
```

Previously the generated crate built with Cargo's stock release settings.

## Why

Investigation of slow DOOP compiles (doop-flowlog `context-insensitive`, 592 rules, 27k-line generated `main.rs`, compiled with `--str-intern`): `-Ztime-passes` attributes **81% of the 572s leaf build to the default thin-local ThinLTO pass**, whose serial thin-link step is super-linear in the IR volume that opt-level 3 and unwind landing pads inflate. The emitted operator code (dd join/arrange/merge over monomorphized tuples) gains nothing from o3's extra inlining, and nothing in the generated code, flowlog-runtime, or timely uses `catch_unwind`.

## Measurements (128-core box, real context-insensitive DOOP)

| | stock profile | this PR |
|---|---|---|
| generated-crate build | 572s | **171s (3.3x)** |
| runtime (batik, `-w 32`, 2 reps) | 34.5/36.0s | 34.6/36.4s (noise) |
| VarPointsTo output | — | **byte-identical** (28,249,074 rows, equal sorted md5) |
| binary size | 121 MB | 92 MB |

The small example `doop.dl` shows the same shape (44.8s -> 33.2s). `lto="off"` was evaluated and deliberately **not** included: it compiles faster still but costs +22% runtime on the real program.

## Validation

- All 111 fixture programs pass byte-diff (`tests/fixtures/run_compiler.sh`)
- Workspace `cargo test`, nightly `fmt --check`, `clippy -D warnings` clean
- Runtime/output measurements above were taken on dd-0.25-branch codegen; this PR targets main (dd 0.24) where the generated-code shape is the same

## Caveats / draft status

- `panic = "abort"`: a panicking worker now aborts the process after printing the message instead of unwinding — same user-visible behavior for a batch CLI, but flagging the semantic change.
- Runtime neutrality is measured on DOOP (String/Spur-tuple joins); a spot-check of one graph-analysis oracle pair (e.g. cspa) before undrafting would close the loop. flowlog-bench cross-version comparison against this commit is the intended next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)