### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "flowlog-build"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "clap",
  "codespan-reporting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-test = "0.2"
 
 # Internal crates.
-flowlog-build = { path = "flowlog-build", version = "0.3.4" }
+flowlog-build = { path = "flowlog-build", version = "0.4.0" }
 flowlog-common = { path = "flowlog-common", version = "0.1.0" }
 flowlog-parser = { path = "flowlog-parser", version = "0.1.0" }
 flowlog-profiler = { path = "flowlog-profiler", version = "0.1.0" }

--- a/flowlog-build/CHANGELOG.md
+++ b/flowlog-build/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.4...flowlog-build-v0.4.0) - 2026-07-26
 
+### Breaking
+
+- generated code targets timely 0.31 / differential-dataflow 0.25 ([#227](https://github.com/flowlog-rs/flowlog/pull/227)); pair with flowlog-runtime 0.3
+
 ### Added
 
 - *(profiler)* periodically flush metrics during incremental commits ([#267](https://github.com/flowlog-rs/flowlog/pull/267))

--- a/flowlog-build/CHANGELOG.md
+++ b/flowlog-build/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.4...flowlog-build-v0.4.0) - 2026-07-26
+
+### Added
+
+- *(profiler)* periodically flush metrics during incremental commits ([#267](https://github.com/flowlog-rs/flowlog/pull/267))
+- *(profiler)* periodically flush metrics during batch runs ([#246](https://github.com/flowlog-rs/flowlog/pull/246))
+- *(profiler)* record plan graph in codegen and read metrics back in… ([#242](https://github.com/flowlog-rs/flowlog/pull/242))
+- *(planner)* fuse spanning equality comparisons into join keys ([#219](https://github.com/flowlog-rs/flowlog/pull/219))
+
+### Fixed
+
+- *(codegen)* deterministic `ord` via single-thread fact interning ([#208](https://github.com/flowlog-rs/flowlog/pull/208))
+
+### Other
+
+- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
+- Migrate to differential-dataflow 0.25 / timely 0.31 ([#227](https://github.com/flowlog-rs/flowlog/pull/227))
+- fold flowlog-typechecker into flowlog-parser ([#224](https://github.com/flowlog-rs/flowlog/pull/224))
+- *(codegen)* emit in-place filter/map_in_place for type-preserving row transforms ([#220](https://github.com/flowlog-rs/flowlog/pull/220))
+- *(typechecker)* post-typecheck constant folding pass ([#209](https://github.com/flowlog-rs/flowlog/pull/209))
+- extract `flowlog-typechecker` crate; per-site spelling in type errors ([#202](https://github.com/flowlog-rs/flowlog/pull/202))
+- *(codegen)* elide identity projections (drop no-op flat_maps) ([#200](https://github.com/flowlog-rs/flowlog/pull/200))
+- *(codegen)* fuse chained unions into a single n-ary concatenate ([#205](https://github.com/flowlog-rs/flowlog/pull/205))
+- *(codegen)* use threshold_total for outer-scope dedup in incremental mode ([#201](https://github.com/flowlog-rs/flowlog/pull/201)) ([#201](https://github.com/flowlog-rs/flowlog/pull/201))
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
+- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
+- support tuple syntax ([#194](https://github.com/flowlog-rs/flowlog/pull/194))
+
 ## [0.3.4](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.3...flowlog-build-v0.3.4) - 2026-06-18
 
 ### Fixed

--- a/flowlog-build/Cargo.toml
+++ b/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.3.4"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/flowlog-common/CHANGELOG.md
+++ b/flowlog-common/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-common-v0.1.0) - 2026-07-26
+
+### Added
+
+- *(profiler)* periodically flush metrics during incremental commits ([#267](https://github.com/flowlog-rs/flowlog/pull/267))
+- *(profiler)* periodically flush metrics during batch runs ([#246](https://github.com/flowlog-rs/flowlog/pull/246))
+
+### Fixed
+
+- *(codegen)* deterministic `ord` via single-thread fact interning ([#208](https://github.com/flowlog-rs/flowlog/pull/208))
+
+### Other
+
+- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))

--- a/flowlog-parser/CHANGELOG.md
+++ b/flowlog-parser/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-parser-v0.1.0) - 2026-07-26
+
+### Added
+
+- *(profiler)* record plan graph in codegen and read metrics back in… ([#242](https://github.com/flowlog-rs/flowlog/pull/242))
+
+### Other
+
+- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
+- fold flowlog-typechecker into flowlog-parser ([#224](https://github.com/flowlog-rs/flowlog/pull/224))
+- *(typechecker)* post-typecheck constant folding pass ([#209](https://github.com/flowlog-rs/flowlog/pull/209))
+- extract `flowlog-typechecker` crate; per-site spelling in type errors ([#202](https://github.com/flowlog-rs/flowlog/pull/202))
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))

--- a/flowlog-profiler/CHANGELOG.md
+++ b/flowlog-profiler/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-profiler-v0.1.0) - 2026-07-26
+
+### Added
+
+- *(profiler)* record plan graph in codegen and read metrics back in… ([#242](https://github.com/flowlog-rs/flowlog/pull/242))
+
+### Other
+
+- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
+- *(codegen)* elide identity projections (drop no-op flat_maps) ([#200](https://github.com/flowlog-rs/flowlog/pull/200))
+- *(codegen)* use threshold_total for outer-scope dedup in incremental mode ([#201](https://github.com/flowlog-rs/flowlog/pull/201)) ([#201](https://github.com/flowlog-rs/flowlog/pull/201))
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
+- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))

--- a/flowlog-runtime/CHANGELOG.md
+++ b/flowlog-runtime/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.5...flowlog-runtime-v0.3.0) - 2026-07-26
 
+### Breaking
+
+- the re-exported `timely` and `differential-dataflow` move to 0.31 / 0.25 ([#227](https://github.com/flowlog-rs/flowlog/pull/227)); projects generated against the 0.30 / 0.24 line should stay on flowlog-runtime 0.2
+
 ### Added
 
 - *(profiler)* periodically flush metrics during batch runs ([#246](https://github.com/flowlog-rs/flowlog/pull/246))

--- a/flowlog-runtime/CHANGELOG.md
+++ b/flowlog-runtime/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.5...flowlog-runtime-v0.3.0) - 2026-07-26
+
+### Added
+
+- *(profiler)* periodically flush metrics during batch runs ([#246](https://github.com/flowlog-rs/flowlog/pull/246))
+
+### Other
+
+- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
+- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
+- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
+
 ## [0.2.5](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.4...flowlog-runtime-v0.2.5) - 2026-06-13
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `flowlog-runtime`: 0.2.5 -> 0.3.0
* `flowlog-common`: 0.1.0
* `flowlog-parser`: 0.1.0
* `flowlog-profiler`: 0.1.0
* `flowlog-build`: 0.3.4 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `flowlog-build` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum flowlog_build::ExecutionMode, previously in file /tmp/.tmpFbKDWg/flowlog-build/src/common/config.rs:10
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-runtime`

<blockquote>

## [0.3.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-runtime-v0.2.5...flowlog-runtime-v0.3.0) - 2026-07-26

### Added

- *(profiler)* periodically flush metrics during batch runs ([#246](https://github.com/flowlog-rs/flowlog/pull/246))

### Other

- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
</blockquote>

## `flowlog-common`

<blockquote>

## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-common-v0.1.0) - 2026-07-26

### Added

- *(profiler)* periodically flush metrics during incremental commits ([#267](https://github.com/flowlog-rs/flowlog/pull/267))
- *(profiler)* periodically flush metrics during batch runs ([#246](https://github.com/flowlog-rs/flowlog/pull/246))

### Fixed

- *(codegen)* deterministic `ord` via single-thread fact interning ([#208](https://github.com/flowlog-rs/flowlog/pull/208))

### Other

- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
</blockquote>

## `flowlog-parser`

<blockquote>

## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-parser-v0.1.0) - 2026-07-26

### Added

- *(profiler)* record plan graph in codegen and read metrics back in… ([#242](https://github.com/flowlog-rs/flowlog/pull/242))

### Other

- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
- fold flowlog-typechecker into flowlog-parser ([#224](https://github.com/flowlog-rs/flowlog/pull/224))
- *(typechecker)* post-typecheck constant folding pass ([#209](https://github.com/flowlog-rs/flowlog/pull/209))
- extract `flowlog-typechecker` crate; per-site spelling in type errors ([#202](https://github.com/flowlog-rs/flowlog/pull/202))
- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
</blockquote>

## `flowlog-profiler`

<blockquote>

## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-profiler-v0.1.0) - 2026-07-26

### Added

- *(profiler)* record plan graph in codegen and read metrics back in… ([#242](https://github.com/flowlog-rs/flowlog/pull/242))

### Other

- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
- *(codegen)* elide identity projections (drop no-op flat_maps) ([#200](https://github.com/flowlog-rs/flowlog/pull/200))
- *(codegen)* use threshold_total for outer-scope dedup in incremental mode ([#201](https://github.com/flowlog-rs/flowlog/pull/201)) ([#201](https://github.com/flowlog-rs/flowlog/pull/201))
- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
</blockquote>

## `flowlog-build`

<blockquote>

## [0.4.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.4...flowlog-build-v0.4.0) - 2026-07-26

### Added

- *(profiler)* periodically flush metrics during incremental commits ([#267](https://github.com/flowlog-rs/flowlog/pull/267))
- *(profiler)* periodically flush metrics during batch runs ([#246](https://github.com/flowlog-rs/flowlog/pull/246))
- *(profiler)* record plan graph in codegen and read metrics back in… ([#242](https://github.com/flowlog-rs/flowlog/pull/242))
- *(planner)* fuse spanning equality comparisons into join keys ([#219](https://github.com/flowlog-rs/flowlog/pull/219))

### Fixed

- *(codegen)* deterministic `ord` via single-thread fact interning ([#208](https://github.com/flowlog-rs/flowlog/pull/208))

### Other

- *(release)* prep first crates.io publish; flowlog-compiler 0.5.0 ([#268](https://github.com/flowlog-rs/flowlog/pull/268))
- Migrate to differential-dataflow 0.25 / timely 0.31 ([#227](https://github.com/flowlog-rs/flowlog/pull/227))
- fold flowlog-typechecker into flowlog-parser ([#224](https://github.com/flowlog-rs/flowlog/pull/224))
- *(codegen)* emit in-place filter/map_in_place for type-preserving row transforms ([#220](https://github.com/flowlog-rs/flowlog/pull/220))
- *(typechecker)* post-typecheck constant folding pass ([#209](https://github.com/flowlog-rs/flowlog/pull/209))
- extract `flowlog-typechecker` crate; per-site spelling in type errors ([#202](https://github.com/flowlog-rs/flowlog/pull/202))
- *(codegen)* elide identity projections (drop no-op flat_maps) ([#200](https://github.com/flowlog-rs/flowlog/pull/200))
- *(codegen)* fuse chained unions into a single n-ary concatenate ([#205](https://github.com/flowlog-rs/flowlog/pull/205))
- *(codegen)* use threshold_total for outer-scope dedup in incremental mode ([#201](https://github.com/flowlog-rs/flowlog/pull/201)) ([#201](https://github.com/flowlog-rs/flowlog/pull/201))
- factor out `flowlog-common` and `flowlog-parser` ([#196](https://github.com/flowlog-rs/flowlog/pull/196))
- Extended profiler follow-ups ([#192](https://github.com/flowlog-rs/flowlog/pull/192))
- support tuple syntax ([#194](https://github.com/flowlog-rs/flowlog/pull/194))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).