### PR TITLE
ci: run required checks on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main", "main-next"]
   pull_request:
     branches: ["main", "main-next"]
+  # Run the required checks against the merge queue's temporary branch too;
+  # without this the queue never receives their status and stalls.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Adds the `merge_group` event trigger to CI so the required checks run against the merge queue's temporary branch. This is the prerequisite for enabling a **merge queue** on `main-next` (eliminates the "update branch → someone merges first → update again" race with require-up-to-date).

## Why

GitHub's merge queue tests each PR on an ephemeral branch (`gh-readonly-queue/…` = latest base + any PRs ahead) via `merge_group` events. If workflows only trigger `on: pull_request`, those checks never run in the queue context, the queue never receives their status, and enqueued PRs stall forever. This trigger is the fix. No change to normal PR/push CI.

## Enabling the queue (follow-up, not in this PR)

Once this is on `main-next`:
1. Turn on the merge queue for `main-next` (ruleset / branch protection), selecting the required checks.
2. ⚠️ **DCO is a GitHub App, not a workflow** — verify its status reports on the `merge_group` ref. If it doesn't, it can't be a queue-required check (or the queue stalls); enforce it at PR time only, or swap in a `merge_group`-capable DCO action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
