### PR TITLE
ci: auto-approve non-major Renovate PRs

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,38 @@
+name: Auto-approve Renovate
+
+# Auto-approve non-major Renovate PRs so they satisfy the "Main Branch"
+# ruleset's required Committer review and flow through auto-merge + the merge
+# queue unattended. Major updates are intentionally excluded (no `automerge`
+# label) so a human reviews them.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+    branches: [main-next]
+
+# The default token needs nothing: approval is submitted with a Committer PAT.
+permissions: {}
+
+jobs:
+  approve:
+    # Gate on Renovate authorship AND the `automerge` label. Both are set by
+    # GitHub / the Renovate config, not by PR contents, so this can't be
+    # spoofed from a fork. Majors are labelled for review, not `automerge`.
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve
+        env:
+          # Fine-grained PAT of a Committers-team member (Pull requests:
+          # write). A Committer approval is what the ruleset requires; the
+          # default GITHUB_TOKEN can't approve and wouldn't count toward the
+          # team review. Renovate PRs aren't authored by the PAT owner, so
+          # approving them is allowed.
+          GH_TOKEN: ${{ secrets.RENOVATE_APPROVE_TOKEN }}
+        run: |
+          gh pr review "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --approve \
+            --body "Auto-approved: non-major Renovate update."


### PR DESCRIPTION
## Summary

Auto-approves **non-major** Renovate PRs so they clear the "Main Branch" ruleset's required Committer review and flow through auto-merge + the merge queue unattended. **Major updates are excluded** — they get no `automerge` label, so they wait for a human (you) to review.

## How it works

- Triggers on Renovate PRs to `main-next` (`pull_request_target`, no PR code checked out — approval only, so it's safe).
- Fail-closed gate: approves **only** if the author is `renovate[bot]` **and** the PR carries the `automerge` label. Anything unlabeled (incl. majors) is left for review.
- Approves using a **Committer PAT** — the ruleset requires the approval to come from the Committers team, and the default `GITHUB_TOKEN` can neither approve nor count toward that team review.

## Setup required before this does anything (2 items)

1. **Repo secret `RENOVATE_APPROVE_TOKEN`** — a fine-grained PAT owned by a Committer (you or hdz284), scoped to this repo with **Pull requests: write**. Renovate PRs aren't authored by the PAT owner, so approving them is allowed.
2. **Renovate `packageRules`** (in your org-level config) to label + scope automerge:
   ```json5
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "bump", "lockFileMaintenance"],
       "automerge": true,
       "addLabels": ["automerge"]
     },
     {
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "addLabels": ["major-review"]
     }
   ]
   ```
   Non-major → labelled `automerge` → auto-approved → auto-merge → queue → merged. Major → labelled `major-review`, no automerge → you review + approve manually.

## Simpler alternative (if you'd rather not run a PAT)

Add `renovate[bot]` (or the Renovate app) as a **bypass actor** on the "Main Branch" ruleset — then Renovate PRs skip the approval requirement entirely and auto-merge with no approve step. Trade-off: Renovate bypasses the *whole* ruleset, and you lose the per-PR label control (majors would need a separate guard). The PAT approach keeps the ruleset strict and the majors-review split clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
