### PR TITLE
fix(parser): parse parenthesised factors without exponential backtracking

### DIFF
--- a/flowlog-parser/src/error.rs
+++ b/flowlog-parser/src/error.rs
@@ -330,6 +330,11 @@ pub enum ParseError {
     #[error("rule body reduces to nothing but its head is not a constant fact")]
     GroundRuleNotConst { span: Span },
 
+    /// A `_` placeholder alone in parentheses. `(_)` is neither grouping
+    /// (a placeholder is not an expression) nor a tuple (no comma).
+    #[error("`_` cannot be grouped: `(_)` is neither a tuple nor an expression")]
+    GroupedPlaceholder { span: Span },
+
     /// A string token is not a valid Rust string literal. FlowLog strings
     /// follow Rust syntax (quoted with Rust's escape alphabet, or raw);
     /// unknown escapes are errors, unlike Souffle's pass-through.
@@ -941,6 +946,13 @@ impl Diagnostic for ParseError {
                 *span,
                 format!("`{literal}` does not fit `{expected:?}`"),
             )),
+
+            ParseError::GroupedPlaceholder { span } => base
+                .with_labels(primary_only(*span))
+                .with_notes(vec![
+                    "a 1-tuple that ignores its component is `(_,)`; grouping needs an expression"
+                        .into(),
+                ]),
 
             ParseError::InvalidStringLiteral { span, reason } => {
                 base.with_labels(labels(*span, reason.clone()))

--- a/flowlog-parser/src/grammar.pest
+++ b/flowlog-parser/src/grammar.pest
@@ -218,34 +218,33 @@ extern_fn_param = { identifier ~ ":" ~ data_type }
 // Note: "x + y * z" is parsed left-to-right as "(x + y) * z"
 arithmetic_expr = { factor ~ (arithmetic_op ~ factor)* }
 
-// `as_cast` first so `as` wins over a UDF named `as` (reserved keyword).
-// `paren_expr` gives explicit grouping: since arithmetic has no operator
-// precedence (it folds strictly left-to-right), parentheses are the only
-// way to override evaluation order, e.g. `x * (a + b)`.
-// One operand of an expression. Ordered choice: `tuple_lit` precedes
-// `paren_expr` because both open with `(`; the comma in a tuple literal is the
-// tiebreaker.
-factor = { as_cast | call_expr | tuple_lit | paren_expr | constant | variable }
+// One operand of an expression. `as_cast` first so `as` wins over a UDF
+// named `as` (reserved keyword).
+factor = { as_cast | call_expr | paren_factor | constant | variable }
 
-// A fixed-tuple literal. Constructs a tuple, or destructures one when matched
-// against a bound variable; a `_` element ignores that component on destructure:
-//   x = (a, b)     construct a 2-tuple
-//   (a, b) = x     destructure into `a` and `b`
-//   (a, _) = x     destructure, ignoring the second component
-//   (a,)           1-tuple — the trailing comma is required
-//   (a)            not a tuple: plain grouping, handled by `paren_expr`
-// The mandatory comma keeps `tuple_lit` distinct from `paren_expr`.
-tuple_lit  = { "(" ~ tuple_elem ~ (("," ~ tuple_elem)+ | ",") ~ ")" }
-tuple_elem = { arithmetic_expr | placeholder }
+// Any `(`-headed operand: a tuple literal, or explicit grouping (the only
+// way to override evaluation order, e.g. `x * (a + b)`, since arithmetic
+// folds strictly left-to-right with no precedence). Commas decide which:
+//   (a, b)     tuple literal: constructs a tuple, or destructures one
+//              when matched against a bound variable
+//   (a, b,)    the same tuple; a trailing comma is allowed
+//   (a, _)     tuple literal; `_` ignores that component on destructure
+//   (a,)       1-tuple; the trailing comma keeps it distinct from grouping
+//   (a + b)    grouping
+//   (a)        grouping (not a 1-tuple)
+//   (_)        rejected in lowering (`ParseError::GroupedPlaceholder`)
+// One rule owns `(` so the interior is parsed exactly once. As separate
+// `(`-headed alternatives of `factor`, pest re-parses the whole interior
+// for each alternative that fails, which is exponential in paren depth
+// (issue #289: a 38-byte fuzz input timed out).
+// `arithmetic_expr` before `placeholder`: pest commits to the first match,
+// so `_x` must parse as a variable before `placeholder` can eat its `_`.
+paren_factor = { "(" ~ paren_elem ~ ("," ~ paren_elem)* ~ trailing_comma? ~ ")" }
+paren_elem = _{ arithmetic_expr | placeholder }
 
-// Parenthesised sub-expression. Both wrappers are silent (`_`): a
-// single-factor `(x)` surfaces as the bare inner factor, while a
-// multi-term `(a + b)` surfaces as `group_expr` (the `+` requires an
-// operator). A group node thus exists only when the grouping affects
-// the left-to-right fold.
-paren_expr  = _{ "(" ~ paren_inner ~ ")" }
-paren_inner = _{ group_expr | factor }
-group_expr  =  { factor ~ (arithmetic_op ~ factor)+ }
+// Visible (not silent) so `(a,)` leaves a second child for the lowering
+// to see; the element lowering drops it.
+trailing_comma = { "," }
 
 // `as(factor, TargetType)` — explicit cast, runtime no-op. Inner is a
 // single `factor` (not `arithmetic_expr`) so the typechecker can lower

--- a/flowlog-parser/src/syntax/ast/arithmetic.rs
+++ b/flowlog-parser/src/syntax/ast/arithmetic.rs
@@ -149,14 +149,7 @@ impl Lexeme for Factor {
             Rule::call_expr => parse_call_expr(inner)?,
             Rule::variable => Self::Var(inner.text().to_string()),
             Rule::constant => Self::Const(inner.lower()?),
-            Rule::tuple_lit => Self::Tuple(inner.lower()?),
-            // Multi-term parenthesised sub-expression: the grammar's
-            // `group_expr` requires at least one operator, so `Group` is
-            // constructed only when grouping affects the fold.
-            Rule::group_expr => Self::Group(Box::new(inner.lower()?)),
-            // Single-factor parens `(x)`: the paren wrappers are silent in
-            // the grammar, so the bare inner factor pair surfaces here.
-            Rule::factor => Self::from_parsed_rule(inner)?,
+            Rule::paren_factor => parse_paren_factor(inner)?,
             other => return Err(grammar_bug(format!("invalid factor rule: {other:?}"))),
         })
     }
@@ -181,6 +174,36 @@ fn parse_call_expr(node: Node) -> Result<Factor, ParseError> {
     } else {
         Ok(Factor::FnCall(FnCall::new(name, args, span)))
     }
+}
+
+/// Resolves a `paren_factor` (`(`-headed operand) into a [`Factor`]: any
+/// comma (a second element or the trailing-comma marker) commits it to a
+/// [`Factor::Tuple`]; otherwise the interior is grouping and becomes a
+/// [`Factor::Group`], or, single-factor, collapses to the bare factor.
+fn parse_paren_factor(node: Node) -> Result<Factor, ParseError> {
+    let span = node.span();
+    let mut children = node.children();
+    let first = children.next_any("parenthesised operand")?;
+    let mut rest = children.peekable();
+
+    if rest.peek().is_none() {
+        // A single comma-free element: plain grouping.
+        if first.rule() == Rule::placeholder {
+            return Err(ParseError::GroupedPlaceholder { span: first.span() });
+        }
+        let expr: Arithmetic = first.lower()?;
+        if expr.rest.is_empty() {
+            return Ok(expr.init);
+        }
+        return Ok(Factor::Group(Box::new(expr)));
+    }
+
+    let fields = std::iter::once(first)
+        .chain(rest)
+        .filter(|c| c.rule() != Rule::trailing_comma)
+        .map(|c| c.lower())
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Factor::Tuple(TupleLit::new(fields, span)))
 }
 
 // =============================================================================
@@ -391,6 +414,69 @@ mod tests {
         };
         assert!(matches!(inner.init(), Factor::Var(v) if v == "b"));
         assert!(!inner.rest().is_empty());
+    }
+
+    /// A comma is what commits parens to a tuple literal: a lone trailing
+    /// comma is a 1-tuple, a `_` element stays a placeholder, and a
+    /// trailing comma after multiple elements is accepted but renders
+    /// canonically without it. Comma-free parens are grouping, pinned by
+    /// `single_factor_parens_collapse_to_the_factor`.
+    #[rstest]
+    #[case("(a,)", "(a,)")]
+    #[case("(_, b)", "(_, b)")]
+    #[case("(a + 1, b)", "(a + 1, b)")]
+    #[case("(a, b,)", "(a, b)")]
+    #[case("(_,)", "(_,)")]
+    fn comma_commits_parens_to_a_tuple(#[case] src: &str, #[case] rendered: &str) {
+        let arith: Arithmetic = parse_node(Rule::arithmetic_expr, src);
+        assert!(matches!(arith.init(), Factor::Tuple(_)), "src={src}");
+        assert_eq!(arith.to_string(), rendered);
+    }
+
+    /// A lone parenthesised `_` is rejected with its dedicated error.
+    #[test]
+    fn grouped_placeholder_is_rejected() {
+        use flowlog_common::FileId;
+
+        use crate::assert_err;
+        use crate::test_util::parse_pair;
+
+        let pair = parse_pair(Rule::arithmetic_expr, "(_)");
+        let result = Arithmetic::from_parsed_rule(Node::new(pair, FileId::new(0)));
+        assert_err!(result, ParseError::GroupedPlaceholder { .. });
+    }
+
+    /// A 200-deep paren nest parses and collapses to the bare factor.
+    /// Under split `(`-headed rules this input would hang the suite; the
+    /// mechanism is documented at `paren_factor` in grammar.pest
+    /// (issue #289).
+    #[test]
+    fn deeply_nested_parens_parse_without_backtracking_blowup() {
+        let src = format!("{}x{}", "(".repeat(200), ")".repeat(200));
+        let arith: Arithmetic = parse_node(Rule::arithmetic_expr, &src);
+        assert!(matches!(arith.init(), Factor::Var(v) if v == "x"));
+    }
+
+    /// A 200-deep unclosed paren nest is rejected; the failure path must
+    /// stay free of the re-parsing blowup too (issue #289).
+    #[test]
+    fn unclosed_paren_nest_is_rejected_without_backtracking_blowup() {
+        use pest::Parser as _;
+
+        use crate::FlowLogParser;
+
+        assert!(FlowLogParser::parse(Rule::arithmetic_expr, &"(".repeat(200)).is_err());
+    }
+
+    /// Empty parens are rejected by the grammar: `paren_factor` requires
+    /// at least one element.
+    #[test]
+    fn empty_parens_are_rejected() {
+        use pest::Parser as _;
+
+        use crate::FlowLogParser;
+
+        assert!(FlowLogParser::parse(Rule::arithmetic_expr, "()").is_err());
     }
 
     /// Each grammar factor kind parses to its variant. Contents are tested

--- a/flowlog-parser/src/syntax/ast/tuple.rs
+++ b/flowlog-parser/src/syntax/ast/tuple.rs
@@ -105,35 +105,20 @@ impl fmt::Display for TupleLit {
     }
 }
 
-impl Lexeme for TupleLit {
+impl Lexeme for TupleElem {
     fn from_parsed_rule(node: Node) -> Result<Self, ParseError> {
-        let span = node.span();
-        let mut fields = Vec::new();
-        for elem in node.children() {
-            if elem.rule() != Rule::tuple_elem {
-                return Err(grammar_bug(format!(
-                    "unexpected child of tuple_lit: {:?}",
-                    elem.rule()
-                )));
-            }
-            let inner = elem.children().next_any("tuple element value")?;
-            let parsed = match inner.rule() {
-                Rule::arithmetic_expr => TupleElem::Expr(inner.lower()?),
-                Rule::placeholder => TupleElem::Placeholder,
-                other => {
-                    return Err(grammar_bug(format!("invalid tuple element: {other:?}")));
-                }
-            };
-            fields.push(parsed);
-        }
-        Ok(Self::new(fields, span))
+        // No wrapper rule exists for elements: the node is the value
+        // itself, an expression or a placeholder.
+        Ok(match node.rule() {
+            Rule::arithmetic_expr => Self::Expr(node.lower()?),
+            Rule::placeholder => Self::Placeholder,
+            other => return Err(grammar_bug(format!("invalid tuple element: {other:?}"))),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use flowlog_common::FileId;
-
     use super::*;
 
     /// A `( x, _ )` literal: one expression element, one placeholder.
@@ -200,19 +185,16 @@ mod tests {
         assert_eq!(one.to_string(), "(x,)");
     }
 
-    /// A well-formed `tuple_lit` parses successfully: every child is a
-    /// `tuple_elem`, so the `!= tuple_elem` reject guard must NOT fire. If the
-    /// guard's comparison were flipped it would reject valid tuples.
+    /// An element value node lowers to the variant its rule selects: an
+    /// expression to `Expr`, a bare `_` to `Placeholder`.
     #[test]
-    fn from_parsed_rule_accepts_valid_tuple() {
-        use pest::Parser;
+    fn from_parsed_rule_lowers_expr_and_placeholder() {
+        use crate::test_util::parse_node;
 
-        use crate::FlowLogParser;
+        let expr: TupleElem = parse_node(Rule::arithmetic_expr, "x + 1");
+        assert!(matches!(expr, TupleElem::Expr(_)));
 
-        let mut pairs = FlowLogParser::parse(Rule::tuple_lit, "(x, y)").unwrap();
-        let tup = TupleLit::from_parsed_rule(Node::new(pairs.next().unwrap(), FileId::new(0)))
-            .expect("valid tuple_lit must parse");
-        assert_eq!(tup.fields().len(), 2);
-        assert_eq!(tup.to_string(), "(x, y)");
+        let hole: TupleElem = parse_node(Rule::placeholder, "_");
+        assert!(matches!(hole, TupleElem::Placeholder));
     }
 }


### PR DESCRIPTION
Fixes #289.

## Root cause

On `(`, `factor` tried three alternatives — `tuple_lit`, the silent `paren_expr` (wrapping `group_expr`), then a bare `factor` — and each fully re-parsed the same nested interior before failing. pest has no memoization, so nested parens cost Theta(3^depth): the 38-byte fuzz artifact took ~13s, blowing the per-input `-timeout=10` added in #287.

## Fix

One rule now owns `(` and parses the interior exactly once; commas decide the form, the same way rustc and CPython separate grouping from tuples:

```pest
paren_factor = { "(" ~ paren_elem ~ ("," ~ paren_elem)* ~ trailing_comma? ~ ")" }
paren_elem = _{ arithmetic_expr | placeholder }
trailing_comma = { "," }
```

`parse_paren_factor` in the lowering turns any comma into a tuple literal; a comma-free interior is grouping (multi-term becomes `Factor::Group`, single-factor collapses to the bare factor, as before).

## Surface changes

- Trailing commas in tuple literals are accepted (`(a, b,)`), matching Rust; `Display` renders canonically without the comma.
- `(_)` moves from a generic pest syntax error to a dedicated `ParseError::GroupedPlaceholder` with a `(_,)` hint. Everything else parses exactly as before.

## Validation

- Issue artifact `timeout-c11d1ee5`: ~13s before, **2ms** after; 4096-byte paren bombs (open and closed) run in <1ms with no stack issues.
- New regression tests: 200-deep nests (well-formed and unclosed), `()`, `(a, b,)`, `(_,)`, and the pinned `GroupedPlaceholder` error.
- `cargo test` workspace, clippy `-D warnings`, rustfmt, typos all green; fixture suites are running locally (CI gates them regardless); I will confirm on this PR.

Follow-up (out of scope here): `as_cast | call_expr` has the same latent re-parse pattern on a different head token (`as(x, 5)` fails late in `as_cast`, then `call_expr` re-parses the interior); worth a `!as_kw` guard on call names in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
