### PR TITLE
refactor(planner): hash transformation fingerprints in flow coordinates

### DIFF
--- a/flowlog-build/src/planner/program_planner.rs
+++ b/flowlog-build/src/planner/program_planner.rs
@@ -182,8 +182,8 @@ mod tests {
     }
 
     /// Both rules key `B` on its first column, but at different rhs
-    /// positions (1 vs 0). Lineage fps embed that position; content-canonical
-    /// materialization must share one arrangement.
+    /// positions (1 vs 0). Fingerprints hash the positional flow, so the
+    /// rhs position must never split the shared arrangement.
     const RHS_ID_SHARING_SRC: &str = "\
         .decl A(x: int32, y: int32)\n\
         .decl B(x: int32, y: int32)\n\
@@ -230,6 +230,29 @@ mod tests {
         assert_eq!(
             consumers, 2,
             "both joins must consume the shared B arrangement"
+        );
+    }
+
+    /// Fingerprints are content-canonical during planning too, not only
+    /// after materialization: the B premaps of both rules must already
+    /// collide at the info level, where the fuse passes group by fp.
+    #[test]
+    fn planning_fingerprints_collide_across_rules() {
+        let pp = analyze(RHS_ID_SHARING_SRC);
+        let b_fp = compute_fp("b");
+
+        let b_premap_fps: Vec<u64> = pp
+            .strata()
+            .iter()
+            .flat_map(|s| s.rule_planners())
+            .flat_map(|rp| rp.transformation_infos())
+            .filter(|info| info.input_info_fp() == (b_fp, None))
+            .map(|info| info.output_info_fp())
+            .collect();
+        assert_eq!(b_premap_fps.len(), 2, "each rule premaps B once");
+        assert_eq!(
+            b_premap_fps[0], b_premap_fps[1],
+            "identical premaps of B must share one fingerprint before materialization"
         );
     }
 

--- a/flowlog-build/src/planner/rule_planner.rs
+++ b/flowlog-build/src/planner/rule_planner.rs
@@ -88,16 +88,43 @@ impl RulePlanner {
         &self.transformations
     }
 
-    /// Materialize all infos into [`Transformation`]s with content-canonical
-    /// fingerprints (see [`Transformation::from_info`]). Must run after post,
-    /// in pipeline order so inputs resolve to their producers' fingerprints.
+    /// Materialize all infos into [`Transformation`]s. Must run after post.
+    ///
+    /// Pure representation conversion: fingerprints are content-current by
+    /// the time this runs (fuse ends with a refresh sweep, and post
+    /// refreshes eagerly).
     pub(crate) fn materialize(&mut self) {
-        let mut fp_map: HashMap<u64, u64> = HashMap::new();
         self.transformations = self
             .transformation_infos
             .iter()
-            .map(|info| Transformation::from_info(info, &mut fp_map))
+            .map(Transformation::from_info)
             .collect();
+    }
+
+    /// Recompute every info's output fingerprint bottom-up and re-point
+    /// consumer ports whose input fingerprints went stale.
+    ///
+    /// Walks in pipeline order (producers precede consumers), so a rename
+    /// is always recorded before any consumer reads it.
+    pub(super) fn refresh_fps(&mut self) {
+        let mut renames: HashMap<u64, u64> = HashMap::new();
+        for info in &mut self.transformation_infos {
+            let (left_fp, right_fp) = info.input_info_fp();
+            if let Some(&new_fp) = renames.get(&left_fp) {
+                info.set_input_fp(true, new_fp);
+            }
+            if let Some(right_fp) = right_fp
+                && let Some(&new_fp) = renames.get(&right_fp)
+            {
+                info.set_input_fp(false, new_fp);
+            }
+
+            let old_fp = info.output_info_fp();
+            info.refresh_output_fp();
+            if old_fp != info.output_info_fp() {
+                renames.insert(old_fp, info.output_info_fp());
+            }
+        }
     }
 
     /// Returns the original rule.

--- a/flowlog-build/src/planner/rule_planner/fuse.rs
+++ b/flowlog-build/src/planner/rule_planner/fuse.rs
@@ -1,17 +1,11 @@
-//! Fuse logic for rule planner.
+//! Fuse pass over a rule's transformation infos: merge map steps into
+//! their producers and push key/value layout requirements upstream, so
+//! the pipeline reaches materialization without redundant hops.
 //!
-//! Warning: you should not modify this file unless you are very sure about what you are doing.
+//! Both passes assume the orderings earlier phases established:
 //!
-//! This module implements the logic to fuse map transformations into their producers
-//! to reduce the number of transformation steps and improve performance.
-//! It also ensures that key-value layout requirements are correctly propagated
-//! through the transformation pipeline.
-//!
-//! Recommended rules when reasoning about fusion order:
-//! 1. Always apply base filters before any further operations.
-//! 2. Always perform possible comparisons before any semijoins.
-//!
-//! Not following these rules might introduce subtle bugs.
+//! 1. Base filters apply before any further operations.
+//! 2. Comparisons apply before any semijoins.
 
 use std::collections::BTreeMap;
 use std::collections::HashSet;
@@ -31,19 +25,23 @@ use crate::planner::KeyValueLayout;
 use crate::planner::PlanError;
 use crate::planner::TransformationInfo;
 
-/// Ordered consumer indices alongside their key/value index selections.
-/// (minimum consumer id, consumer ids, key indices, value indices)
-type ConsumerLayout = (usize, Vec<usize>, Vec<usize>, Vec<usize>);
-/// Assigned producer indices with their consumers and key/value index selections.
-/// (assigned producer ids, consumer ids, key indices, value indices)
-type LayoutAssignment = (Vec<usize>, Vec<usize>, Vec<usize>, Vec<usize>);
+/// Consumer input ports grouped by the (key indices, value indices) layout
+/// they demand of a shared producer. A port is (consumer index, `is_left`);
+/// see [`TransformationInfo::set_input_fp`] for the `is_left` convention.
+type LayoutDemands = BTreeMap<(Vec<usize>, Vec<usize>), Vec<(usize, bool)>>;
+/// Ordered consumer input ports alongside their key/value index selections.
+/// (minimum consumer id, consumer ports, key indices, value indices)
+type ConsumerLayout = (usize, Vec<(usize, bool)>, Vec<usize>, Vec<usize>);
+/// Assigned producer indices with their consumer ports and key/value index selections.
+/// (assigned producer ids, consumer ports, key indices, value indices)
+type LayoutAssignment = (Vec<usize>, Vec<(usize, bool)>, Vec<usize>, Vec<usize>);
 
 // =========================================================================
 // Fusion
 // =========================================================================
 impl RulePlanner {
-    /// Run fusion passes (map fusion and KV-layout fusion) on
-    /// the planned transformation infos.
+    /// Runs both fusion passes, then settles the fingerprints their
+    /// rewiring deferred.
     pub(crate) fn fuse(&mut self, original_atom_fp: &HashSet<u64>) -> Result<(), PlanError> {
         trace!(
             "Transformation infos before fusion:\n{}",
@@ -51,6 +49,12 @@ impl RulePlanner {
         );
         self.fuse_map(original_atom_fp)?;
         self.fuse_kv_layout(original_atom_fp)?;
+        // Input rewiring inside the passes above defers fingerprint
+        // refreshes (an eager refresh would invalidate the fp-keyed maps
+        // mid-pass); settle them now so fingerprints are content-current
+        // whenever control is outside fuse.
+        self.refresh_fps();
+        self.rebuild_producer_consumer(original_atom_fp)?;
         trace!(
             "Transformation infos after fusion:\n{}",
             self.transformation_infos_dump()
@@ -60,10 +64,13 @@ impl RulePlanner {
 }
 
 impl RulePlanner {
-    /// Fuse map transformation infos.
+    /// Merges every fusable map into its producer(s): the producer takes
+    /// over the map's output layout, predicates, and name, the map's
+    /// consumers re-point to the producer, and the map is removed.
     ///
-    /// Map transformations that directly consume the output of other transformations
-    /// (and are not neg joins) can be fused into their producers.
+    /// Maps reading an EDB (no producer to merge into) and SIP
+    /// projections (the project/semijoin pair must stay intact) are left
+    /// in place.
     fn fuse_map(&mut self, original_atom_fp: &HashSet<u64>) -> Result<(), PlanError> {
         let mut fused_map_indices = Vec::new();
 
@@ -82,12 +89,13 @@ impl RulePlanner {
                 continue;
             };
 
-            // Do not fuse SIP projection transformations
+            // Fusing a SIP projection would collapse SIP's
+            // project/semijoin pair into the wrong producer.
             if *is_sip_projection {
                 continue;
             }
 
-            // Do not fuse if the input is from an EDB
+            // An EDB input has no producer transformation to merge into.
             if original_atom_fp.contains(input_info_fp) {
                 trace!(
                     "[fuse_map] skip at idx {}: input is original atom {:#018x}",
@@ -105,11 +113,11 @@ impl RulePlanner {
             let input_producer_indices = self.producer_indices(input_fp)?;
             let mut input_producer_output_fp = 0u64;
             for &input_producer_index in &input_producer_indices {
-                // Short-lived borrow to check if producer is a neg join
                 let producer_tx = &self.transformation_infos[input_producer_index];
                 if producer_tx.is_neg_join() && !predicates.compare_exprs.is_empty() {
-                    // We always apply possible comparisons before neg joins, so it is impossible
-                    // to fuse a map with a neg join producer if there are any comparisons.
+                    // Comparisons always apply before neg joins (module
+                    // ordering rule 2), so a map with comparisons can
+                    // never sit downstream of a neg join.
                     return Err(PlanError::internal(
                         "fuse_map: impossible fusion of map with neg join producer",
                     ));
@@ -126,7 +134,6 @@ impl RulePlanner {
                     out_kv_layout.value()
                 );
 
-                // Apply fused layout + comparisons + fn_call predicates to producer, and get new output fp
                 input_producer_output_fp = self.apply_fused_layout_filters_cmps(
                     input_producer_index,
                     &out_kv_layout,
@@ -137,12 +144,14 @@ impl RulePlanner {
 
             let output_consumer_indices = self.consumer_indices(output_fp)?;
 
-            // Update all consumers to point to the producer's new output
+            // Update all consumers to point to the producer's new output.
+            let mut patched: HashSet<usize> = HashSet::new();
             for &output_consumer_index in &output_consumer_indices {
-                let consumer_tx = &mut self.transformation_infos[output_consumer_index];
-                consumer_tx.update_input_fake_info_fp(input_producer_output_fp, &output_fp);
+                if patched.insert(output_consumer_index) {
+                    let consumer_tx = &mut self.transformation_infos[output_consumer_index];
+                    consumer_tx.update_input_fp(input_producer_output_fp, &output_fp);
+                }
 
-                // Update the producer-consumer mapping
                 self.insert_consumer(
                     original_atom_fp,
                     input_producer_output_fp,
@@ -152,11 +161,10 @@ impl RulePlanner {
                     "[fuse_map]   -> updated consumer idx {} to input {:#018x}",
                     output_consumer_index, input_producer_output_fp
                 );
-                // Note: No need to update the input key-value layout of consumers here.
-                // They will be updated when processed as join producers in later iterations.
+                // Consumer input layouts stay as they are: each is updated
+                // when its own iteration processes it as a join producer.
             }
 
-            // Update the producer_consumer map
             fused_map_indices.push(index);
         }
 
@@ -170,13 +178,15 @@ impl RulePlanner {
             self.transformation_infos_dump()
         );
 
-        // After removing fused maps, rebuild the producer-consumer
+        // Removals shifted indices and fusion changed fingerprints; the
+        // map must be re-derived before anyone consults it.
         self.rebuild_producer_consumer(original_atom_fp)?;
         Ok(())
     }
 
-    /// Fuse correct key-value layout requirements from downstream transformation infos
-    /// to upstream transformations.
+    /// Pushes each consumer's required key/value split upstream, so
+    /// producers emit arrangements keyed the way their consumers read
+    /// them.
     fn fuse_kv_layout(&mut self, original_atom_fp: &HashSet<u64>) -> Result<(), PlanError> {
         // Collect output fingerprints in transformation order, keeping only
         // the first occurrence of each. Order matters for sharing
@@ -191,15 +201,15 @@ impl RulePlanner {
             .collect();
 
         for tx_fp in tx_fps {
-            // Copy out the producer index and current consumers (if any), then mutate
+            // Clone out of the map; the loop body mutates `self`.
             let Some((producer_indices, consumers)) = self.producer_consumer.get(&tx_fp).cloned()
             else {
-                // No producer found - likely an original atom; ignore
+                // No producer: an original atom, nothing to re-key.
                 continue;
             };
 
             if consumers.is_empty() {
-                // No consumers - likely a final output; ignore
+                // No consumers: a final output, no layout demand on it.
                 continue;
             }
 
@@ -213,34 +223,34 @@ impl RulePlanner {
                     "[fuse_kv_layout] fuse at producer fp {:#018x} -> consumers {:?}; key ids: {:?}, value ids: {:?}",
                     tx_fp, consumers, key_indices, value_indices
                 );
-                // Update producer layout and fingerprint
                 let mut new_output_fp = 0u64;
                 for producer_idx in producers {
                     new_output_fp = {
                         let producer_tx = &mut self.transformation_infos[producer_idx];
                         producer_tx.refactor_output_key_value_layout(&key_indices, &value_indices);
-                        producer_tx.update_output_fake_sig();
+                        producer_tx.refresh_output_fp();
                         producer_tx.output_info_fp()
                     };
                 }
 
-                // Update consumers to use new fingerprint
-                for consumer_idx in consumers {
-                    self.transformation_infos[consumer_idx]
-                        .update_input_fake_info_fp(new_output_fp, &tx_fp);
+                // Rewire each consumer port to the new fingerprint. Ports,
+                // not fingerprint matching: after the producer refresh both
+                // sides of a self-join may already hold equal fps, and only
+                // the recorded side belongs to this layout assignment.
+                for (consumer_idx, is_left) in consumers {
+                    self.transformation_infos[consumer_idx].set_input_fp(is_left, new_output_fp);
                 }
             }
         }
 
-        // After updating kv-layouts, rebuild the producer-consumer
+        // Producer fingerprints changed; the map must be re-derived
+        // before anyone consults it.
         self.rebuild_producer_consumer(original_atom_fp)?;
         Ok(())
     }
 }
 
-// -----------------------------
-// Small helpers (private)
-// -----------------------------
+// --- Small helpers ---
 impl RulePlanner {
     /// Rebuild the fused map's output layout over the producer's positions,
     /// update the producer's layout and comparisons, then return the new
@@ -253,8 +263,6 @@ impl RulePlanner {
         predicates: &KvPredicates,
         fused_map_output_name: String,
     ) -> Result<u64, PlanError> {
-        // Build the new output layout by transferring the fused map's
-        // positions onto the current producer output
         let all_positions = self.collect_output_positions(producer_idx);
         let new_out_kv_layout = Self::transfer_layout(&all_positions, fused_out_layout)?;
 
@@ -263,9 +271,8 @@ impl RulePlanner {
         let remapped_var_eq = Self::remap_var_eq_constraints(&all_positions, &predicates.var_eq)?;
         let remapped_cmps = Self::remap_comparisons(&all_positions, &predicates.compare_exprs)?;
 
-        // Update producer output layout, predicates, name and fingerprint.
-        // The producer now semantically emits what the fused map used to emit,
-        // so its output_name inherits the map's.
+        // The producer now semantically emits what the fused map used to
+        // emit, so its output_name inherits the map's.
         {
             let producer_tx = &mut self.transformation_infos[producer_idx];
             producer_tx.update_output_key_value_layout(new_out_kv_layout);
@@ -277,16 +284,15 @@ impl RulePlanner {
                 producer_tx.update_comparisons(remapped_cmps)?;
             }
             producer_tx.update_output_name(fused_map_output_name);
-            producer_tx.update_output_fake_sig();
+            producer_tx.refresh_output_fp();
         }
 
-        // Return the new output fingerprint
         let new_fp = self.transformation_infos[producer_idx].output_info_fp();
         self.insert_producer(new_fp, producer_idx);
         Ok(new_fp)
     }
 
-    // Collect all output positions (keys + values) from an upstream transformation.
+    /// Collects a producer's output positions, keys then values.
     #[inline]
     fn collect_output_positions(&self, producer_idx: usize) -> Vec<ArithmeticPos> {
         let layout = self.transformation_infos[producer_idx].output_kv_layout();
@@ -298,7 +304,8 @@ impl RulePlanner {
             .collect()
     }
 
-    // Rebuild a fused map's output layout over its producer's output positions.
+    /// Rebuilds a fused map's output layout over its producer's output
+    /// positions.
     #[inline]
     fn transfer_layout(
         positions: &[ArithmeticPos],
@@ -335,8 +342,8 @@ impl RulePlanner {
         ))
     }
 
-    /// Remap comparison expressions by converting each variable signature to the
-    /// corresponding ArithmeticPos from the provided positions and rebuilding.
+    /// Remaps a fused map's comparison expressions onto the producer's
+    /// output positions.
     fn remap_comparisons(
         positions: &[ArithmeticPos],
         cmps: &[ComparisonExprPos],
@@ -354,7 +361,8 @@ impl RulePlanner {
             .collect()
     }
 
-    /// Remap an ArithmeticPos by resolving each variable signature through `positions`.
+    /// Remaps an arithmetic expression by resolving each of its variable
+    /// signatures through `positions`.
     fn remap_arithmetic(
         positions: &[ArithmeticPos],
         expr: &ArithmeticPos,
@@ -375,6 +383,8 @@ impl RulePlanner {
         Ok(expr.map_vars(&|sig| positions[sig.argument_id()].init().clone()))
     }
 
+    /// Remaps a fused map's constant-equality constraints onto the
+    /// producer's output positions.
     fn remap_const_eq_constraints(
         positions: &[ArithmeticPos],
         constraints: &[(AtomArgumentSignature, Constant)],
@@ -388,6 +398,8 @@ impl RulePlanner {
             .collect()
     }
 
+    /// Remaps a fused map's variable-equality constraints onto the
+    /// producer's output positions.
     fn remap_var_eq_constraints(
         positions: &[ArithmeticPos],
         constraints: &[(AtomArgumentSignature, AtomArgumentSignature)],
@@ -416,6 +428,8 @@ impl RulePlanner {
         )
     }
 
+    /// Resolves an atom-argument signature to the first signature of its
+    /// position in the producer's output.
     fn remap_atom_signature(
         positions: &[ArithmeticPos],
         sig: &AtomArgumentSignature,
@@ -436,12 +450,13 @@ impl RulePlanner {
         })
     }
 
-    /// Rebuild the producer_consumer map and key-value layouts after fusion.
+    /// Re-derives `producer_consumer` from the current infos: producers
+    /// from output fingerprints, consumers from input fingerprints, one
+    /// consumer entry per input port.
     fn rebuild_producer_consumer(
         &mut self,
         original_atom_fp: &HashSet<u64>,
     ) -> Result<(), PlanError> {
-        // Clear caches
         self.producer_consumer.clear();
 
         let count = self.transformation_infos.len();
@@ -450,7 +465,7 @@ impl RulePlanner {
             count
         );
 
-        // First pass: register all producers
+        // Producers first: insert_consumer requires its producer entry.
         for index in 0..count {
             let output_fp = self.transformation_infos[index].output_info_fp();
             self.insert_producer(output_fp, index);
@@ -460,7 +475,6 @@ impl RulePlanner {
             );
         }
 
-        // Second pass: register all consumers for each input fingerprint
         for index in 0..count {
             let (left_fp, right_fp_opt) = self.transformation_infos[index].input_info_fp();
             for input_fp in [Some(left_fp), right_fp_opt].into_iter().flatten() {
@@ -468,7 +482,6 @@ impl RulePlanner {
             }
         }
 
-        // Detailed mapping summary
         for (fp, (prod_idx, consumers)) in &self.producer_consumer {
             trace!(
                 "[rebuild_producer_consumer] mapping: fp {:#018x} -> producer {:?}, consumers {:?}",
@@ -483,18 +496,20 @@ impl RulePlanner {
         Ok(())
     }
 
-    /// Collect distinct key-value layouts required by consumers of a given input fingerprint.
-    /// Sorted by minimum consumer index.
+    /// Collects the distinct key/value layouts the consumers of `input_fp`
+    /// demand, each with the ports demanding it, ordered by minimum
+    /// consumer index.
     fn collect_consumer_layout_indices(
         &mut self,
         consumer_indices: &[usize],
         input_fp: u64,
     ) -> Result<Vec<ConsumerLayout>, PlanError> {
-        // Map from (key indices, value indices) to consumer ids
-        let mut layouts: BTreeMap<(Vec<usize>, Vec<usize>), Vec<usize>> = BTreeMap::new();
+        let mut layouts: LayoutDemands = BTreeMap::new();
         let mut real_key_value_layout = None;
 
         // First pass: only join and antijoin contribute real key/value layout requirements.
+        // Check both sides independently: one collection can feed both sides
+        // of a self-join, and each side may demand a different layout.
         for &consumer_idx in consumer_indices {
             let join_inputs = match &self.transformation_infos[consumer_idx] {
                 TransformationInfo::JoinToKV {
@@ -520,30 +535,32 @@ impl RulePlanner {
             };
 
             if let Some((left_fp, right_fp, left_layout, right_layout)) = join_inputs {
-                let matched_layout = if *left_fp == input_fp {
-                    left_layout
-                } else if *right_fp == input_fp {
-                    right_layout
-                } else {
+                let matched_sides = [
+                    (*left_fp == input_fp).then_some((true, left_layout)),
+                    (*right_fp == input_fp).then_some((false, right_layout)),
+                ];
+                if matched_sides.iter().all(Option::is_none) {
                     return Err(PlanError::internal(format!(
                         "collect_consumer_layout_indices: consumer idx {consumer_idx} does not match input fp {input_fp:#018x} in join/antijoin layout"
                     )));
-                };
-
-                if real_key_value_layout.is_none() {
-                    real_key_value_layout = Some(matched_layout.clone());
                 }
-                let (key_indices, value_indices) =
-                    matched_layout.extract_argument_ids_from_layout();
-                layouts
-                    .entry((key_indices, value_indices))
-                    .or_default()
-                    .push(consumer_idx);
+
+                for (side, matched_layout) in matched_sides.into_iter().flatten() {
+                    if real_key_value_layout.is_none() {
+                        real_key_value_layout = Some(matched_layout.clone());
+                    }
+                    let (key_indices, value_indices) =
+                        matched_layout.extract_argument_ids_from_layout();
+                    layouts
+                        .entry((key_indices, value_indices))
+                        .or_default()
+                        .push((consumer_idx, side));
+                }
             }
         }
 
-        // Second pass: KV-to-KV consumers inherit the join/antijoin layout requirement.
-        // They don't define their own key/value split — they adopt the first join/antijoin's.
+        // Second pass: KV-to-KV consumers define no key/value split of
+        // their own; they adopt the first join/antijoin's.
         for &consumer_idx in consumer_indices {
             // Only process KV-to-KV maps whose input matches this producer.
             if !matches!(
@@ -574,29 +591,27 @@ impl RulePlanner {
             layouts
                 .entry((key_indices, value_indices))
                 .or_default()
-                .push(consumer_idx);
+                .push((consumer_idx, true));
         }
 
         let mut consumer_collection: Vec<ConsumerLayout> = layouts
             .into_iter()
             .map(|((key_ids, value_ids), mut consumers)| {
                 consumers.sort_unstable();
-                (consumers[0], consumers, key_ids, value_ids)
+                (consumers[0].0, consumers, key_ids, value_ids)
             })
             .collect();
         consumer_collection.sort_by_key(|(first_consumer, ..)| *first_consumer);
         Ok(consumer_collection)
     }
 
-    /// Assign producer indices to consumer layout kinds.
-    /// Ensures that each consumer layout kind is assigned at least one producer index
-    /// that appears before its first consumer index.
+    /// Assigns producer indices to consumer layout kinds, giving each kind
+    /// at least one producer that appears before its first consumer.
     fn assign_layout_to_producer(
         tx_fp: u64,
         producer_indices: &[usize],
         consumer_layouts: &[ConsumerLayout],
     ) -> Result<Vec<LayoutAssignment>, PlanError> {
-        // Check feasibility.
         if consumer_layouts.len() > producer_indices.len() {
             return Err(PlanError::internal(format!(
                 "assign_layout_to_producer: {tx_fp:#018x} has {} consumer layout kinds but only {} producers available",
@@ -632,8 +647,8 @@ impl RulePlanner {
             ));
         }
 
-        // If there are any remaining available producers, assign them to the first consumer layout kind.
-        // Randomly assign also works, for simplify code we just push to the first one.
+        // Leftover producers all land on the first layout kind; any
+        // assignment would do, this is the simplest.
         if !available.is_empty() {
             match assignments.first_mut() {
                 Some((producer_ids, ..)) => {
@@ -657,10 +672,9 @@ mod tests {
     use super::super::common::test_setup;
     use crate::planner::TransformationInfo;
 
-    /// A filter whose input is an EDB atom must survive fuse — the EDB
-    /// guard at fuse.rs:84 blocks fusion into something that has no
-    /// upstream producer. A broken guard would error out or silently
-    /// drop the filter.
+    /// A filter whose input is an EDB atom must survive fuse: there is no
+    /// upstream producer to merge it into. A broken guard would error out
+    /// or silently drop the filter.
     #[test]
     fn fuse_map_skips_edb_input() {
         let (mut planner, mut catalog) = test_setup(
@@ -689,7 +703,7 @@ mod tests {
     }
 
     /// After equi-join fusion, fuse must key each side's arrangement on the
-    /// *materialized* computed expression (`x + 1` / `y + 2`) — collapsing it
+    /// *materialized* computed expression (`x + 1` / `y + 2`); collapsing it
     /// to the base column would join on the wrong value.
     #[test]
     fn fuse_keys_arrangement_on_materialized_equijoin_column() {
@@ -726,9 +740,9 @@ mod tests {
         );
     }
 
-    /// fuse.rs:79 explicitly skips `is_sip_projection == true`. If that
-    /// guard were removed, SIP's project→semijoin pair would collapse
-    /// into the wrong producer and SIP semantics would silently break.
+    /// `fuse_map` explicitly skips SIP projections. If that guard were
+    /// removed, SIP's project/semijoin pair would collapse into the wrong
+    /// producer and SIP semantics would silently break.
     ///
     /// Rule shape avoids positive-subset relations among atoms so that
     /// `prepare`'s `apply_positive_semijoin` doesn't consume the SIP

--- a/flowlog-build/src/planner/rule_planner/post.rs
+++ b/flowlog-build/src/planner/rule_planner/post.rs
@@ -67,7 +67,7 @@ impl RulePlanner {
         let new_layout = KeyValueLayout::new(Vec::new(), output_values);
         last_tx.update_row_output(true);
         last_tx.update_output_key_value_layout(new_layout);
-        last_tx.update_output_fake_sig();
+        last_tx.refresh_output_fp();
         Ok(())
     }
 
@@ -82,7 +82,7 @@ impl RulePlanner {
 
         // We default here assume the input layout is all values from the first positive atom.
         // No additional mapping is needed.
-        let (input_fake_sig, input_kv_layout) = (
+        let (input_fp, input_kv_layout) = (
             catalog.positive_atom_fingerprint(0),
             KeyValueLayout::new(
                 Vec::new(),
@@ -97,7 +97,7 @@ impl RulePlanner {
         // Post is a layout-only alignment; the name passes through unchanged.
         let input_name = catalog.positive_atom_name(0)?.to_string();
         let mut post_tx = TransformationInfo::kv_to_kv(
-            input_fake_sig,
+            input_fp,
             input_name.clone(),
             input_name,
             true,
@@ -106,7 +106,7 @@ impl RulePlanner {
             KvPredicates::default(),
         );
         post_tx.update_row_output(true);
-        post_tx.update_output_fake_sig();
+        post_tx.refresh_output_fp();
 
         self.transformation_infos.push(post_tx);
         Ok(())

--- a/flowlog-build/src/planner/stratum_planner.rs
+++ b/flowlog-build/src/planner/stratum_planner.rs
@@ -162,9 +162,7 @@ impl StratumPlanner {
             planner.post(catalog)?;
         }
 
-        // Phase 6: Materialize per-rule transformations, rewriting lineage
-        // (rhs_id-laden) fingerprints to content-canonical ones so identical
-        // operations dedup across rules.
+        // Phase 6: Materialize per-rule transformations.
         for planner in rule_planners.iter_mut() {
             planner.materialize();
         }

--- a/flowlog-build/src/planner/transformation.rs
+++ b/flowlog-build/src/planner/transformation.rs
@@ -4,14 +4,11 @@
 //! through query execution plans. Transformations represent operations like filtering,
 //! projection, joins, and aggregation that convert input collections into output collections.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
-use flowlog_common::compute_fp;
 use tracing::trace;
 
-use crate::catalog::JoinPredicates;
 use crate::planner::Collection;
 
 mod flow;
@@ -214,66 +211,25 @@ impl Transformation {
     }
 }
 
-/// Lineage fp → content fp; absent entries (name-based atom fps) pass through.
-fn resolve_fp(fp_map: &HashMap<u64, u64>, fp: u64) -> u64 {
-    fp_map.get(&fp).copied().unwrap_or(fp)
-}
-
 // ========================
 // Constructors
 // ========================
 impl Transformation {
-    /// Materialize a [`TransformationInfo`] into a [`Transformation`] whose
-    /// output fingerprint is content-canonical — `hash(variant tag, resolved
-    /// input fps, flow)`, all rhs_id-free — unlike the lineage info
-    /// fingerprints, which embed rule-local atom positions and defeat
-    /// cross-rule sharing.
+    /// Materialize a [`TransformationInfo`] into a [`Transformation`].
     ///
-    /// `fp_map` (per rule, threaded in pipeline order) maps info fp →
-    /// content fp so inputs resolve to their producers; many info fps
-    /// mapping to one content fp is the intended sharing.
-    pub(crate) fn from_info(info: &TransformationInfo, fp_map: &mut HashMap<u64, u64>) -> Self {
-        // Tag mirrors the variant picked below, so equal fingerprints
-        // imply the same variant.
-        let (left, right) = info.input_info_fp();
-        let left_fp = resolve_fp(fp_map, left);
-        let right_fp = right.map(|fp| resolve_fp(fp_map, fp));
-        let tag = match info {
-            TransformationInfo::KVToKV { .. } => {
-                match (info.is_row_input(), info.is_row_output()) {
-                    (true, true) => "row_to_row",
-                    (true, false) => "row_to_kv",
-                    (false, true) => "kv_to_row",
-                    (false, false) => "kv_to_kv",
-                }
-            }
-            TransformationInfo::JoinToKV { .. } => {
-                if info.is_row_output() {
-                    "jn_to_row"
-                } else {
-                    "jn_to_kv"
-                }
-            }
-            TransformationInfo::AntiJoinToKV { .. } => {
-                if info.is_row_output() {
-                    "njn_to_row"
-                } else {
-                    "njn_to_kv"
-                }
-            }
-        };
-
-        let tx = match info {
-            TransformationInfo::KVToKV { .. } => Self::kv_to_kv(info, tag, left_fp),
-            TransformationInfo::JoinToKV { .. } => {
-                Self::join(info, tag, left_fp, right_fp.unwrap())
-            }
-            TransformationInfo::AntiJoinToKV { .. } => {
-                Self::antijoin(info, tag, left_fp, right_fp.unwrap())
-            }
-        };
-        fp_map.insert(info.output_info_fp(), tx.output().fingerprint());
-        tx
+    /// Pure representation conversion: the info's fingerprints are already
+    /// content-canonical (`hash(variant tag, input fps, flow)`, rhs_id-free),
+    /// so they are adopted as-is; identical operations within and across
+    /// rules share fingerprints, which downstream dedup collapses.
+    ///
+    /// Requires every fingerprint to be current (fuse ends with a refresh
+    /// sweep, and later mutation sites refresh eagerly).
+    pub(crate) fn from_info(info: &TransformationInfo) -> Self {
+        match info {
+            TransformationInfo::KVToKV { .. } => Self::kv_to_kv(info),
+            TransformationInfo::JoinToKV { .. } => Self::join(info),
+            TransformationInfo::AntiJoinToKV { .. } => Self::antijoin(info),
+        }
     }
 
     /// Creates a unary transformation from input/output key-value layouts.
@@ -292,16 +248,11 @@ impl Transformation {
     /// - `RowToKv`: Row input → Key-value output (structuring rows into KV pairs)
     /// - `KvToRow`: Key-value input → Row output (flattening KV pairs into rows)
     /// - `KvToKv`: Key-value input → Key-value output (re-keying / re-structuring)
-    fn kv_to_kv(info: &TransformationInfo, tag: &'static str, input_fp: u64) -> Self {
+    fn kv_to_kv(info: &TransformationInfo) -> Self {
         trace!("Creating kv_to_kv transformation with info:\n{}", info);
-        // Create the transformation flow that defines how data moves through the operation
-        let flow = TransformationFlow::kv_to_kv(
-            info.input_kv_layout().0,
-            info.output_kv_layout(),
-            info.kv_predicates(),
-        );
-
-        let output_fp = compute_fp((tag, input_fp, &flow));
+        let flow = info.flow();
+        let (input_fp, _) = info.input_info_fp();
+        let output_fp = info.output_info_fp();
 
         let input = Arc::new(Collection::new(
             input_fp,
@@ -359,16 +310,11 @@ impl Transformation {
     /// A binary join Transformation variant chosen by the output layout:
     /// - `JnToRow`: Key-value ⋈ Key-value producing a flat row output
     /// - `JnToKv`:  Key-value ⋈ Key-value producing a key-value output
-    fn join(info: &TransformationInfo, tag: &'static str, left_fp: u64, right_fp: u64) -> Self {
-        // Create transformation flow that defines how the join operation processes data
-        let flow = TransformationFlow::join_to_kv(
-            info.input_kv_layout().0,
-            info.input_kv_layout().1.unwrap(),
-            info.output_kv_layout(),
-            info.join_predicates(),
-        );
-
-        let output_fp = compute_fp((tag, left_fp, right_fp, &flow));
+    fn join(info: &TransformationInfo) -> Self {
+        let flow = info.flow();
+        let (left_fp, right_fp) = info.input_info_fp();
+        let right_fp = right_fp.unwrap();
+        let output_fp = info.output_info_fp();
 
         let input = (
             Arc::new(Collection::new(
@@ -427,22 +373,17 @@ impl Transformation {
     ///
     /// Panics if the left collection is not key-only, as antijoins require the left
     /// collection to contain only keys for filtering purposes.
-    fn antijoin(info: &TransformationInfo, tag: &'static str, left_fp: u64, right_fp: u64) -> Self {
+    fn antijoin(info: &TransformationInfo) -> Self {
         // Antijoins require the left collection to be key-only (used for filtering)
         assert!(
             info.input_kv_layout().0.value().is_empty(),
             "Planner error: antijoin - left collection must be key-only"
         );
 
-        // Create transformation flow (no comparison expressions for antijoins)
-        let flow = TransformationFlow::join_to_kv(
-            info.input_kv_layout().0,
-            info.input_kv_layout().1.unwrap(),
-            info.output_kv_layout(),
-            &JoinPredicates::default(), // No predicates for antijoins
-        );
-
-        let output_fp = compute_fp((tag, left_fp, right_fp, &flow));
+        let flow = info.flow();
+        let (left_fp, right_fp) = info.input_info_fp();
+        let right_fp = right_fp.unwrap();
+        let output_fp = info.output_info_fp();
 
         let input = (
             Arc::new(Collection::new(

--- a/flowlog-build/src/planner/transformation/info.rs
+++ b/flowlog-build/src/planner/transformation/info.rs
@@ -7,16 +7,17 @@
 //! produce an output tuple.
 //!
 //! These are high-level descriptions that do not yet refer to concrete
-//! collections (with their actual schemas). Instead, they use fake
-//! fingerprints and key/value layouts as placeholders, which are later
-//! replaced with real ones once they are known. This allows building
-//! a transformation plan before all details are finalized.
+//! collections (with their actual schemas). Layouts start as drafts that
+//! later passes refine in place; the output fingerprint is recomputed from
+//! current content on every mutation, so equal fingerprints always mean
+//! "materializes to the same transformation".
 
 use std::fmt;
 
 use flowlog_common::compute_fp;
 use flowlog_parser::Constant;
 
+use super::TransformationFlow;
 use crate::catalog::ArithmeticPos;
 use crate::catalog::AtomArgumentSignature;
 use crate::catalog::ComparisonExprPos;
@@ -92,17 +93,19 @@ impl KeyValueLayout {
 /// Transformation information, describing how to transform input collection(s)
 /// into an output collection, along with any constraints that must hold.
 ///
-/// `output_info_fp` is a lineage fingerprint that wires the per-rule
-/// pipeline; materialization rewrites it to a content-canonical one.
+/// Equal `output_info_fp`s mean "materializes to the same transformation",
+/// regardless of which rule or atom position built the info, compare
+/// fingerprints to find shareable work at any planning stage. After
+/// mutating an info, call [`Self::refresh_output_fp`] to keep this true.
 #[derive(Clone, Debug)]
 pub(crate) enum TransformationInfo {
     /// Unary Key-Value to Key-Value transformation (filter, map, projection, etc.).
     KVToKV {
-        /// Upstream (input) collection fingerprint (fake until resolved).
+        /// Upstream (input) collection fingerprint (re-pointed by later passes).
         input_info_fp: u64,
         /// Upstream collection's hierarchical name (e.g. `π[x](reach)`).
         input_name: String,
-        /// Output collection fingerprint (fake until resolved).
+        /// Output collection fingerprint (refreshed by later passes).
         output_info_fp: u64,
         /// Output collection's hierarchical name.
         output_name: String,
@@ -112,7 +115,7 @@ pub(crate) enum TransformationInfo {
         is_row_output: bool,
         /// Input layout (key/value positions).
         input_kv_layout: KeyValueLayout,
-        /// Output layout (key/value positions) (fake until resolved).
+        /// Output layout (key/value positions) (refined by later passes).
         output_kv_layout: KeyValueLayout,
         /// Filter predicates (equality constraints, comparisons, UDF predicates).
         predicates: KvPredicates,
@@ -122,15 +125,15 @@ pub(crate) enum TransformationInfo {
 
     /// Binary Join to Key-Value transformation.
     JoinToKV {
-        /// Left input collection fingerprint.
+        /// Left input collection fingerprint (re-pointed by later passes).
         left_input_info_fp: u64,
         /// Left input's hierarchical name.
         left_input_name: String,
-        /// Right input collection fingerprint.
+        /// Right input collection fingerprint (re-pointed by later passes).
         right_input_info_fp: u64,
         /// Right input's hierarchical name.
         right_input_name: String,
-        /// Output collection fingerprint (fake until resolved).
+        /// Output collection fingerprint (refreshed by later passes).
         output_info_fp: u64,
         /// Output collection's hierarchical name (e.g. `(reach ⋈[y] arc)`).
         output_name: String,
@@ -140,7 +143,7 @@ pub(crate) enum TransformationInfo {
         left_input_kv_layout: KeyValueLayout,
         /// Right input layout (its value contributes to output value).
         right_input_kv_layout: KeyValueLayout,
-        /// Output layout (key/value positions) (fake until resolved).
+        /// Output layout (key/value positions) (refined by later passes).
         output_kv_layout: KeyValueLayout,
         /// Filter predicates (comparisons and UDF predicates).
         predicates: JoinPredicates,
@@ -148,15 +151,15 @@ pub(crate) enum TransformationInfo {
 
     /// Binary Anti-Join to Key-Value transformation.
     AntiJoinToKV {
-        /// Left input collection fingerprint.
+        /// Left input collection fingerprint (re-pointed by later passes).
         left_input_info_fp: u64,
         /// Left input's hierarchical name.
         left_input_name: String,
-        /// Right input collection fingerprint.
+        /// Right input collection fingerprint (re-pointed by later passes).
         right_input_info_fp: u64,
         /// Right input's hierarchical name.
         right_input_name: String,
-        /// Output collection fingerprint (fake until resolved).
+        /// Output collection fingerprint (refreshed by later passes).
         output_info_fp: u64,
         /// Output collection's hierarchical name (e.g. `(reach ▷[y] arc)`).
         output_name: String,
@@ -166,7 +169,7 @@ pub(crate) enum TransformationInfo {
         left_input_kv_layout: KeyValueLayout,
         /// Right input layout (its value is ignored in the output, but key participates).
         right_input_kv_layout: KeyValueLayout,
-        /// Output layout (key/value positions) (fake until resolved).
+        /// Output layout (key/value positions) (refined by later passes).
         output_kv_layout: KeyValueLayout,
     },
 }
@@ -175,35 +178,30 @@ pub(crate) enum TransformationInfo {
 // Constructors
 // ========================
 impl TransformationInfo {
-    /// Build a Key-Value to Key-Value transformation with a derived (fake) output fingerprint.
+    /// Build a Key-Value to Key-Value transformation.
     pub(crate) fn kv_to_kv(
-        input_fake_sig: u64,
+        input_fp: u64,
         input_name: String,
         output_name: String,
         is_row_input: bool,
         input_kv_layout: KeyValueLayout,
-        output_fake_kv_layout: KeyValueLayout,
+        output_kv_layout: KeyValueLayout,
         predicates: KvPredicates,
     ) -> Self {
-        let fake_output_sig = compute_fp((
-            "kv_to_kv",
-            &input_fake_sig,
-            &input_kv_layout,
-            &output_fake_kv_layout,
-            &predicates,
-        ));
-        Self::KVToKV {
-            input_info_fp: input_fake_sig,
+        let mut info = Self::KVToKV {
+            input_info_fp: input_fp,
             input_name,
-            output_info_fp: fake_output_sig,
+            output_info_fp: 0,
             output_name,
             is_row_input,
             is_row_output: false,
             input_kv_layout,
-            output_kv_layout: output_fake_kv_layout,
+            output_kv_layout,
             predicates,
             is_sip_projection: false,
-        }
+        };
+        info.refresh_output_fp();
+        info
     }
 
     /// Mark this Key-Value transformation as a SIP projection.
@@ -220,76 +218,62 @@ impl TransformationInfo {
         Ok(self)
     }
 
-    /// Build a Join to Key-Value transformation with a derived (fake) output fingerprint.
+    /// Build a Join to Key-Value transformation.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn join_to_kv(
-        left_fake_sig: u64,
+        left_input_fp: u64,
         left_input_name: String,
-        right_fake_sig: u64,
+        right_input_fp: u64,
         right_input_name: String,
         output_name: String,
         left_kv_layout: KeyValueLayout,
         right_kv_layout: KeyValueLayout,
-        output_fake_kv_layout: KeyValueLayout,
+        output_kv_layout: KeyValueLayout,
         predicates: JoinPredicates,
     ) -> Self {
-        let fake_output_sig = compute_fp((
-            "join_to_kv",
-            &left_fake_sig,
-            &right_fake_sig,
-            &left_kv_layout,
-            &right_kv_layout,
-            &output_fake_kv_layout,
-            &predicates,
-        ));
-        Self::JoinToKV {
-            left_input_info_fp: left_fake_sig,
+        let mut info = Self::JoinToKV {
+            left_input_info_fp: left_input_fp,
             left_input_name,
-            right_input_info_fp: right_fake_sig,
+            right_input_info_fp: right_input_fp,
             right_input_name,
-            output_info_fp: fake_output_sig,
+            output_info_fp: 0,
             output_name,
             is_row_output: false,
             left_input_kv_layout: left_kv_layout,
             right_input_kv_layout: right_kv_layout,
-            output_kv_layout: output_fake_kv_layout,
+            output_kv_layout,
             predicates,
-        }
+        };
+        info.refresh_output_fp();
+        info
     }
 
-    /// Build an AntiJoin to Key-Value transformation with a derived (fake) output fingerprint.
+    /// Build an AntiJoin to Key-Value transformation.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn anti_join_to_kv(
-        left_fake_sig: u64,
+        left_input_fp: u64,
         left_input_name: String,
-        right_fake_sig: u64,
+        right_input_fp: u64,
         right_input_name: String,
         output_name: String,
         left_kv_layout: KeyValueLayout,
         right_kv_layout: KeyValueLayout,
-        output_fake_kv_layout: KeyValueLayout,
+        output_kv_layout: KeyValueLayout,
     ) -> Self {
-        let fake_output_sig = compute_fp((
-            "anti_join_to_kv",
-            &left_fake_sig,
-            &right_fake_sig,
-            &left_kv_layout,
-            &right_kv_layout,
-            &output_fake_kv_layout,
-        ));
-
-        Self::AntiJoinToKV {
-            left_input_info_fp: left_fake_sig,
+        let mut info = Self::AntiJoinToKV {
+            left_input_info_fp: left_input_fp,
             left_input_name,
-            right_input_info_fp: right_fake_sig,
+            right_input_info_fp: right_input_fp,
             right_input_name,
-            output_info_fp: fake_output_sig,
+            output_info_fp: 0,
             output_name,
             is_row_output: false,
             left_input_kv_layout: left_kv_layout,
             right_input_kv_layout: right_kv_layout,
-            output_kv_layout: output_fake_kv_layout,
-        }
+            output_kv_layout,
+        };
+        info.refresh_output_fp();
+        info
     }
 }
 
@@ -453,6 +437,7 @@ impl TransformationInfo {
     }
 
     /// Predicate filters for KVToKV transformations.
+    #[cfg(test)]
     #[inline]
     pub(crate) fn kv_predicates(&self) -> &KvPredicates {
         match self {
@@ -461,12 +446,70 @@ impl TransformationInfo {
         }
     }
 
-    /// Predicate filters for JoinToKV transformations.
-    #[inline]
-    pub(crate) fn join_predicates(&self) -> &JoinPredicates {
+    /// Variant tag mixed into the output fingerprint; names the
+    /// [`Transformation`](crate::planner::Transformation) variant this info
+    /// materializes into, so equal fingerprints imply the same variant.
+    fn content_tag(&self) -> &'static str {
         match self {
-            Self::JoinToKV { predicates, .. } => predicates,
-            _ => panic!("Planner error: join_predicates is only available for JoinToKV"),
+            Self::KVToKV { .. } => match (self.is_row_input(), self.is_row_output()) {
+                (true, true) => "row_to_row",
+                (true, false) => "row_to_kv",
+                (false, true) => "kv_to_row",
+                (false, false) => "kv_to_kv",
+            },
+            Self::JoinToKV { .. } => {
+                if self.is_row_output() {
+                    "jn_to_row"
+                } else {
+                    "jn_to_kv"
+                }
+            }
+            Self::AntiJoinToKV { .. } => {
+                if self.is_row_output() {
+                    "njn_to_row"
+                } else {
+                    "njn_to_kv"
+                }
+            }
+        }
+    }
+
+    /// Lower the current layouts and predicates to the positional
+    /// [`TransformationFlow`] this info materializes into. The flow
+    /// references collection slots, not atom-argument signatures, which is
+    /// what keeps the output fingerprint free of rule-local positions.
+    pub(crate) fn flow(&self) -> TransformationFlow {
+        match self {
+            Self::KVToKV {
+                input_kv_layout,
+                output_kv_layout,
+                predicates,
+                ..
+            } => TransformationFlow::kv_to_kv(input_kv_layout, output_kv_layout, predicates),
+            Self::JoinToKV {
+                left_input_kv_layout,
+                right_input_kv_layout,
+                output_kv_layout,
+                predicates,
+                ..
+            } => TransformationFlow::join_to_kv(
+                left_input_kv_layout,
+                right_input_kv_layout,
+                output_kv_layout,
+                predicates,
+            ),
+            Self::AntiJoinToKV {
+                left_input_kv_layout,
+                right_input_kv_layout,
+                output_kv_layout,
+                ..
+            } => TransformationFlow::join_to_kv(
+                left_input_kv_layout,
+                right_input_kv_layout,
+                output_kv_layout,
+                // Antijoins carry no comparison predicates.
+                &JoinPredicates::default(),
+            ),
         }
     }
 }
@@ -475,26 +518,25 @@ impl TransformationInfo {
 // Mutating Methods
 // ========================
 impl TransformationInfo {
-    /// Replace a placeholder (fake) input fingerprint with the resolved (real) one.
+    /// Rewire one input port to a new collection fingerprint.
     ///
-    /// This method updates the input fingerprint after an upstream transformation
-    /// finalizes its output fingerprint. For binary operations (joins/anti-joins),
-    /// it automatically determines which input (left or right) to update based on
-    /// the provided fake signature.
-    ///
-    /// # Arguments
-    ///
-    /// * `input_real_sig` - The resolved (real) fingerprint to use
-    /// * `input_fake_sig` - The placeholder fingerprint to replace
+    /// Port-addressed counterpart of [`Self::update_input_fp`]: use it when
+    /// ports need *different* targets. One collection can feed both sides
+    /// of a join, so a fingerprint cannot single out a port; `is_left` can.
+    /// It selects the left input of a join/anti-join, and the single input
+    /// of a unary transformation counts as its left.
     ///
     /// # Panics
     ///
-    /// For binary operations, panics if `input_fake_sig` doesn't match either
-    /// the left or right input fingerprint.
-    pub(crate) fn update_input_fake_info_fp(&mut self, input_real_sig: u64, input_fake_sig: &u64) {
+    /// Panics if `is_left` is `false` on a unary transformation.
+    pub(crate) fn set_input_fp(&mut self, is_left: bool, new_fp: u64) {
+        assert!(
+            is_left || !matches!(self, Self::KVToKV { .. }),
+            "Planner error: set_input_fp: no right input on a unary transformation"
+        );
         match self {
             Self::KVToKV { input_info_fp, .. } => {
-                *input_info_fp = input_real_sig;
+                *input_info_fp = new_fp;
             }
             Self::JoinToKV {
                 left_input_info_fp,
@@ -506,13 +548,48 @@ impl TransformationInfo {
                 right_input_info_fp,
                 ..
             } => {
-                if left_input_info_fp == input_fake_sig {
-                    *left_input_info_fp = input_real_sig;
+                if is_left {
+                    *left_input_info_fp = new_fp;
                 } else {
-                    *right_input_info_fp = input_real_sig;
+                    *right_input_info_fp = new_fp;
                 }
             }
         }
+    }
+
+    /// Rename a consumed collection: re-point every input port holding
+    /// `old_fp` to `new_fp`.
+    ///
+    /// Value-addressed counterpart of [`Self::set_input_fp`]: safe exactly
+    /// because every matching port gets the *same* target, a self-join
+    /// reading `old_fp` on both sides moves both in one call. When ports
+    /// need different targets, address them via [`Self::set_input_fp`]
+    /// instead.
+    ///
+    /// # Panics
+    ///
+    /// For binary operations, panics if `old_fp` matches neither input.
+    pub(crate) fn update_input_fp(&mut self, new_fp: u64, old_fp: &u64) {
+        let (left_fp, right_fp) = self.input_info_fp();
+        let Some(right_fp) = right_fp else {
+            self.set_input_fp(true, new_fp);
+            return;
+        };
+        // Both sides may hold the same collection (a self-join over one
+        // shared arrangement); patch every side that matches.
+        let mut matched = false;
+        if left_fp == *old_fp {
+            self.set_input_fp(true, new_fp);
+            matched = true;
+        }
+        if right_fp == *old_fp {
+            self.set_input_fp(false, new_fp);
+            matched = true;
+        }
+        assert!(
+            matched,
+            "Planner error: update_input_fp: {old_fp:#018x} matches neither input"
+        );
     }
 
     /// Update whether the output is row-based.
@@ -550,7 +627,7 @@ impl TransformationInfo {
         }
     }
 
-    /// Replace a placeholder (fake) output layout with its resolved (real) positions.
+    /// Replace the draft output layout with its resolved positions.
     ///
     /// Necessary once the actual output schema is known, since downstream operators
     /// (e.g., joins) require concrete key/value layouts.
@@ -664,73 +741,18 @@ impl TransformationInfo {
         }
     }
 
-    /// Recompute the (fake) output fingerprint using the current resolved fields.
-    ///
-    /// Call this after all relevant inputs/layouts/constraints are up-to-date.
-    pub(crate) fn update_output_fake_sig(&mut self) {
+    /// Recompute the output fingerprint from the current fields: the variant
+    /// tag, the input fingerprint(s), and the positional flow. Nothing else
+    /// enters the hash, so the fingerprint is free of rule-local atom
+    /// positions at every stage. Call after any mutation of inputs, layouts,
+    /// flags, or constraints.
+    pub(crate) fn refresh_output_fp(&mut self) {
+        let (left_fp, right_fp) = self.input_info_fp();
+        let fp = compute_fp((self.content_tag(), left_fp, right_fp, &self.flow()));
         match self {
-            Self::KVToKV {
-                input_info_fp,
-                is_row_input,
-                is_row_output,
-                input_kv_layout,
-                output_kv_layout,
-                predicates,
-                output_info_fp,
-                ..
-            } => {
-                *output_info_fp = compute_fp((
-                    "kv_to_kv",
-                    input_info_fp,
-                    is_row_input,
-                    is_row_output,
-                    input_kv_layout,
-                    output_kv_layout,
-                    predicates,
-                ));
-            }
-            Self::JoinToKV {
-                left_input_info_fp,
-                right_input_info_fp,
-                is_row_output,
-                left_input_kv_layout,
-                right_input_kv_layout,
-                output_kv_layout,
-                predicates,
-                output_info_fp,
-                ..
-            } => {
-                *output_info_fp = compute_fp((
-                    "join_to_kv",
-                    left_input_info_fp,
-                    right_input_info_fp,
-                    is_row_output,
-                    left_input_kv_layout,
-                    right_input_kv_layout,
-                    output_kv_layout,
-                    predicates,
-                ));
-            }
-            Self::AntiJoinToKV {
-                left_input_info_fp,
-                right_input_info_fp,
-                is_row_output,
-                left_input_kv_layout,
-                right_input_kv_layout,
-                output_kv_layout,
-                output_info_fp,
-                ..
-            } => {
-                *output_info_fp = compute_fp((
-                    "anti_join_to_kv",
-                    left_input_info_fp,
-                    right_input_info_fp,
-                    is_row_output,
-                    left_input_kv_layout,
-                    right_input_kv_layout,
-                    output_kv_layout,
-                ));
-            }
+            Self::KVToKV { output_info_fp, .. }
+            | Self::JoinToKV { output_info_fp, .. }
+            | Self::AntiJoinToKV { output_info_fp, .. } => *output_info_fp = fp,
         }
     }
 }


### PR DESCRIPTION
## Problem

Planning fingerprints hash layouts that reference rule-local atom positions (`(rhs_id, argument_id)` signatures), so identical operations built by different rules hash differently. #148 worked around this by re-hashing every fingerprint into content-canonical form at materialization and translating through a per-rule `fp_map` — two hash spaces, a translation layer, and a silent `resolve_fp` passthrough where a missed map entry was indistinguishable from a leaf atom fingerprint.

## Change

Hash the positional `TransformationFlow` instead, at construction and on every refresh. The flow speaks in collection slots — `rhs_id` cannot appear in it by construction — so the planning fingerprint **is** the content fingerprint: equal fingerprints mean "materializes to the same transformation" at every planning stage, within and across rules (the fuse passes' memo-style grouping now sees cross-rule sharing too).

- The recipe lives in exactly one place, `TransformationInfo::refresh_output_fp`; `from_info` is pure representation conversion.
- `fuse` ends with a refresh sweep settling the renames its input rewiring deferred; `resolve_fp` / `fp_map` are deleted.
- Content-canonical fps let one collection feed **both sides of a self-join** before the key split is fused in — fuse's fp-based side matching silently collected the left demand twice and lost the right one (caught by Dyck). Consumer ports are now explicit: demand notes carry `(consumer, is_left)` and rewire via `set_input_fp`; `update_input_fp` keeps rename semantics for map fusion.
- Sweeps `fuse.rs` comments to the `docs/dev/comments.md` rules.

Final fingerprint values at fixpoint hash the same content as before, so sharing behavior is unchanged; the existing sharing tests (`rhs_id_does_not_split_identical_arrangements`, `equal_fingerprint_implies_equal_content`, Dyck prune count) pass unmodified, plus a new test pinning pre-materialization cross-rule collision.

## Verification

- `cargo test` (workspace) and `cargo clippy --workspace --all-targets -- -D warnings` clean
- Fixture suites: compiler path 124/124, lib path 124/124 (includes the one `--sip` fixture)
- Not yet run: the Soufflé oracle — recommend one run (ideally with `--sip`) before merge, since SIP fixture coverage is thin

## Follow-up (tracked in design notes)

Store the port bit in `producer_consumer` itself (consumers as `Vec<(usize, bool)>`), which removes `update_input_fp` and `fuse_map`'s dedup guard entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)