### PR TITLE
fix(parser): refuse `as` as a call name so a failed cast is not re-parsed

### DIFF
--- a/flowlog-parser/src/grammar.pest
+++ b/flowlog-parser/src/grammar.pest
@@ -218,8 +218,9 @@ extern_fn_param = { identifier ~ ":" ~ data_type }
 // Note: "x + y * z" is parsed left-to-right as "(x + y) * z"
 arithmetic_expr = { factor ~ (arithmetic_op ~ factor)* }
 
-// One operand of an expression. `as_cast` first so `as` wins over a UDF
-// named `as` (reserved keyword).
+// One operand of an expression. `as_cast` must precede `variable`, or a
+// bare `as` matches as a variable and the cast never parses; `call_expr`
+// refuses `as` outright (see `call_expr`).
 factor = { as_cast | call_expr | paren_factor | constant | variable }
 
 // Any `(`-headed operand: a tuple literal, or explicit grouping (the only
@@ -420,7 +421,11 @@ head_arg = { aggregate_expr | arithmetic_expr }
 // a hit becomes a built-in call, otherwise a UDF (`.extern fn`) call.
 // Appears inside expressions, never bare in a body.
 // Example: cat(a, b), strlen(x), my_udf(x, y + 1)
+// `!as_kw` because a failed `as_cast` (a bad type in `as(x, 5)`) would
+// otherwise retry here as a call named `as`, re-parsing the interior at
+// every nesting level (issue #298: a 151-byte input took 19s).
 call_expr = {
+    !as_kw ~
     identifier ~
     "(" ~
     (arithmetic_expr ~ ("," ~ arithmetic_expr)*)? ~

--- a/flowlog-parser/src/syntax/ast/arithmetic.rs
+++ b/flowlog-parser/src/syntax/ast/arithmetic.rs
@@ -479,6 +479,38 @@ mod tests {
         assert!(FlowLogParser::parse(Rule::arithmetic_expr, "()").is_err());
     }
 
+    /// A malformed cast stops the expression at the bare `as`, leaving
+    /// `(x, 5)` for the enclosing rule, rather than being taken as a call
+    /// named `as` (issue #298).
+    #[test]
+    fn malformed_cast_is_not_accepted_as_a_call() {
+        use crate::test_util::parse_pair;
+
+        // `5` is not a type, so `as_cast` fails at its type argument.
+        assert_eq!(parse_pair(Rule::arithmetic_expr, "as(x, 5)").as_str(), "as");
+    }
+
+    /// The reserved-name guard keys on a whole word, so a UDF whose name
+    /// only starts with `as` is still a call.
+    #[test]
+    fn udf_whose_name_starts_with_as_still_parses() {
+        let arith: Arithmetic = parse_node(Rule::arithmetic_expr, "assert(x)");
+        assert!(matches!(arith.init(), Factor::FnCall(c) if c.name() == "assert"));
+    }
+
+    /// A 200-deep unterminated cast nest stops at the bare `as` instead of
+    /// re-parsing every level; the mechanism is documented at `call_expr`
+    /// in grammar.pest (issue #298). A *valid* nest cannot pin this: pest
+    /// never backtracks out of a successful alternative, so only a failing
+    /// nest exercises the retry.
+    #[test]
+    fn unclosed_cast_nest_is_refused_without_backtracking_blowup() {
+        use crate::test_util::parse_pair;
+
+        let src = "as(".repeat(200);
+        assert_eq!(parse_pair(Rule::arithmetic_expr, &src).as_str(), "as");
+    }
+
     /// Each grammar factor kind parses to its variant. Contents are tested
     /// in each variant's own module (`cast.rs`, `fn_call.rs`, `builtin.rs`,
     /// `tuple.rs`); `TupleProj` is absent because it has no surface syntax.


### PR DESCRIPTION
Fixes #298. Follow-up to #294, which fixed the same defect class on `(`.

## Root cause

`factor = { as_cast | call_expr | ... }`. A cast commits after `as(` but can still fail at its type argument (`as(x, 5)`), and `call_expr` accepted `as` as an ordinary identifier — so pest retried the same text as a call named `as` and re-parsed the whole interior. Each nesting level doubled the work.

Measured on the failing shape (unterminated `as(` nest), pre-fix:

| depth | bytes | time |
|---|---|---|
| 8 | 49 | 0.18 ms |
| 16 | 97 | 45.5 ms |
| 22 | 133 | 3072 ms |

Exactly 2^depth across 22 consecutive points.

## Fix

One token: `call_expr` refuses the reserved `as`, making the two alternatives disjoint at the head token so neither can re-consume the other's input.

```pest
call_expr = {
    !as_kw ~
    identifier ~ "(" ~ (arithmetic_expr ~ ("," ~ arithmetic_expr)*)? ~ ")"
}
```

Fuzz artifact: **18.8s to 2ms**. Failing nests are now linear from depth 8 out to 4096.

## Why a guard here, when #294 left-factored

The `(`-headed alternatives in #294 shared their *entire* interior, so parsing once and classifying afterwards was lossless. These two don't: `as_cast`'s second argument is a `type_ref`, `call_expr`'s is an `arithmetic_expr`. Left-factoring would be a surface regression — `as(x, (a: number))` parses today via `type_ref`'s `tuple_type`, which an expression-argument rule cannot accept — and it would move the `expected type_ref` diagnostic into lowering, losing the span at the type position. Same principle both times (make the choice decidable without re-parsing), different mechanism because the shared prefix differs.

## Behavior changes

- A malformed cast is now a syntax error pointing at the bad type (`expected type_ref`) rather than surfacing later as an unknown UDF.
- Names that merely start with `as` (`assert(x)`) still parse as calls, since `as_kw` requires a word boundary.
- `as` remains usable as a variable, relation, and type-alias name. Only the call-name position refuses it, which is the only position where the ambiguity exists. Fully reserving it would have to reserve `count`/`sum`/`min`/`max`/`match` too — names users legitimately want for columns — so that is deliberately out of scope.

## Tests

Three regression tests. The deep one nests an **unterminated** cast on purpose: pest never backtracks out of a successful alternative, so a well-formed nest takes `as_cast` at every level and cannot exercise the retry — a valid-nest test passes even on the unfixed grammar.

## Adjacent findings (not in this PR)

- `predicate`: `compare_expr` and `disjunction_group` are both `(`-headed and re-parse a shared interior. Quadratic, not exponential, and capped at ~0.33s by libFuzzer's default `max_len` of 4096, so it is under the 10s limit. Fixable by the same left-factoring used in #294.
- `main_grammar` orders `fact | rule`, so every rule re-parses its head. Measured 34% slower than `rule | fact` on a rule-heavy 53 KB file, and `comp_body_item` already orders `rule | fact`. One-token swap, pure performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)