### PR TITLE
ci(renovate): use platform auto-merge + label automerge PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,12 +17,12 @@
 
   // Weekly Cargo.lock refresh: CI builds against the same fresh in-range
   // resolution that users of generated crates always get (they have no lockfile).
-  lockFileMaintenance: { enabled: true, automerge: true },
+  lockFileMaintenance: { enabled: true, automerge: true, addLabels: ["automerge"] },
 
-  // GitHub's native auto-merge proved unreliable here (armed PRs with green
-  // required checks sat unmerged for hours); have Renovate merge green
-  // automerge PRs itself during its visits instead.
-  platformAutomerge: false,
+  // Platform auto-merge feeds the merge queue: Renovate arms GitHub
+  // auto-merge, the auto-approve workflow supplies the required Committer
+  // review, and the queue merges. 
+  platformAutomerge: true,
 
   customManagers: [
     {
@@ -68,6 +68,7 @@
       matchManagers: ["cargo"],
       matchUpdateTypes: ["patch"],
       automerge: true,
+      addLabels: ["automerge"],
     },
     {
       // Stable (>=1.x) crates: minors are semver-compatible and in-range
@@ -77,6 +78,7 @@
       matchUpdateTypes: ["minor"],
       matchCurrentVersion: ">=1.0.0",
       automerge: true,
+      addLabels: ["automerge"],
     },
   ],
 }


### PR DESCRIPTION
## What

Makes Renovate's existing automerge rules actually flow through the new merge queue + auto-approve:

- **`platformAutomerge: false` → `true`.** The merge queue on `main-next` requires GitHub's native auto-merge; Renovate's self-merge can't merge into a queue-gated branch. The old "armed PRs sat unmerged for hours" was really the **missing Committer approval** (the ruleset requires one, Renovate can't self-approve) — now supplied by the auto-approve workflow.
- **`addLabels: ["automerge"]`** on the automerge rules (patch, stable `>=1.0` minor, lockFileMaintenance) so the auto-approve workflow's label gate fires on exactly those PRs. Majors / 0.x-minors stay unlabelled → human review.

## Resulting flow (hands-off, non-major deps)

Renovate opens PR → labels `automerge` + arms auto-merge → auto-approve workflow approves (Committer PAT) → merge queue tests against fresh `main-next` → merges.

## Scope

`main-next` only — `useBaseBranchConfig: "merge"` makes it take effect immediately for main-next runs; `main` catches up at the next release. No `main` PR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
