### PR TITLE
feat(profiler): periodically flush metrics during incremental commits

### DIFF
--- a/flowlog-build/src/build/engine/batch.rs
+++ b/flowlog-build/src/build/engine/batch.rs
@@ -196,8 +196,8 @@ fn gen_run_body(
     let size_cell_decls = &parts.size_cell_decls;
     let size_cell_clones = &parts.size_cell_clones;
     let profile_init = &parts.profile_init;
-    let metrics_write = &parts.metrics_write_batch;
-    let step_loop = &parts.batch_step_loop;
+    let metrics_write = &parts.metrics_write;
+    let step_loop = &parts.step_loop;
 
     let (host_partitions, worker_partition_clones) = gen_host_partitions(edbs);
     let inputs_new_args = gen_inputs_new_args(edbs);

--- a/flowlog-build/src/build/engine/incremental.rs
+++ b/flowlog-build/src/build/engine/incremental.rs
@@ -387,7 +387,8 @@ fn gen_worker_closure(
     let inspectors = &parts.inspectors;
     let flush = &parts.flush;
     let profile_init = &parts.profile_init;
-    let metrics_write = &parts.metrics_write_incremental;
+    let metrics_write = &parts.metrics_write;
+    let step_loop = &parts.step_loop;
 
     let inputs_new_args = gen_inputs_new_args(program);
 
@@ -473,9 +474,7 @@ fn gen_worker_closure(
                         time_stamp += 1;
                         inputs.advance_to_all(time_stamp);
                         inputs.flush_all();
-                        while probe.less_than(&time_stamp) {
-                            worker.step();
-                        }
+                        #step_loop
 
                         #metrics_write
 

--- a/flowlog-build/src/codegen/code_parts.rs
+++ b/flowlog-build/src/codegen/code_parts.rs
@@ -50,14 +50,11 @@ pub struct CodeParts {
     pub profile_ops: TokenStream,
     /// Logger registration code (emitted inside worker closure).
     pub profile_init: TokenStream,
-    /// Metrics write-out code for batch mode.
-    pub metrics_write_batch: TokenStream,
-    /// Metrics write-out code for incremental mode.
-    pub metrics_write_incremental: TokenStream,
-    /// Batch run loop: a plain `while worker.step()` fixpoint, or (when
-    /// profiling with a non-zero flush interval) a stepping loop that
-    /// periodically re-dumps metrics.
-    pub batch_step_loop: TokenStream,
+    /// Metrics write-out for the current mode; empty without profiling.
+    pub metrics_write: TokenStream,
+    /// Step loop for the current mode; flushes metrics periodically when
+    /// profiled.
+    pub step_loop: TokenStream,
 
     /// Type aliases and constants for the `(Data, Diff, Time)` triple.
     pub type_declarations: TokenStream,
@@ -120,10 +117,16 @@ impl CodeGen {
             size_cell_clones,
         } = self.collect_inspectors(plan_graph);
 
-        // -- Metrics write code (mode-specific) --
-        let metrics_write_batch = self.gen_metrics_write_batch();
-        let metrics_write_incremental = self.gen_metrics_write_incremental();
-        let batch_step_loop = self.gen_batch_step_loop();
+        // A run is either batch or incremental, never both, so build only the
+        // matching pair.
+        let (metrics_write, step_loop) = if self.config.is_incremental() {
+            (
+                self.gen_metrics_write_incremental(),
+                self.gen_incremental_step_loop(),
+            )
+        } else {
+            (self.gen_metrics_write_batch(), self.gen_batch_step_loop())
+        };
 
         // Rendered after the codegen loop so the plan graph is fully
         // populated. Empty when profile is off.
@@ -147,9 +150,8 @@ impl CodeGen {
             profile_structs,
             profile_ops,
             profile_init,
-            metrics_write_batch,
-            metrics_write_incremental,
-            batch_step_loop,
+            metrics_write,
+            step_loop,
             type_declarations,
             semiring_modules,
         })

--- a/flowlog-build/src/codegen/profile.rs
+++ b/flowlog-build/src/codegen/profile.rs
@@ -213,21 +213,7 @@ impl CodeGen {
             return quote! {};
         }
 
-        // TODO: no periodic in-commit flush here yet (batch has one via
-        // `gen_batch_step_loop`), so a fat single commit leaves no partial
-        // snapshot until it completes. Adding it needs a write-without-reset
-        // variant: the counter reset below must run only on the final
-        // per-commit write, or a periodic partial would split one
-        // transaction's delta across writes.
-        let dir = format!("{}/metrics", self.profile_log_dir());
-        let ops_fmt = format!("{dir}/operators_worker_t{{}}_{{}}.log");
-        let chans_fmt = format!("{dir}/channels_worker_t{{}}_{{}}.log");
-        let write = gen_metrics_write_core(
-            &dir,
-            quote! { format!(#ops_fmt, time_stamp - 1, index) },
-            quote! { format!(#chans_fmt, time_stamp - 1, index) },
-        );
-
+        let write = self.gen_metrics_write_incremental_tables();
         quote! {
             #write
 
@@ -243,25 +229,45 @@ impl CodeGen {
         }
     }
 
-    /// Emits the batch run loop (`worker` and `index` in scope). Without
-    /// profiling or with a zero flush interval this is a plain
-    /// step-to-fixpoint loop. With a non-zero interval the dataflow is
-    /// stepped in a loop that re-dumps the batch metrics every `interval`
-    /// milliseconds (overwriting the `t0` tables), so a long or interrupted
-    /// run still leaves the latest cumulative snapshot on disk. The final
-    /// authoritative dump still runs after the loop drains.
-    pub(crate) fn gen_batch_step_loop(&self) -> TokenStream {
+    /// Emits the incremental table write for the in-flight transaction: dumps
+    /// the counters as they stand into the `t{time_stamp-1}` table pair
+    /// (`time_stamp` and `index` in scope), leaving them intact for the caller
+    /// to reset or keep accumulating. Not resetting lets the same table pair
+    /// be overwritten repeatedly within one transaction without splitting its
+    /// delta across writes.
+    fn gen_metrics_write_incremental_tables(&self) -> TokenStream {
+        let dir = format!("{}/metrics", self.profile_log_dir());
+        let ops_fmt = format!("{dir}/operators_worker_t{{}}_{{}}.log");
+        let chans_fmt = format!("{dir}/channels_worker_t{{}}_{{}}.log");
+        gen_metrics_write_core(
+            &dir,
+            quote! { format!(#ops_fmt, time_stamp - 1, index) },
+            quote! { format!(#chans_fmt, time_stamp - 1, index) },
+        )
+    }
+
+    /// Emits a step loop that periodically flushes metrics. Without profiling
+    /// or with a zero flush interval this is the plain `while #cond { #step }`
+    /// loop; otherwise the same loop re-dumps metrics via `write` every
+    /// `metrics_flush_interval_ms` milliseconds, so a long or interrupted run
+    /// still leaves the latest snapshot on disk.
+    fn gen_flush_loop(
+        &self,
+        cond: TokenStream,
+        step: TokenStream,
+        write: TokenStream,
+    ) -> TokenStream {
         let interval = self.config.metrics_flush_interval_ms();
         if !self.config.profiling_enabled() || interval == 0 {
-            return quote! { while worker.step() {} };
+            return quote! { while #cond { #step } };
         }
 
-        let write = self.gen_metrics_write_batch();
         quote! {
             {
                 let mut __flowlog_last_flush = std::time::Instant::now();
                 let __flowlog_flush_interval = std::time::Duration::from_millis(#interval);
-                while worker.step() {
+                while #cond {
+                    #step
                     if __flowlog_last_flush.elapsed() >= __flowlog_flush_interval {
                         #write
                         __flowlog_last_flush = std::time::Instant::now();
@@ -269,6 +275,28 @@ impl CodeGen {
                 }
             }
         }
+    }
+
+    /// Emits the batch run loop (`worker` and `index` in scope): steps the
+    /// dataflow to fixpoint, periodically flushing metrics when profiled.
+    pub(crate) fn gen_batch_step_loop(&self) -> TokenStream {
+        self.gen_flush_loop(
+            quote! { worker.step() },
+            quote! {},
+            self.gen_metrics_write_batch(),
+        )
+    }
+
+    /// Emits the incremental commit step loop (`worker`, `probe`,
+    /// `time_stamp`, and `index` in scope): steps the dataflow until the probe
+    /// reaches the just-advanced `time_stamp`, periodically flushing metrics
+    /// when profiled.
+    pub(crate) fn gen_incremental_step_loop(&self) -> TokenStream {
+        self.gen_flush_loop(
+            quote! { probe.less_than(&time_stamp) },
+            quote! { worker.step(); },
+            self.gen_metrics_write_incremental_tables(),
+        )
     }
 }
 

--- a/flowlog-build/src/lib.rs
+++ b/flowlog-build/src/lib.rs
@@ -164,11 +164,11 @@ impl Builder {
         self
     }
 
-    /// Milliseconds between periodic metric flushes during a profiled batch
-    /// run, so a long or interrupted run still leaves the latest snapshot on
-    /// disk. Defaults to `0` (flush only at the end); set a non-zero value to
-    /// snapshot periodically. Batch modes only, and ignored unless
-    /// [`Self::profile`] is set.
+    /// Milliseconds between periodic metric flushes during a profiled run, so
+    /// a long or interrupted run still leaves the latest snapshot on disk.
+    /// Defaults to `0` (flush only at each natural write point: after a batch
+    /// run drains, or after each incremental commit); a non-zero value also
+    /// snapshots mid-run. Ignored unless [`Self::profile`] is set.
     pub fn metrics_flush_interval_ms(mut self, ms: u64) -> Self {
         self.metrics_flush_interval_ms = ms;
         self

--- a/flowlog-common/src/config.rs
+++ b/flowlog-common/src/config.rs
@@ -58,10 +58,11 @@ pub struct Config {
     /// interning order — and therefore `ord(_)` values — is deterministic across
     /// worker counts (`-w N` matches `-w 1`).
     pub serialize_load: bool,
-    /// Milliseconds between periodic metric flushes while a profiled batch
-    /// run is executing, so a long or interrupted run still leaves the latest
-    /// cumulative snapshot on disk. `0` flushes only at the end. Batch modes
-    /// only: incremental modes snapshot per transaction and ignore this.
+    /// Milliseconds between periodic metric flushes while a profiled run is
+    /// executing, so a long or interrupted run still leaves the latest
+    /// snapshot on disk. `0` flushes only at each natural write point (batch:
+    /// after the run drains; incremental: after each transaction commits). A
+    /// non-zero interval additionally re-dumps the in-flight tables mid-run.
     pub metrics_flush_interval_ms: u64,
 }
 
@@ -145,7 +146,7 @@ impl Config {
         self.serialize_load
     }
 
-    /// Milliseconds between periodic metric flushes; `0` means end-only.
+    /// Milliseconds between periodic metric flushes; `0` disables them.
     pub fn metrics_flush_interval_ms(&self) -> u64 {
         self.metrics_flush_interval_ms
     }

--- a/flowlog-compiler/src/assembly/batch.rs
+++ b/flowlog-compiler/src/assembly/batch.rs
@@ -33,8 +33,8 @@ pub(crate) fn gen_batch_main(
         size_cell_decls,
         size_cell_clones,
         profile_init,
-        metrics_write_batch: metrics_write,
-        batch_step_loop: step_loop,
+        metrics_write,
+        step_loop,
         ..
     } = parts;
     let Input {

--- a/flowlog-compiler/src/assembly/inc.rs
+++ b/flowlog-compiler/src/assembly/inc.rs
@@ -32,7 +32,8 @@ pub(crate) fn gen_incremental_main(
         size_cell_decls,
         size_cell_clones,
         profile_init,
-        metrics_write_incremental: metrics_write,
+        metrics_write,
+        step_loop,
         ..
     } = p;
     let Input {
@@ -147,9 +148,7 @@ pub(crate) fn gen_incremental_main(
                                         r.advance_to(time_stamp);
                                         r.flush();
                                     }
-                                    while probe.less_than(&time_stamp) {
-                                        worker.step();
-                                    }
+                                    #step_loop
 
                                     #metrics_write
 
@@ -251,9 +250,7 @@ pub(crate) fn gen_incremental_main(
                                     r.advance_to(time_stamp);
                                     r.flush();
                                 }
-                                while probe.less_than(&time_stamp) {
-                                    worker.step();
-                                }
+                                #step_loop
 
                                 #metrics_write
 

--- a/flowlog-compiler/src/cli.rs
+++ b/flowlog-compiler/src/cli.rs
@@ -40,10 +40,10 @@ pub struct Cli {
     #[arg(long, short = 'P')]
     pub profile: bool,
 
-    /// Milliseconds between periodic metric flushes while a profiled batch
-    /// run executes, so a long or interrupted run still leaves the latest
-    /// partial metrics on disk. `0` flushes only at the end. Batch modes
-    /// only; needs `--profile`.
+    /// Milliseconds between periodic metric flushes while a profiled run
+    /// executes, so a long or interrupted run still leaves the latest partial
+    /// metrics on disk. `0` flushes only at each natural write point (end of a
+    /// batch run, or after each incremental commit). Needs `--profile`.
     #[arg(long, value_name = "MS", default_value_t = 5000)]
     pub metrics_flush_interval_ms: u64,
 


### PR DESCRIPTION
## What

Batch profiling gained a periodic in-run metrics flush in #246. Incremental mode still wrote each transaction's metric tables only after its commit drained, so a long or interrupted commit left that transaction with nothing on disk. This extends the same opt-in flush to the incremental commit path, and folds the now-redundant mode-specific `CodeParts` fields into single per-mode fields.

## Changes

- **Incremental periodic flush.** A profiled incremental commit re-dumps the in-flight transaction's `t{ts-1}` tables every `--metrics-flush-interval-ms` ms while its fixpoint runs, *without* resetting the per-transaction counters; the authoritative write-and-reset still runs when the commit drains. Writes go through the existing `write_atomic`, so an interrupted flush can't tear a table. Library engine + CLI shell (both worker roles); the Quit-drain and preload loops stay plain.
- **Knobs.** `--metrics-flush-interval-ms` / `Builder::metrics_flush_interval_ms` (default 5000 CLI, 0 library) now apply to incremental too; `0` flushes only at each natural write point. Docs updated; the #246 `TODO` is retired.
- **Cleanup.** A run is batch or incremental but never both, so `metrics_write_{batch,incremental}` + `{batch,incremental}_step_loop` collapse to one `metrics_write` + one `step_loop`, chosen by `is_incremental()`. The shared flush timer/guard scaffolding lives in one `gen_flush_loop` helper that both step-loop generators call.
