### PR TITLE
ci(renovate): rebase only on conflict, not on every base advance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,8 +21,13 @@
 
   // Platform auto-merge feeds the merge queue: Renovate arms GitHub
   // auto-merge, the auto-approve workflow supplies the required Committer
-  // review, and the queue merges. 
+  // review, and the queue merges.
   platformAutomerge: true,
+
+  // The merge queue rebuilds each entry against the current base, so don't
+  // force-push (and re-run CI on) PRs merely because main-next advanced;
+  // rebase only on a genuine conflict.
+  rebaseWhen: "conflicted",
 
   customManagers: [
     {


### PR DESCRIPTION
Stops the CI-rerun storm from Renovate rebasing every open PR whenever `main-next` advances.

**Why safe:** with the merge queue, each entry is rebuilt + re-tested against the current base on its `merge_group` branch, so a behind-but-clean PR doesn't need a Renovate rebase — the queue validates the real merge. `rebaseWhen: "conflicted"` keeps Renovate rebasing on genuine conflicts (so lockfile clashes still resolve), just not on mere "behind".

Net: ~1–2 CI runs per dep PR instead of a re-test on every base advance. `main-next` overlay → takes effect on Renovate's next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)