### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,28 +268,28 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "flowlog-build"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "flowlog-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "codespan-reporting",
  "educe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,14 +256,14 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3e1715a2bf74bc8f68cd7bae12ff144f02669c602106ad1fa16f2ba62e646"
+checksum = "e451fac8dd8dece16234604bf1efce6e90fddd8ab6ad4d66eec0eca5160959dd"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-test = "0.2"
 
 # Internal crates.
-flowlog-build = { path = "flowlog-build", version = "0.4.0" }
+flowlog-build = { path = "flowlog-build", version = "0.5.0" }
 flowlog-common = { path = "flowlog-common", version = "0.1.0" }
-flowlog-parser = { path = "flowlog-parser", version = "0.1.0" }
+flowlog-parser = { path = "flowlog-parser", version = "0.2.0" }
 flowlog-planner = { path = "flowlog-planner", version = "0.1.0" }
 flowlog-profiler = { path = "flowlog-profiler", version = "0.1.0" }
 

--- a/flowlog-build/CHANGELOG.md
+++ b/flowlog-build/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.4.0...flowlog-build-v0.5.0) - 2026-08-03
+
+### Other
+
+- *(batch)* adaptive spin-then-park draining the dataflow to fixpoint ([#138](https://github.com/flowlog-rs/flowlog/pull/138))
+- *(build)* [**breaking**] extract planner into flowlog-planner crate ([#273](https://github.com/flowlog-rs/flowlog/pull/273))
+
 ## [0.4.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.3.4...flowlog-build-v0.4.0) - 2026-07-26
 
 ### Breaking

--- a/flowlog-build/Cargo.toml
+++ b/flowlog-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-build"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/flowlog-build/src/codegen/profile.rs
+++ b/flowlog-build/src/codegen/profile.rs
@@ -280,11 +280,39 @@ impl CodeGen {
     /// Emits the batch run loop (`worker` and `index` in scope): steps the
     /// dataflow to fixpoint, periodically flushing metrics when profiled.
     pub(crate) fn gen_batch_step_loop(&self) -> TokenStream {
-        self.gen_flush_loop(
-            quote! { worker.step() },
-            quote! {},
-            self.gen_metrics_write_batch(),
-        )
+        let step = quote! {{
+            let more = if __flowlog_idle_steps < __FLOWLOG_SPIN_BEFORE_PARK {
+                worker.step()
+            } else {
+                worker.step_or_park(Some(__FLOWLOG_PARK_TIMEOUT))
+            };
+            if more {
+                if __flowlog_activations.borrow().empty_for()
+                    == Some(std::time::Duration::ZERO)
+                {
+                    __flowlog_idle_steps = 0;
+                } else if __flowlog_idle_steps < __FLOWLOG_SPIN_BEFORE_PARK {
+                    __flowlog_idle_steps += 1;
+                }
+            }
+            more
+        }};
+        let step_loop = self.gen_flush_loop(step, quote! {}, self.gen_metrics_write_batch());
+
+        quote! {
+            {
+                // Spin briefly after scheduled work to avoid a park/wake round
+                // trip at progress barriers. Once idle, park with a bounded
+                // timeout so workers stop consuming a core while profiling can
+                // still flush on schedule.
+                const __FLOWLOG_SPIN_BEFORE_PARK: u64 = 4096;
+                const __FLOWLOG_PARK_TIMEOUT: std::time::Duration =
+                    std::time::Duration::from_millis(1);
+                let __flowlog_activations = worker.activations();
+                let mut __flowlog_idle_steps = 0u64;
+                #step_loop
+            }
+        }
     }
 
     /// Emits the incremental commit step loop (`worker`, `probe`,

--- a/flowlog-parser/CHANGELOG.md
+++ b/flowlog-parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-parser-v0.1.0...flowlog-parser-v0.2.0) - 2026-08-03
+
+### Other
+
+- *(build)* [**breaking**] extract planner into flowlog-planner crate ([#273](https://github.com/flowlog-rs/flowlog/pull/273))
+
 ## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-parser-v0.1.0) - 2026-07-26
 
 ### Added

--- a/flowlog-parser/Cargo.toml
+++ b/flowlog-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowlog-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/flowlog-planner/CHANGELOG.md
+++ b/flowlog-planner/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-planner-v0.1.0) - 2026-08-03
+
+### Other
+
+- *(planner)* harden catalog metadata ([#275](https://github.com/flowlog-rs/flowlog/pull/275))
+- *(build)* [**breaking**] extract planner into flowlog-planner crate ([#273](https://github.com/flowlog-rs/flowlog/pull/273))

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -51,34 +51,34 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3e1715a2bf74bc8f68cd7bae12ff144f02669c602106ad1fa16f2ba62e646"
+checksum = "e451fac8dd8dece16234604bf1efce6e90fddd8ab6ad4d66eec0eca5160959dd"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]


### PR DESCRIPTION



## 🤖 New release

* `flowlog-parser`: 0.1.0 -> 0.2.0 (✓ API compatible changes)
* `flowlog-planner`: 0.1.0
* `flowlog-build`: 0.4.0 -> 0.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `flowlog-parser`

<blockquote>

## [0.2.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-parser-v0.1.0...flowlog-parser-v0.2.0) - 2026-08-03

### Other

- *(build)* [**breaking**] extract planner into flowlog-planner crate ([#273](https://github.com/flowlog-rs/flowlog/pull/273))
</blockquote>

## `flowlog-planner`

<blockquote>

## [0.1.0](https://github.com/flowlog-rs/flowlog/releases/tag/flowlog-planner-v0.1.0) - 2026-08-03

### Other

- *(planner)* harden catalog metadata ([#275](https://github.com/flowlog-rs/flowlog/pull/275))
- *(build)* [**breaking**] extract planner into flowlog-planner crate ([#273](https://github.com/flowlog-rs/flowlog/pull/273))
</blockquote>

## `flowlog-build`

<blockquote>

## [0.5.0](https://github.com/flowlog-rs/flowlog/compare/flowlog-build-v0.4.0...flowlog-build-v0.5.0) - 2026-08-03

### Other

- *(batch)* adaptive spin-then-park draining the dataflow to fixpoint ([#138](https://github.com/flowlog-rs/flowlog/pull/138))
- *(build)* [**breaking**] extract planner into flowlog-planner crate ([#273](https://github.com/flowlog-rs/flowlog/pull/273))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).