### PR TITLE
test(fixtures): shard e2e across runners via --shard I/N

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,13 @@ jobs:
       - name: 📖 Doctests
         run: cargo test --doc --workspace
 
-  fixtures:
-    name: 🏁 End-to-end fixtures
+  # End-to-end fixtures, split across runners. Tune the count via the matrix length.
+  fixtures-shard:
+    name: 🏁 e2e shard ${{ matrix.shard }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -92,10 +97,21 @@ jobs:
       - name: 💾 Cache cargo build
         uses: Swatinem/rust-cache@v2
 
-      - name: 🏁 End-to-end fixture tests
+      - name: 🏁 End-to-end fixtures
         run: |
-          bash tests/fixtures/run_compiler.sh -j 4
-          bash tests/fixtures/run_lib.sh -j 4
+          bash tests/fixtures/run_compiler.sh -j 4 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+          bash tests/fixtures/run_lib.sh -j 4 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+
+  # Required check "🏁 End-to-end fixtures": keeps a stable name; green only if
+  # every shard passed.
+  fixtures:
+    name: 🏁 End-to-end fixtures
+    needs: [fixtures-shard]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          [ "${{ needs.fixtures-shard.result }}" = success ] || { echo "a fixture shard failed"; exit 1; }
 
   fmt:
     name: 🎨 rustfmt

--- a/tests/fixtures/common.sh
+++ b/tests/fixtures/common.sh
@@ -213,26 +213,62 @@ count_tests() {
 # CLI helpers
 ###############################################################################
 
-# Parse `[-j N] [-h] [--] [positional…]`. Populates `PARSED_JOBS` (positive int,
-# default 1) and `PARSED_POSITIONAL` (array). On `-h|--help` invokes the
-# script-supplied `usage_fn` and exits 0.
+# Parse `[-j N] [--shard I/N] [-h] [--] [positional…]`. Populates `PARSED_JOBS`
+# (positive int, default 1), `PARSED_POSITIONAL` (array), and `PARSED_SHARD`
+# ("I/N" or empty). On `-h|--help` invokes `usage_fn` and exits 0.
 PARSED_JOBS=1
 PARSED_POSITIONAL=()
+PARSED_SHARD=""
 parse_jobs_flag() {
     local usage_fn="$1"; shift
     PARSED_JOBS=1
     PARSED_POSITIONAL=()
+    PARSED_SHARD=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -h|--help) "$usage_fn"; exit 0 ;;
             -j) PARSED_JOBS="${2:?}"; shift 2 ;;
             -j*) PARSED_JOBS="${1#-j}"; shift ;;
+            --shard) PARSED_SHARD="${2:?}"; shift 2 ;;
+            --shard=*) PARSED_SHARD="${1#--shard=}"; shift ;;
             --) shift; PARSED_POSITIONAL+=("$@"); break ;;
             *) PARSED_POSITIONAL+=("$1"); shift ;;
         esac
     done
     [[ "$PARSED_JOBS" =~ ^[1-9][0-9]*$ ]] \
         || die "Invalid -j value: $PARSED_JOBS (expected positive integer)"
+    [[ -z "$PARSED_SHARD" || "$PARSED_SHARD" =~ ^[1-9][0-9]*/[1-9][0-9]*$ ]] \
+        || die "Invalid --shard value: $PARSED_SHARD (expected I/N)"
+}
+
+# Every fixture name across the configured categories, sorted — the stable
+# order `--shard` slices over.
+all_test_names() {
+    local cat cat_dir test_dir
+    for cat in "${CATEGORIES[@]}"; do
+        cat_dir="${TESTS_DIR}/${cat}"
+        [[ -d "$cat_dir" ]] || continue
+        for test_dir in "$cat_dir"/*/; do
+            [[ -f "$test_dir/program.dl" ]] || continue
+            basename "$test_dir"
+        done
+    done | sort
+}
+
+# When `--shard I/N` was given, narrow `PARSED_POSITIONAL` to this shard: every
+# Nth name of the sorted list. Lets CI fan the suite across runners without
+# naming fixtures; a shard is just a subset of the usual named-test path.
+apply_shard() {
+    [[ -n "$PARSED_SHARD" ]] || return 0
+    (( ${#PARSED_POSITIONAL[@]} == 0 )) \
+        || die "--shard cannot be combined with explicit test names"
+    local index="${PARSED_SHARD%/*}" total="${PARSED_SHARD#*/}"
+    (( index >= 1 && index <= total )) || die "--shard out of range: $PARSED_SHARD"
+    local i=0 name
+    while IFS= read -r name; do
+        (( i % total == index - 1 )) && PARSED_POSITIONAL+=("$name")
+        (( i++ )) || true
+    done < <(all_test_names)
 }
 
 ###############################################################################

--- a/tests/fixtures/run_compiler.sh
+++ b/tests/fixtures/run_compiler.sh
@@ -37,7 +37,7 @@ export FLOWLOG_RUNTIME_PATH="${ROOT_DIR}/flowlog-runtime"
 usage() {
     cat <<EOF
 Usage:
-  $(basename "$0") [-j N] [test_name ...]
+  $(basename "$0") [-j N] [--shard I/N] [test_name ...]
 
 Run FlowLog binary-mode end-to-end tests. Tests are organized by category:
   datalog-batch/  Standard batch Datalog evaluation (default mode)
@@ -56,11 +56,13 @@ Options:
   -j N            Run up to N fixtures in parallel (default 1).
                   Each fixture already gets its own work_dir, so parallelism
                   is safe in binary mode.
+  --shard I/N     Run only shard I of N (the fixtures split into N groups).
 
 Examples:
   $(basename "$0")                     # run all tests sequentially
   $(basename "$0") -j 8                # 8 fixtures at a time
   $(basename "$0") recursive_max       # run one test
+  $(basename "$0") --shard 1/8         # first of 8 shards
 EOF
 }
 
@@ -266,6 +268,7 @@ run_tasks_parallel() {
 
 main() {
     parse_jobs_flag usage "$@"
+    apply_shard
     local jobs="$PARSED_JOBS"
     set -- "${PARSED_POSITIONAL[@]}"
 

--- a/tests/fixtures/run_lib.sh
+++ b/tests/fixtures/run_lib.sh
@@ -39,7 +39,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/runner_synth.sh"
 usage() {
     cat <<EOF
 Usage:
-  $(basename "$0") [-j N] [test_name ...]
+  $(basename "$0") [-j N] [--shard I/N] [test_name ...]
 
 Run FlowLog library-mode end-to-end tests against the datalog-batch,
 datalog-inc, and extend-batch fixtures. Batch fixtures (CSV in, files
@@ -59,12 +59,14 @@ Options:
                   owns its own runner crate at target/e2e-lib/runner-{slot},
                   so the shared crate state in lib mode is sharded rather
                   than locked.
+  --shard I/N     Run only shard I of N (the fixtures split into N groups).
 
 Examples:
   $(basename "$0")                     # run every fixture sequentially
   $(basename "$0") -j 4                # 4 workers in parallel
   $(basename "$0") agg_sum             # one batch test
   $(basename "$0") recursive_tc_delta  # one incremental test
+  $(basename "$0") --shard 1/8         # first of 8 shards
 EOF
 }
 
@@ -296,6 +298,7 @@ run_tasks_parallel() {
 
 main() {
     parse_jobs_flag usage "$@"
+    apply_shard
     local jobs="$PARSED_JOBS"
     set -- "${PARSED_POSITIONAL[@]}"
 


### PR DESCRIPTION
The `🏁 End-to-end fixtures` job runs **~100 min** and kept blowing past the merge queue's check timeout.

**Portable fix — a `--shard I/N` option on the fixture runners** (added once in `common.sh`, inherited by `run_compiler.sh` + `run_lib.sh`): runs every Nth of the sorted fixtures. It's a subset of the existing named-test path, so it works **locally and under any CI**, not just GitHub:
```
tests/fixtures/run_compiler.sh --shard 1/8
```

**CI** fans it into an **8-way matrix** on free standard runners. A tiny gate job keeps the required-check context `🏁 End-to-end fixtures` **stable** (green only if all shards pass), so branch protection + the merge queue need no changes. Tune the shard count via the matrix length.

Verified the partition is disjoint, complete, and balanced (124 fixtures → 16×4 + 15×4). Expected wall-clock ~100 min → ~30 min, $0 (public repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)