### PR TITLE
feat(compiler): --build-dir keeps and reuses the generated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "flowlog-profiler",
  "proc-macro2",
  "quote",
+ "tempfile",
  "thiserror",
  "toml_edit",
  "tracing",

--- a/flowlog-compiler/Cargo.toml
+++ b/flowlog-compiler/Cargo.toml
@@ -25,5 +25,8 @@ flowlog-common = { workspace = true, features = ["clap"] }
 flowlog-parser.workspace = true
 flowlog-profiler.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/flowlog-compiler/src/build.rs
+++ b/flowlog-compiler/src/build.rs
@@ -6,8 +6,9 @@
 //!    complete Cargo project (`main.rs`, `relation.rs`, `Cargo.toml`, etc.)
 //!    under [`CompileOptions::build_dir`]. No external tools are invoked.
 //! 2. **`build`** — shell out to `cargo build --release` in that directory,
-//!    copy the resulting binary to [`CompileOptions::executable_path`], and remove
-//!    the intermediate crate unless [`CompileOptions::save_temps`] is set.
+//!    copy the resulting binary to [`CompileOptions::executable_path`], and
+//!    remove the scratch crate unless the user named a build directory
+//!    (a named directory persists and doubles as a recompile cache).
 //!
 //! Both are `pub(crate)`; external callers use [`Compiler::compile`] which
 //! runs them in sequence.
@@ -59,8 +60,12 @@ impl Compiler {
         let main_rs = self.assemble_main(&parts, &bin_imports, &worker_helpers)?;
 
         // Cargo project metadata.
-        let cargo_toml =
-            scaffold::render_cargo_toml(&self.options.crate_name(), &self.config, features);
+        let cargo_toml = scaffold::render_cargo_toml(
+            &self.options.crate_name(),
+            &self.config,
+            features,
+            self.options.keeps_build_dir(),
+        );
         let cargo_config = scaffold::render_cargo_config();
 
         self.write_project(&parts, &main_rs, &relation_rs, &cargo_toml, &cargo_config)
@@ -69,8 +74,8 @@ impl Compiler {
     }
 
     /// Compile the emitted crate with `cargo build --release`, install the
-    /// binary at [`CompileOptions::executable_path`], and (unless `--save-temps`)
-    /// remove the intermediate crate directory.
+    /// binary at [`CompileOptions::executable_path`], and remove the crate
+    /// directory unless [`CompileOptions::keeps_build_dir`] holds.
     pub(crate) fn build(&self) -> io::Result<()> {
         let build_dir = self.options.build_dir();
         let crate_name = self.options.crate_name();
@@ -102,9 +107,11 @@ impl Compiler {
         Ok(())
     }
 
-    /// Remove the intermediate crate directory unless `--save-temps` is set.
+    /// Remove the crate directory unless [`CompileOptions::keeps_build_dir`]
+    /// holds; a kept directory persists as the recompile cache (see
+    /// [`CompileOptions::build_dir`]).
     fn cleanup_build_dir(&self, build_dir: &Path) -> io::Result<()> {
-        if !self.options.save_temps() {
+        if !self.options.keeps_build_dir() {
             fs::remove_dir_all(build_dir).map_err(|e| {
                 io::Error::new(
                     e.kind(),
@@ -140,8 +147,9 @@ fn run_cargo(build_dir: &Path, args: &[&str]) -> io::Result<()> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(io::Error::other(format!(
-            "cargo {} failed:\n{stderr}",
-            args.join(" ")
+            "cargo {} failed (generated crate kept at '{}'):\n{stderr}",
+            args.join(" "),
+            build_dir.display()
         )));
     }
     Ok(())

--- a/flowlog-compiler/src/cli.rs
+++ b/flowlog-compiler/src/cli.rs
@@ -57,10 +57,13 @@ pub struct Cli {
     #[arg(long, value_name = "PATH")]
     pub udf_file: Option<String>,
 
-    /// Keep the intermediate generated Rust crate instead of cleaning it up
-    /// after building the executable.
-    #[arg(long)]
-    pub save_temps: bool,
+    /// Build the generated Rust crate in DIR and keep it afterwards.
+    /// Reusing the same DIR skips dependency rebuilds, reuses incremental
+    /// artifacts across recompiles, and leaves the generated sources
+    /// readable. Without it, the crate is built in a hidden scratch
+    /// directory that is removed after a successful build.
+    #[arg(short = 'B', long, value_name = "DIR")]
+    pub build_dir: Option<String>,
 
     /// Type-check the generated crate with `cargo check` instead of building
     /// an executable. Faster; conflicts with `-o`.
@@ -97,7 +100,7 @@ impl Cli {
             self.executable_path.clone(),
             self.output_dir.clone(),
             self.fact_dir.clone(),
-            self.save_temps,
+            self.build_dir.clone(),
             self.check,
         )
     }

--- a/flowlog-compiler/src/lib.rs
+++ b/flowlog-compiler/src/lib.rs
@@ -64,8 +64,9 @@ impl Compiler {
     }
 
     /// Emit the scaffolded Rust crate, run `cargo build --release`, copy the
-    /// binary to [`CompileOptions::executable_path`], and clean up build artifacts
-    /// unless [`CompileOptions::save_temps`] is set. When [`CompileOptions::check_only`]
+    /// binary to [`CompileOptions::executable_path`], and clean up the
+    /// scratch crate unless the user named a build directory, which then
+    /// persists as a recompile cache. When [`CompileOptions::check_only`]
     /// is set, the crate is type-checked with `cargo check` instead.
     ///
     /// Returns a [`BoxError`] on failure — user-facing codegen diagnostics

--- a/flowlog-compiler/src/options.rs
+++ b/flowlog-compiler/src/options.rs
@@ -14,8 +14,12 @@ pub struct CompileOptions {
     output_dir: Option<String>,
     /// Directory containing input fact files, if any.
     fact_dir: Option<String>,
-    /// Keep the intermediate generated Rust crate instead of cleaning it up.
-    save_temps: bool,
+    /// User-named build directory for the generated crate. Naming one opts
+    /// into persistence: the directory survives the build and doubles as a
+    /// recompile cache (an unchanged program rebuilds as a cargo no-op, an
+    /// edited one incrementally). `None` builds in a hidden scratch
+    /// directory that is removed after a successful build.
+    build_dir: Option<PathBuf>,
     /// Type-check the emitted crate with `cargo check`.
     check_only: bool,
 }
@@ -28,7 +32,7 @@ impl CompileOptions {
         executable_path: Option<String>,
         output_dir: Option<String>,
         fact_dir: Option<String>,
-        save_temps: bool,
+        build_dir: Option<String>,
         check_only: bool,
     ) -> Self {
         let executable_path = executable_path
@@ -38,7 +42,7 @@ impl CompileOptions {
             executable_path,
             output_dir,
             fact_dir,
-            save_temps,
+            build_dir: build_dir.map(PathBuf::from),
             check_only,
         }
     }
@@ -54,12 +58,21 @@ impl CompileOptions {
             .unwrap_or("out")
     }
 
-    /// Intermediate build directory for the generated Rust crate.
-    /// Uses a hidden dotfile name so it won't collide
+    /// Build directory for the generated Rust crate: the user-named one
+    /// when given, otherwise a scratch sibling of the executable. The
+    /// scratch default uses a hidden dotfile name so it won't collide
     /// with the final executable or any user files.
     pub fn build_dir(&self) -> PathBuf {
-        self.executable_path
-            .with_file_name(format!(".{}.build", self.executable_name()))
+        self.build_dir.clone().unwrap_or_else(|| {
+            self.executable_path
+                .with_file_name(format!(".{}.build", self.executable_name()))
+        })
+    }
+
+    /// Returns `true` if the user named a build directory, which then
+    /// persists after the build.
+    pub fn keeps_build_dir(&self) -> bool {
+        self.build_dir.is_some()
     }
 
     /// Sanitized name suitable for use as a Cargo package/binary name.
@@ -95,11 +108,42 @@ impl CompileOptions {
         self.fact_dir.as_deref()
     }
 
-    pub fn save_temps(&self) -> bool {
-        self.save_temps
-    }
-
     pub fn check_only(&self) -> bool {
         self.check_only
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(executable: Option<&str>, build_dir: Option<&str>) -> CompileOptions {
+        CompileOptions::new(
+            "analysis.dl",
+            executable.map(String::from),
+            None,
+            None,
+            build_dir.map(String::from),
+            false,
+        )
+    }
+
+    /// Scratch builds must not collide with the executable or user files,
+    /// so the default is a hidden dot-directory beside the binary, and it
+    /// is not kept.
+    #[test]
+    fn build_dir_defaults_to_hidden_sibling_of_executable() {
+        let opts = options(Some("out/bin"), None);
+        assert_eq!(opts.build_dir(), PathBuf::from("out/.bin.build"));
+        assert!(!opts.keeps_build_dir());
+    }
+
+    /// Naming a directory replaces the scratch default and opts into
+    /// keeping it.
+    #[test]
+    fn named_build_dir_wins_and_is_kept() {
+        let opts = options(Some("out/bin"), Some("cache/dir"));
+        assert_eq!(opts.build_dir(), PathBuf::from("cache/dir"));
+        assert!(opts.keeps_build_dir());
     }
 }

--- a/flowlog-compiler/src/scaffold.rs
+++ b/flowlog-compiler/src/scaffold.rs
@@ -103,7 +103,12 @@ impl Compiler {
 /// Dependencies are feature-gated: we emit only what the generated code
 /// actually references so the downstream `cargo build` pulls the minimum
 /// set of crates.
-pub(crate) fn render_cargo_toml(crate_name: &str, config: &Config, features: &Features) -> String {
+pub(crate) fn render_cargo_toml(
+    crate_name: &str,
+    config: &Config,
+    features: &Features,
+    keep_build_dir: bool,
+) -> String {
     let mut doc = DocumentMut::new();
 
     doc["package"] = Item::Table(Table::new());
@@ -121,6 +126,9 @@ pub(crate) fn render_cargo_toml(crate_name: &str, config: &Config, features: &Fe
     // Build the emitted crate at opt-level 2 without unwinding: both
     // measured runtime-neutral on the generated dataflow code while
     // cutting `cargo build --release` about 3x on large programs.
+    // Incremental compilation pays off only when the build directory
+    // survives to the next compile and costs cold-build time otherwise,
+    // so it is emitted only for kept (user-named) directories.
     {
         let mut profile = Table::new();
         profile.set_implicit(true);
@@ -129,6 +137,9 @@ pub(crate) fn render_cargo_toml(crate_name: &str, config: &Config, features: &Fe
         let release = doc["profile"]["release"].as_table_mut().unwrap();
         release["opt-level"] = value(2);
         release["panic"] = "abort".into();
+        if keep_build_dir {
+            release["incremental"] = value(true);
+        }
     }
 
     doc["dependencies"] = Item::Table(Table::new());
@@ -222,9 +233,15 @@ fn ensure_dir(dir: &Path) -> io::Result<()> {
 }
 
 /// Write a UTF-8 text file, creating parent directories as needed.
+/// Skips the write when the file already holds `contents`: preserving the
+/// mtime lets cargo fingerprint an unchanged generated source as fresh,
+/// so recompiling an unmodified program is a no-op.
 fn write_file(path: &Path, contents: &str) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         ensure_dir(parent)?;
+    }
+    if fs::read_to_string(path).is_ok_and(|current| current == contents) {
+        return Ok(());
     }
     fs::write(path, contents)
 }
@@ -239,3 +256,59 @@ const PROMPT_RS_TMPL: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/templates/prompt_rs.tpl"
 ));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `incremental = true` costs cold-build time and pays off only when
+    /// the build directory survives to a later compile, so it must ride
+    /// with kept directories and never with scratch ones.
+    #[test]
+    fn incremental_is_emitted_only_for_kept_build_dirs() {
+        let config = Config::default();
+        let features = Features::default();
+        let kept = render_cargo_toml("bin", &config, &features, true);
+        let scratch = render_cargo_toml("bin", &config, &features, false);
+        assert!(kept.contains("incremental = true"));
+        assert!(!scratch.contains("incremental"));
+    }
+
+    /// An unchanged file must keep its mtime so cargo fingerprints it as
+    /// fresh; a changed one must be rewritten. Exercised directly because
+    /// the mtime effect is unobservable through the public API without
+    /// running cargo.
+    #[test]
+    fn write_file_rewrites_only_on_content_change() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("main.rs");
+        write_file(&path, "fn main() {}").expect("initial write");
+
+        let old = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(100);
+        let file = fs::File::options()
+            .write(true)
+            .open(&path)
+            .expect("open for mtime");
+        file.set_modified(old).expect("set mtime");
+        drop(file);
+
+        write_file(&path, "fn main() {}").expect("no-op rewrite");
+        let unchanged = fs::metadata(&path)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+        assert_eq!(
+            unchanged, old,
+            "content-equal write must not touch the file"
+        );
+
+        write_file(&path, "fn main() { run() }").expect("changed rewrite");
+        let changed = fs::metadata(&path)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+        assert_ne!(changed, old, "changed content must be written out");
+        let body = fs::read_to_string(&path).expect("read back");
+        assert_eq!(body, "fn main() { run() }");
+    }
+}


### PR DESCRIPTION
Follow-up to #228 (merged).

## What

Replace `--save-temps` with a path-valued **`--build-dir DIR`** — the build tree is a *place*, and naming the place is what opts you into its persistence (the CMake/cargo model, applied to a gcc-shaped CLI):

```
flowlog p.dl -o bin                    # gcc mode: nothing left but bin
flowlog p.dl -o bin --build-dir D      # CMake mode: D holds the crate + cargo cache
flowlog p.dl -o bin --build-dir D      # rerun: deps cached, leaf rebuilds incrementally
```

- **Without `--build-dir`**: build in the hidden scratch dir, remove it on success, keep it and print its path on failure — today's released behavior, unchanged; one-shot builds pay zero overhead (no `incremental` in the profile).
- **With `--build-dir D`**: emit the crate into `D`, keep it. Generated files are rewritten only when content changed (preserving mtimes for cargo's fingerprints), and `incremental = true` is emitted into the release profile only in this mode.

One path answers everything a boolean flag left dangling: keep it? (you named it) — where? (there) — inspect the generated Rust? (open it) — clean? (`rm -rf D`) — CI caching? (cache-restore `D`).

## Measurements (128-core box, example doop.dl)

| scenario | time |
|---|---|
| cold build | ~45s |
| recompile with same `--build-dir` | ~29s (deps cached, incremental leaf) |
| default one-shot build | unchanged |

Honest scope note: codegen emission order is not yet byte-stable across compiler runs, so an unchanged program still re-emits and rebuilds the leaf crate. Tracking issue #231 covers making emission deterministic crate by crate; with that patch applied, unchanged recompiles measured **0.06s** (cargo no-op) and `--check` re-checks warm at 0.05s. The two are deliberately separate: the stable-order change touches planner/stratifier internals and deserves its own review (it also fixes content-fingerprint instability that can randomly defeat cross-rule sharing).

## Validation

- An `incremental = true` binary produces byte-identical VarPointsTo on DOOP batik (28,249,074 rows); runtime 35.5s vs 35.2s baseline at 32 workers
- Unit tests pin the build-dir contract (scratch default vs named), the incremental gating, and the write-if-changed mtime behavior
- Behavior tested end-to-end: default removes the scratch dir; `--build-dir` persists with `incremental = true` present only then; failure keeps the crate and prints its path
- Workspace tests, nightly fmt, `clippy -D warnings` clean

## Breaking change

`--save-temps` is removed (it named one purpose of what is really a location decision). Scripts that used it for inspection get the same files from `--build-dir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
