### PR TITLE
ci(release-plz): sign off the release commit for DCO

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,6 +44,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: 🤖 release-plz (release-pr)
+        id: release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         with:
           command: release-pr
@@ -52,6 +53,29 @@ jobs:
           # the release PR triggers downstream CI (ci.yml) on its own pushes.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: ✍️ Sign off the release commit (DCO)
+        # release-plz has no sign-off option, and the DCO check requires a
+        # Signed-off-by matching the commit author. Amend one in on the
+        # author's behalf, using the commit's own author identity so the
+        # sign-off matches. Guarded so a rerun does not re-amend.
+        if: steps.release-plz.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch='${{ fromJSON(steps.release-plz.outputs.pr).head_branch }}'
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git fetch origin "$branch"
+          git checkout -B "$branch" "origin/$branch"
+          if git show -s --format='%(trailers:key=Signed-off-by,valueonly)' | grep -q .; then
+            echo "Release commit already signed off."; exit 0
+          fi
+          git config user.name  "$(git show -s --format='%an')"
+          git config user.email "$(git show -s --format='%ae')"
+          git commit --amend --signoff --no-edit
+          git push --force-with-lease origin "HEAD:$branch"
+          echo "Signed off the release commit on $branch."
 
   release-plz-release:
     name: Publish on release merge to main


### PR DESCRIPTION
release-plz has no native sign-off option, so its `chore: release` commit lacks a `Signed-off-by` and trips the DCO check (seen on #264).

This adds a step after release-plz that amends a sign-off onto the release commit **as the commit's own author**, so DCO's author-match passes, and pushes with the release PAT so DCO/CI re-evaluate. Guarded so reruns don't re-amend an already-signed commit.

Note: DCO is currently *advisory*, so this isn't blocking today — it's to keep release PRs green now and enforced-clean once we re-require DCO (after the app's `merge_group` support deploys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)