### PR TITLE
ci: workflow-based DCO check that runs in the merge queue

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,44 @@
+name: DCO
+
+# Workflow-based DCO so the check reports on `merge_group` too. The probot
+# DCO app only posts on `pull_request`, so it never responds in the merge
+# queue and the queue times the PR out. This re-verifies Signed-off-by on
+# both events; the same commits that passed on the PR pass again in-queue.
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: DCO
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify Signed-off-by on all commits
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            base="${{ github.event.merge_group.base_sha }}"
+            head="${{ github.event.merge_group.head_sha }}"
+          else
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          fi
+          echo "Checking commits in ${base}..${head}"
+          missing=0
+          while read -r sha; do
+            [ -z "$sha" ] && continue
+            # Skip merge commits (2+ parents); DCO applies to authored commits.
+            [ "$(git rev-list --parents -n1 "$sha" | wc -w)" -gt 2 ] && continue
+            if ! git show -s --format=%B "$sha" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
+              echo "::error::commit ${sha} is missing a Signed-off-by trailer: $(git show -s --format=%s "$sha")"
+              missing=1
+            fi
+          done < <(git rev-list "${base}..${head}")
+          [ "$missing" -eq 0 ] && echo "All commits are signed off." || { echo "DCO failed."; exit 1; }


### PR DESCRIPTION
The probot **DCO app** only reports on `pull_request`, never `merge_group` — so in the merge queue GitHub waits for a `DCO` status that never arrives and ejects the PR (*"no response for status checks"*). This is why #246 and the Renovate batch keep getting kicked.

Replaces it with a **workflow-based DCO** that verifies `Signed-off-by` on **both** `pull_request` and `merge_group`, so the required check reports in-queue. Same commits that passed on the PR pass again in the queue.

Part 1 of 2 (also needs a copy on `main` to register); then I swap the required check from the app to this workflow + flip `strict:false`. Bypass-merge (queue is stuck on the old DCO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)