### PR TITLE
ci: register Renovate auto-approve on the default branch

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,26 @@
+name: Auto-approve Renovate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+    branches: [main-next]
+
+permissions: {}
+
+jobs:
+  approve:
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve
+        env:
+          # Committer PAT: the ruleset requires a Committers-team approval,
+          # which GITHUB_TOKEN cannot provide.
+          GH_TOKEN: ${{ secrets.RENOVATE_APPROVE_TOKEN }}
+        run: |
+          gh pr review "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --approve \
+            --body "Auto-approved: non-major Renovate update."


### PR DESCRIPTION
## Why

`pull_request_target` workflows only fire when the workflow file exists on the repo's **default branch** (`main`). The auto-approve workflow was added to `main-next` only (#248), so GitHub never registered it — it's absent from the Actions list and had **0** `pull_request_target` runs. Adding it to `main` registers it; at runtime the base branch's copy (`main-next`) is used for `main-next` PRs.

## Depends on
- Secret `RENOVATE_APPROVE_TOKEN` (Committer PAT, Pull requests: write) — added.
- Renovate `packageRules` labelling non-major updates `automerge` (snippet in #248) — org config.

Comments trimmed vs the `main-next` copy (kept only the PAT rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
