### PR TITLE
ci(fuzz): fail on slow inputs instead of hanging until cancellation

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -59,9 +59,17 @@ jobs:
         # Short smoke on push; the deeper run happens on the daily schedule.
         # Pin gnu explicitly — the runner otherwise defaults to musl, whose
         # static libc breaks the sanitizer.
-        run: cargo fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=${{ github.event_name == 'schedule' && '600' || '120' }}
+        #
+        # -timeout bounds one input; -max_total_time cannot, since it is
+        # only checked between inputs. Without the bound, one pathological
+        # input hangs the job until the GitHub timeout cancels it, and a
+        # cancelled job skips the artifact and issue steps below (they run
+        # on `failure()` only). A healthy parse is sub-millisecond, so 10s
+        # means hang: libFuzzer kills the input, writes a `timeout-*`
+        # artifact, and fails the run like any other find.
+        run: cargo fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -timeout=10 -max_total_time=${{ github.event_name == 'schedule' && '600' || '120' }}
 
-      - name: 📤 Upload crash artifacts
+      - name: 📤 Upload fuzz artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
@@ -69,7 +77,7 @@ jobs:
           path: fuzz/artifacts/
           if-no-files-found: ignore
 
-      - name: 📣 File an issue on crash
+      - name: 📣 File an issue on a find
         if: failure()
         uses: actions/github-script@v9
         with:
@@ -81,31 +89,35 @@ jobs:
             try {
               files = fs.readdirSync(dir).filter(f => /^(crash|timeout|oom|leak)-/.test(f));
             } catch (e) {}
-            // No crash artifact => the failure was infra/build, not a fuzz find.
+            // No artifact => the failure was infra/build, not a fuzz find.
             if (files.length === 0) return;
             const { owner, repo } = context.repo;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             const marker = `<!-- fuzz-crash-${target} -->`;
             const file = files[0];
+            const kind = file.split('-')[0]; // crash | timeout | oom | leak
             const buf = fs.readFileSync(`${dir}/${file}`);
             const hex = buf.toString('hex').replace(/(..)/g, '$1 ').trim().slice(0, 800);
             const text = buf.toString('utf8');
             const printable = /^[\x09\x0a\x0d\x20-\x7e]*$/.test(text)
               ? text.slice(0, 1000) : '(non-UTF-8 — see hex)';
-            const body = `${marker}\n**Fuzzing found a crash in \`${target}\`** ([run](${runUrl})).\n\n`
+            const body = `${marker}\n**Fuzzing found a ${kind} in \`${target}\`** ([run](${runUrl})).\n\n`
               + `Artifact \`${file}\` (${buf.length} bytes).\n\n`
               + `Input (text):\n\`\`\`\n${printable}\n\`\`\`\n\n`
               + `Input (hex):\n\`\`\`\n${hex}\n\`\`\`\n\n`
               + `Reproduce — download the artifact from the run, then:\n`
-              + `\`\`\`\ncargo +nightly fuzz run ${target} <artifact>\n\`\`\``;
+              + `\`\`\`\ncargo +nightly fuzz run ${target} <artifact> -- -timeout=10\n\`\`\``;
             const { data: open } = await github.rest.issues.listForRepo({
               owner, repo, state: 'open', labels: 'fuzz-crash', per_page: 50,
             });
             const existing = open.find(i => (i.body || '').includes(marker));
             if (existing) {
+              // Bump on the nightly only: every push re-finds an open
+              // issue, and a comment per push is noise.
+              if (context.eventName !== 'schedule') return;
               await github.rest.issues.createComment({ owner, repo, issue_number: existing.number,
-                body: `Still crashing as of ${runUrl} (artifact \`${file}\`).` });
+                body: `Still reproducing as of ${runUrl} (artifact \`${file}\`).` });
             } else {
-              await github.rest.issues.create({ owner, repo, title: `Fuzz: crash in \`${target}\``,
+              await github.rest.issues.create({ owner, repo, title: `Fuzz: ${kind} in \`${target}\``,
                 body, labels: ['fuzz-crash', 'bug'] });
             }


### PR DESCRIPTION
## Problem

Every Fuzz run since 2026-08-02 (15 straight, push and nightly) has ended **cancelled** at the 30-minute job limit. The persisted corpus contains inputs that the parser handles in exponential time (pest backtracking on nested parens; a 38-byte input takes ~13s, and each 4 extra bytes multiplies that by 5-25x), so seed-corpus replay alone outlives the job.

Cancellation is the worst failure mode here: the artifact-upload and issue-filing steps are gated on `failure()`, so a cancelled job reports nothing. The only trace of the finding was a slow-unit line in the log text.

`-max_total_time` cannot catch this: libFuzzer only checks it between inputs, and it appears not to apply during seed replay at all (the hung runs never printed `INITED`).

## Change

- Pass `-timeout=10` (per-input bound). A healthy parse is sub-millisecond, so 10s means hang: libFuzzer kills the input, writes a `timeout-*` artifact, and exits non-zero, flowing through the existing find-report pipeline exactly like a crash. This mirrors standard practice (OSS-Fuzz runs libFuzzer targets with `-timeout=25`).
- Issue script: title and body now name the artifact kind (`crash`/`timeout`/`oom`/`leak`) instead of hardcoding "crash", and the "still reproducing" bump fires only on the nightly so per-push re-finds of an open issue do not spam it.
- Repro command in filed issues carries the same `-timeout` flag as CI.

## Verification

Locally, in corpus-directory mode (the mode CI runs): a 42-byte paren bomb seeded into a corpus dir is killed after 11s, `timeout-dc99051911...` lands in `fuzz/artifacts/parse/`, and cargo exits 1.

## What to expect after merge

The first run on `main-next` will **fail** (not hang): the poisoned corpus trips the timeout during replay, uploads the artifact, and auto-files `Fuzz: timeout in parse`. That red is the honest signal — the underlying grammar bug (exponential backtracking in `factor`'s paren alternatives) is real and gets fixed in a follow-up PR; the corpus inputs then become free regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)