### PR TITLE
feat(profiler): periodically flush metrics during batch runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "serde",
+ "tempfile",
  "timely",
 ]
 

--- a/flowlog-build/src/build/engine/batch.rs
+++ b/flowlog-build/src/build/engine/batch.rs
@@ -197,6 +197,7 @@ fn gen_run_body(
     let size_cell_clones = &parts.size_cell_clones;
     let profile_init = &parts.profile_init;
     let metrics_write = &parts.metrics_write_batch;
+    let step_loop = &parts.batch_step_loop;
 
     let (host_partitions, worker_partition_clones) = gen_host_partitions(edbs);
     let inputs_new_args = gen_inputs_new_args(edbs);
@@ -236,7 +237,7 @@ fn gen_run_body(
                 inputs.apply_inline_all(index);
                 inputs.close_all();
 
-                while worker.step() {}
+                #step_loop
 
                 #(#flush)*
                 barrier.wait();

--- a/flowlog-build/src/build/imports.rs
+++ b/flowlog-build/src/build/imports.rs
@@ -57,15 +57,14 @@ pub(crate) fn gen_lib_imports(
 
 /// Items the generated `OpMetrics` struct and its logger reference
 /// unqualified; kept conditional so non-profile builds don't drag in
-/// `HashMap` / `File` / timely logging for nothing.
+/// `HashMap` / timely logging for nothing. The metric tables write through
+/// `flowlog_runtime::io::write_atomic`, so no `File`/`Write` import is needed.
 fn profile_imports(profile: bool) -> TokenStream {
     if !profile {
         return quote! {};
     }
     quote! {
         use std::collections::HashMap;
-        use std::fs::File;
-        use std::io::{BufWriter, Write};
         use std::time::Duration;
         use ::flowlog_runtime::timely::logging::{StartStop, TimelyEvent, TimelyEventBuilder};
     }

--- a/flowlog-build/src/build/pipeline.rs
+++ b/flowlog-build/src/build/pipeline.rs
@@ -110,5 +110,6 @@ fn build_config(builder: &Builder, program: &str) -> Config {
             .collect(),
         output_to_stdout: false,
         serialize_load: false,
+        metrics_flush_interval_ms: builder.metrics_flush_interval_ms,
     }
 }

--- a/flowlog-build/src/codegen/code_parts.rs
+++ b/flowlog-build/src/codegen/code_parts.rs
@@ -54,6 +54,10 @@ pub struct CodeParts {
     pub metrics_write_batch: TokenStream,
     /// Metrics write-out code for incremental mode.
     pub metrics_write_incremental: TokenStream,
+    /// Batch run loop: a plain `while worker.step()` fixpoint, or (when
+    /// profiling with a non-zero flush interval) a stepping loop that
+    /// periodically re-dumps metrics.
+    pub batch_step_loop: TokenStream,
 
     /// Type aliases and constants for the `(Data, Diff, Time)` triple.
     pub type_declarations: TokenStream,
@@ -119,6 +123,7 @@ impl CodeGen {
         // -- Metrics write code (mode-specific) --
         let metrics_write_batch = self.gen_metrics_write_batch();
         let metrics_write_incremental = self.gen_metrics_write_incremental();
+        let batch_step_loop = self.gen_batch_step_loop();
 
         // Rendered after the codegen loop so the plan graph is fully
         // populated. Empty when profile is off.
@@ -144,6 +149,7 @@ impl CodeGen {
             profile_init,
             metrics_write_batch,
             metrics_write_incremental,
+            batch_step_loop,
             type_declarations,
             semiring_modules,
         })

--- a/flowlog-build/src/codegen/profile.rs
+++ b/flowlog-build/src/codegen/profile.rs
@@ -213,6 +213,12 @@ impl CodeGen {
             return quote! {};
         }
 
+        // TODO: no periodic in-commit flush here yet (batch has one via
+        // `gen_batch_step_loop`), so a fat single commit leaves no partial
+        // snapshot until it completes. Adding it needs a write-without-reset
+        // variant: the counter reset below must run only on the final
+        // per-commit write, or a periodic partial would split one
+        // transaction's delta across writes.
         let dir = format!("{}/metrics", self.profile_log_dir());
         let ops_fmt = format!("{dir}/operators_worker_t{{}}_{{}}.log");
         let chans_fmt = format!("{dir}/channels_worker_t{{}}_{{}}.log");
@@ -234,6 +240,34 @@ impl CodeGen {
             }
             chan_send.borrow_mut().clear();
             chan_recv.borrow_mut().clear();
+        }
+    }
+
+    /// Emits the batch run loop (`worker` and `index` in scope). Without
+    /// profiling or with a zero flush interval this is a plain
+    /// step-to-fixpoint loop. With a non-zero interval the dataflow is
+    /// stepped in a loop that re-dumps the batch metrics every `interval`
+    /// milliseconds (overwriting the `t0` tables), so a long or interrupted
+    /// run still leaves the latest cumulative snapshot on disk. The final
+    /// authoritative dump still runs after the loop drains.
+    pub(crate) fn gen_batch_step_loop(&self) -> TokenStream {
+        let interval = self.config.metrics_flush_interval_ms();
+        if !self.config.profiling_enabled() || interval == 0 {
+            return quote! { while worker.step() {} };
+        }
+
+        let write = self.gen_metrics_write_batch();
+        quote! {
+            {
+                let mut __flowlog_last_flush = std::time::Instant::now();
+                let __flowlog_flush_interval = std::time::Duration::from_millis(#interval);
+                while worker.step() {
+                    if __flowlog_last_flush.elapsed() >= __flowlog_flush_interval {
+                        #write
+                        __flowlog_last_flush = std::time::Instant::now();
+                    }
+                }
+            }
         }
     }
 }
@@ -284,23 +318,26 @@ fn gen_metrics_write_core(
                 let mut rows: Vec<&OpMetrics> = map.values().collect();
                 rows.sort_by(|a, b| a.addr.cmp(&b.addr));
 
-                let mut w = BufWriter::new(File::create(#ops_path_expr)?);
-                writeln!(w, #ops_header, "addr", "acts", "active_ms", "name")?;
-                for m in &rows {
-                    // Non-applicable dimensions print `n/a`.
-                    let (acts, active_ms) = m.time.as_ref().map_or_else(
-                        || ("n/a".to_string(), "n/a".to_string()),
-                        |t| (
-                            t.activations.to_string(),
-                            format!("{:.3}", t.total_active.as_secs_f64() * 1000.0),
-                        ),
-                    );
-                    writeln!(w, #ops_header, fmt_addr(&m.addr), acts, active_ms, m.name)?;
-                }
-                if rows.is_empty() {
-                    writeln!(w, "(no operators recorded)")?;
-                }
-                w.flush()?;
+                // Periodic flushes can be interrupted mid-write, so route the
+                // table through an atomic write.
+                ::flowlog_runtime::io::write_atomic(#ops_path_expr, |w| {
+                    writeln!(w, #ops_header, "addr", "acts", "active_ms", "name")?;
+                    for m in &rows {
+                        // Non-applicable dimensions print `n/a`.
+                        let (acts, active_ms) = m.time.as_ref().map_or_else(
+                            || ("n/a".to_string(), "n/a".to_string()),
+                            |t| (
+                                t.activations.to_string(),
+                                format!("{:.3}", t.total_active.as_secs_f64() * 1000.0),
+                            ),
+                        );
+                        writeln!(w, #ops_header, fmt_addr(&m.addr), acts, active_ms, m.name)?;
+                    }
+                    if rows.is_empty() {
+                        writeln!(w, "(no operators recorded)")?;
+                    }
+                    Ok(())
+                })?;
 
                 // Channel table, sorted by topology for stable output.
                 let info = chan_info.borrow();
@@ -323,20 +360,21 @@ fn gen_metrics_write_core(
                     .collect();
                 chans.sort();
 
-                let mut w = BufWriter::new(File::create(#chans_path_expr)?);
-                writeln!(
-                    w,
-                    #chans_header,
-                    "scope", "src", "src_port", "tgt", "tgt_port", "batch", "sent", "recvd"
-                )?;
-                for (scope, src, src_port, tgt, tgt_port, batch, sent, recvd) in chans {
+                ::flowlog_runtime::io::write_atomic(#chans_path_expr, |w| {
                     writeln!(
                         w,
                         #chans_header,
-                        fmt_addr(scope), src, src_port, tgt, tgt_port, batch, sent, recvd
+                        "scope", "src", "src_port", "tgt", "tgt_port", "batch", "sent", "recvd"
                     )?;
-                }
-                w.flush()
+                    for (scope, src, src_port, tgt, tgt_port, batch, sent, recvd) in chans {
+                        writeln!(
+                            w,
+                            #chans_header,
+                            fmt_addr(scope), src, src_port, tgt, tgt_port, batch, sent, recvd
+                        )?;
+                    }
+                    Ok(())
+                })
             };
             if let Err(e) = dump() {
                 eprintln!("flowlog profiling: metrics dump into {} failed: {e}", #dir);

--- a/flowlog-build/src/lib.rs
+++ b/flowlog-build/src/lib.rs
@@ -115,6 +115,7 @@ pub struct Builder {
     pub(crate) profile: bool,
     pub(crate) include_dirs: Vec<PathBuf>,
     pub(crate) udf_file: Option<PathBuf>,
+    pub(crate) metrics_flush_interval_ms: u64,
 }
 
 impl Builder {
@@ -160,6 +161,16 @@ impl Builder {
     /// panics if the combination is requested.
     pub fn profile(mut self, enabled: bool) -> Self {
         self.profile = enabled;
+        self
+    }
+
+    /// Milliseconds between periodic metric flushes during a profiled batch
+    /// run, so a long or interrupted run still leaves the latest snapshot on
+    /// disk. Defaults to `0` (flush only at the end); set a non-zero value to
+    /// snapshot periodically. Batch modes only, and ignored unless
+    /// [`Self::profile`] is set.
+    pub fn metrics_flush_interval_ms(mut self, ms: u64) -> Self {
+        self.metrics_flush_interval_ms = ms;
         self
     }
 

--- a/flowlog-common/src/config.rs
+++ b/flowlog-common/src/config.rs
@@ -58,6 +58,11 @@ pub struct Config {
     /// interning order — and therefore `ord(_)` values — is deterministic across
     /// worker counts (`-w N` matches `-w 1`).
     pub serialize_load: bool,
+    /// Milliseconds between periodic metric flushes while a profiled batch
+    /// run is executing, so a long or interrupted run still leaves the latest
+    /// cumulative snapshot on disk. `0` flushes only at the end. Batch modes
+    /// only: incremental modes snapshot per transaction and ignore this.
+    pub metrics_flush_interval_ms: u64,
 }
 
 impl Config {
@@ -138,6 +143,11 @@ impl Config {
     /// Whether fact-string interning must be serial for deterministic `ord(_)`.
     pub fn serialize_load(&self) -> bool {
         self.serialize_load
+    }
+
+    /// Milliseconds between periodic metric flushes; `0` means end-only.
+    pub fn metrics_flush_interval_ms(&self) -> u64 {
+        self.metrics_flush_interval_ms
     }
 }
 

--- a/flowlog-compiler/src/assembly/batch.rs
+++ b/flowlog-compiler/src/assembly/batch.rs
@@ -34,6 +34,7 @@ pub(crate) fn gen_batch_main(
         size_cell_clones,
         profile_init,
         metrics_write_batch: metrics_write,
+        batch_step_loop: step_loop,
         ..
     } = parts;
     let Input {
@@ -89,7 +90,7 @@ pub(crate) fn gen_batch_main(
                         r.close();
                     }
 
-                    while worker.step() {}
+                    #step_loop
 
                     // Flush per-worker output buffers into the shared ones,
                     // then worker 0 merges and writes results.

--- a/flowlog-compiler/src/cli.rs
+++ b/flowlog-compiler/src/cli.rs
@@ -40,6 +40,13 @@ pub struct Cli {
     #[arg(long, short = 'P')]
     pub profile: bool,
 
+    /// Milliseconds between periodic metric flushes while a profiled batch
+    /// run executes, so a long or interrupted run still leaves the latest
+    /// partial metrics on disk. `0` flushes only at the end. Batch modes
+    /// only; needs `--profile`.
+    #[arg(long, value_name = "MS", default_value_t = 5000)]
+    pub metrics_flush_interval_ms: u64,
+
     /// Enable Sideways Information Passing to propagate binding constraints
     /// from rule heads into body atoms, reducing intermediate results.
     #[arg(long)]
@@ -90,6 +97,7 @@ impl Cli {
             include_dirs: self.include_dirs.clone(),
             output_to_stdout: self.output_dir.as_deref() == Some("-"),
             serialize_load: false,
+            metrics_flush_interval_ms: self.metrics_flush_interval_ms,
         }
     }
 

--- a/flowlog-compiler/src/imports.rs
+++ b/flowlog-compiler/src/imports.rs
@@ -184,10 +184,9 @@ fn std_imports(inc: bool, prof: bool, f: &Features) -> TokenStream {
             }
         };
         let output_buf = output_buffer_imports(inc, f.output_buffers());
+
         return quote! {
             #rc_refcell
-            use std::fs::File;
-            use std::io::{BufWriter, Write};
             #output_buf
             use std::time::{Duration, Instant};
         };

--- a/flowlog-runtime/Cargo.toml
+++ b/flowlog-runtime/Cargo.toml
@@ -20,6 +20,7 @@ ordered-float = { workspace = true, features = ["serde"] }
 regex.workspace = true
 rustc-hash.workspace = true
 serde = { workspace = true }
+tempfile.workspace = true
 timely.workspace = true
 
 [lints]

--- a/flowlog-runtime/src/io.rs
+++ b/flowlog-runtime/src/io.rs
@@ -1,37 +1,27 @@
 //! I/O and partition helpers used by the generated engine code.
 //!
-//! - [`partition`] — split an owned `Vec` into per-worker slices for the
+//! - [`partition`]: split an owned `Vec` into per-worker slices for the
 //!   library-mode batch engine's ingest path.
-//! - [`byte_range_reader`] — split a CSV file across timely workers so each
+//! - [`byte_range_reader`]: split a CSV file across timely workers so each
 //!   reads its own byte slice (binary mode).
-//! - [`shard_int`] / [`shard_str`] / [`shard_spur`] — pick the owning
-//!   worker for a tuple based on its first column (binary mode).
-//!
-//! # Byte-range reader example
-//!
-//! ```ignore
-//! if let Some((reader, budget)) = byte_range_reader(path, index, peers) {
-//!     let mut buf = Vec::new();
-//!     let mut consumed = 0u64;
-//!     while consumed < budget {
-//!         buf.clear();
-//!         let n = reader.read_until(b'\n', &mut buf).unwrap_or(0);
-//!         if n == 0 { break; }
-//!         consumed += n as u64;
-//!         // parse &buf …
-//!     }
-//! }
-//! ```
+//! - [`shard_int`] / [`shard_str`] / [`shard_spur`]: pick the owning worker
+//!   for a tuple based on its first column (binary mode).
+//! - [`write_atomic`]: write a file via a temp sibling and rename so a
+//!   reader never sees a half-written file.
 
 use std::fs::File;
+use std::io;
 use std::io::BufRead;
 use std::io::BufReader;
+use std::io::BufWriter;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
+use std::io::Write;
 use std::path::Path;
 
 use lasso::Spur;
+use tempfile::NamedTempFile;
 
 // =========================================================================
 // Per-worker partitioning
@@ -39,9 +29,8 @@ use lasso::Spur;
 
 /// Split `v` into `n` roughly-equal owned partitions, in order.
 ///
-/// Used by the generated library-mode engine to hand each timely worker its
-/// own slice by value — no `Arc` sharing, no per-tuple clone, each tuple
-/// moves directly into the worker's `InputSession`.
+/// Each element moves by value into its partition (no `Arc` sharing, no
+/// per-tuple clone), so a consumer takes ownership of its slice directly.
 ///
 /// `n.max(1)` partitions are produced; if `v.len() < n` some partitions
 /// are empty. The last partition absorbs any remainder when the division
@@ -110,7 +99,7 @@ pub fn byte_range_reader(
     }
 
     // Any worker whose range begins at byte 0 reads from the start with no
-    // alignment skip — there's no previous byte to peek at. Worker 0 always
+    // alignment skip; there's no previous byte to peek at. Worker 0 always
     // hits this; others hit it when `chunk == 0` (peers > file_size), which
     // puts the whole file on the last worker.
     if start == 0 {
@@ -147,7 +136,7 @@ pub fn byte_range_reader(
 
 /// Shard an integer-typed first column across `peers` workers.
 ///
-/// Returns `true` if worker `index` should own this tuple.
+/// Returns `true` if worker `index` owns this tuple.
 #[inline]
 pub fn shard_int(first: i64, peers: usize, index: usize) -> bool {
     first.rem_euclid(peers as i64) as usize == index
@@ -155,7 +144,8 @@ pub fn shard_int(first: i64, peers: usize, index: usize) -> bool {
 
 /// Shard a string-typed first column across `peers` workers.
 ///
-/// Uses a 32-bit FNV-1a hash to distribute strings uniformly.
+/// Returns `true` if worker `index` owns this tuple, hashing with 32-bit
+/// FNV-1a for a uniform distribution.
 #[inline]
 pub fn shard_str(first: &str, peers: usize, index: usize) -> bool {
     let mut hash: u32 = 0x811c9dc5;
@@ -167,7 +157,105 @@ pub fn shard_str(first: &str, peers: usize, index: usize) -> bool {
 }
 
 /// Shard an interned-string first column ([`lasso::Spur`]) across `peers`.
+///
+/// Returns `true` if worker `index` owns this tuple.
 #[inline]
 pub fn shard_spur(first: Spur, peers: usize, index: usize) -> bool {
     (first.into_inner().get() as usize) % peers == index
+}
+
+// =========================================================================
+// Atomic file write
+// =========================================================================
+
+/// Write `path` atomically: stream through `write` into a temp file in the
+/// same directory, then persist it over `path` in a single rename. A failed
+/// or interrupted write leaves `path` untouched, so a concurrent reader never
+/// observes a half-written file. Delegates the platform-specific atomic
+/// replace to `tempfile`, which handles the Unix and Windows differences.
+///
+/// The temp file is a sibling of `path` so the rename stays within one
+/// filesystem (a metadata move, not a copy). `path` must have a parent or be
+/// relative to the current directory.
+pub fn write_atomic(
+    path: impl AsRef<Path>,
+    write: impl FnOnce(&mut dyn Write) -> io::Result<()>,
+) -> io::Result<()> {
+    let path = path.as_ref();
+    let mut tmp = match path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        Some(dir) => NamedTempFile::new_in(dir)?,
+        None => NamedTempFile::new()?,
+    };
+    {
+        let mut buf = BufWriter::new(&mut tmp);
+        write(&mut buf)?;
+        buf.flush()?;
+    }
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A completed write leaves the destination with exactly the bytes
+    /// written and no leftover temp sibling in the directory.
+    #[test]
+    fn write_atomic_persists_content_and_leaves_no_temp() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("out.log");
+        write_atomic(&path, |w| write!(w, "hello")).expect("write");
+
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), "hello");
+        let names: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+        assert_eq!(
+            names.len(),
+            1,
+            "only the persisted file should remain: {names:?}"
+        );
+    }
+
+    /// A second write replaces the destination rather than appending or
+    /// erroring on the existing file.
+    #[test]
+    fn write_atomic_overwrites_existing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("out.log");
+        write_atomic(&path, |w| write!(w, "first")).expect("first");
+        write_atomic(&path, |w| write!(w, "second")).expect("second");
+
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), "second");
+    }
+
+    /// The atomicity guarantee: a closure error propagates, the existing
+    /// destination keeps its old contents (the write never clobbers the
+    /// target), and the temp sibling is cleaned up rather than left behind.
+    #[test]
+    fn write_atomic_failed_write_preserves_existing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("out.log");
+        write_atomic(&path, |w| write!(w, "original")).expect("seed");
+
+        let err = write_atomic(&path, |w| {
+            write!(w, "partial")?;
+            Err(io::Error::other("boom"))
+        })
+        .expect_err("closure error must propagate");
+        assert_eq!(err.to_string(), "boom");
+
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), "original");
+        let names: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+        assert_eq!(
+            names.len(),
+            1,
+            "temp sibling should be cleaned up: {names:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Batch profiling wrote its operator/channel metric tables only once, after the dataflow drained, so a long-running or interrupted `-P` run left nothing on disk. This adds an **opt-in periodic flush**: while a profiled batch run steps to fixpoint, it re-dumps the `t0` tables every N ms (overwriting them), so the latest cumulative snapshot always survives interruption.

## Changes

- **Knobs** (batch modes only; consulted only under `--profile`):
  - CLI `--metrics-flush-interval-ms` — default `5000`.
  - Library `Builder::metrics_flush_interval_ms(ms)` — default `0` (end-only; opt in explicitly).
  - `0` disables (writes only at end, prior behavior).
- **Codegen**: `gen_batch_step_loop` wraps the `while worker.step()` loop with a time-gated re-dump when profiling and interval > 0. Both run-loop templates — the library engine (`build/engine/batch.rs`) and the CLI binary (`compiler/assembly/batch.rs`) — splice the shared `batch_step_loop` `CodeParts` fragment.
- **Atomic writes**: metric tables now write through new `flowlog_runtime::io::write_atomic` (temp sibling + `NamedTempFile::persist` rename), so an interrupted flush can't leave a torn table for the reader. Shared by the batch and incremental write paths.

## Overhead

| workload | interval | result |
|---|---|---|
| doop / batik, `-w 1` | 1 ms (worst) | ~0% (within noise) |
| doop / batik, `-w 18` | 5000 ms (default) | ~0% |
| doop / batik, `-w 18` | 1 ms (pathological) | +47% (kernel / file-write contention) |

Negligible at the default; only a tiny interval at high worker counts hurts, because each worker flushes its own file pair and the concurrent syscall volume dominates.

## Release coupling (before this reaches crates.io users)

Generated code now calls `flowlog_runtime::io::write_atomic`, a **new public runtime API**. The generated crate depends on the crates.io `flowlog-runtime`, so at release time:

- `flowlog-runtime` must be **published** with `write_atomic`, and
- the scaffold version floor (`flowlog-compiler/src/scaffold.rs`, currently `"0.2.3"`) bumped to that release.

CI is unaffected — the e2e/oracle runners patch the runtime to the local checkout via `FLOWLOG_RUNTIME_PATH`. This only matters for released compilers. Left for the release step since `release-plz` assigns the runtime version.

## Follow-ups (not in this PR)

- **Incremental periodic flush** (TODO in `gen_metrics_write_incremental`): needs a write-without-reset variant so a fat single commit's per-transaction delta isn't split across partial writes.
- **A `-P` fixture** in the oracle/e2e suite: the profiling codegen path has no compile/run coverage in CI today (every fixture is non-`-P`).
- Optionally split the now-grab-bag `flowlog-runtime/src/io.rs` into a re-exporting `io/` folder (keeps the `io::` API path stable).

## Test plan

- `write_atomic`: 3 unit tests — persist + no leftover temp, overwrite, and the atomicity guarantee (failed write leaves the existing file intact and cleans the temp).
- Manually verified profiled generated code compiles and runs with `FLOWLOG_RUNTIME_PATH` set, and the `t0` tables refresh mid-run.
- Local CI gates green: `clippy --all-targets -D warnings`, workspace tests, doctests, rustfmt, cargo-deny, typos, taplo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
