### PR TITLE
feat(compiler): support shared Cargo target directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "flowlog-profiler",
  "proc-macro2",
  "quote",
+ "serde_json",
  "tempfile",
  "thiserror",
  "toml_edit",

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ $ flowlog-compiler <PROGRAM> [OPTIONS]
 - `-F, --fact-dir <DIR>` — default directory for relative `.input` filenames; the executable can override it at runtime.
 - `-o <PATH>` — output executable path; defaults to the program stem (`reach.dl` → `./reach`).
 - `-D, --output-dir <DIR>` — default directory for `.output` files; `-` prints tuples to stdout. The executable can override it at runtime.
+- `-B, --build-dir <DIR>` — keep the generated Rust project in this directory for subsequent builds.
+- `-T, --target-dir <DIR>` — share Cargo artifacts across build directories; overrides `CARGO_TARGET_DIR`. Relative paths start at the compiler's working directory.
 - `--mode <MODE>` — `batch` (default) or `inc`.
 - `--sip` — sideways information passing: filter later body atoms by earlier bindings to shrink joins (off by default).
 - `--str-intern` — intern string columns at load for faster joins and lower memory (off by default).

--- a/flowlog-compiler/Cargo.toml
+++ b/flowlog-compiler/Cargo.toml
@@ -15,6 +15,7 @@ clap = { workspace = true, features = ["derive"] }
 codespan-reporting.workspace = true
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
+serde_json.workspace = true
 thiserror.workspace = true
 toml_edit = { workspace = true }
 tracing.workspace = true

--- a/flowlog-compiler/src/build.rs
+++ b/flowlog-compiler/src/build.rs
@@ -1,17 +1,6 @@
-//! Pipeline stages behind [`Compiler::compile`].
-//!
-//! The compile pipeline has two halves:
-//!
-//! 1. **`emit_sources`** — run the generator over the program and write a
-//!    complete Cargo project (`main.rs`, `relation.rs`, `Cargo.toml`, etc.)
-//!    under [`CompileOptions::build_dir`]. No external tools are invoked.
-//! 2. **`build`** — shell out to `cargo build --release` in that directory,
-//!    copy the resulting binary to [`CompileOptions::executable_path`], and
-//!    remove the scratch crate unless the user named a build directory
-//!    (a named directory persists and doubles as a recompile cache).
-//!
-//! Both are `pub(crate)`; external callers use [`Compiler::compile`] which
-//! runs them in sequence.
+//! Source generation, Cargo invocation, and executable installation.
+//! Cargo messages provide artifact paths; project cleanup handles scratch
+//! directories separately from reusable Cargo artifacts.
 
 use std::env;
 use std::fs;
@@ -32,11 +21,7 @@ use crate::relation;
 use crate::scaffold;
 
 impl Compiler {
-    /// Produce the scaffolded Rust crate in [`CompileOptions::build_dir`].
-    ///
-    /// Runs all code-generation passes (dataflow graph, relation handlers,
-    /// output drain, imports) and writes the resulting source files to disk.
-    /// Pure codegen — cargo is not invoked here.
+    /// Writes the generated Cargo project without invoking Cargo.
     pub(crate) fn emit_sources(
         &mut self,
         program_planner: &ProgramPlanner,
@@ -45,7 +30,6 @@ impl Compiler {
         let parts = self.codegen.generate(program_planner, plan_graph)?;
         let features = self.codegen.features();
 
-        // `src/relation.rs` — Relation trait + per-EDB `Rel{name}` input handlers.
         let relation_body = relation::gen_relation(
             &self.program,
             features,
@@ -61,7 +45,6 @@ impl Compiler {
         let bin_imports = imports::gen_imports(&self.config, features);
         let main_rs = self.assemble(&parts, &bin_imports)?;
 
-        // Cargo project metadata.
         let cargo_toml = scaffold::render_cargo_toml(
             &self.options.crate_name(),
             &self.config,
@@ -75,23 +58,34 @@ impl Compiler {
         Ok(())
     }
 
-    /// Compile the emitted crate with `cargo build --release`, install the
-    /// binary at [`CompileOptions::executable_path`], and remove the crate
-    /// directory unless [`CompileOptions::keeps_build_dir`] holds.
+    /// Builds and installs the generated executable. Scratch projects are
+    /// removed only after installation succeeds.
     pub(crate) fn build(&self) -> io::Result<()> {
         let build_dir = self.options.build_dir();
         let crate_name = self.options.crate_name();
         let executable_path = self.options.executable_path();
 
-        run_cargo(&build_dir, &["build", "--release"])?;
-
-        // Cargo produces the binary under the sanitized crate name; copy it
-        // to the user's requested path (appending `.exe` on Windows if the
-        // user omitted it).
-        let built = build_dir
-            .join("target")
-            .join("release")
-            .join(format!("{crate_name}{}", env::consts::EXE_SUFFIX));
+        // Cargo settings can change both the artifact directory and platform
+        // layout. Reading its JSON costs a parser dependency but avoids
+        // duplicating those rules when locating the executable.
+        let messages = run_cargo(
+            &build_dir,
+            self.options.target_dir(),
+            &[
+                "build",
+                "--release",
+                "--message-format=json-render-diagnostics",
+            ],
+        )?;
+        let built = find_executable(&messages, &crate_name).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "cargo build in '{}' succeeded but reported no executable for '{crate_name}'",
+                    build_dir.display()
+                ),
+            )
+        })?;
         let dest = exe_with_platform_suffix(executable_path);
         install_binary(&built, &dest)?;
         info!("Executable written to '{}'", dest.display());
@@ -101,17 +95,16 @@ impl Compiler {
         Ok(())
     }
 
-    /// Type-check the emitted crate with `cargo check`.
+    /// Type-checks the generated project without producing an executable.
     pub(crate) fn check(&self) -> io::Result<()> {
         let build_dir = self.options.build_dir();
-        run_cargo(&build_dir, &["check"])?;
+        run_cargo(&build_dir, self.options.target_dir(), &["check"])?;
         self.cleanup_build_dir(&build_dir)?;
         Ok(())
     }
 
-    /// Remove the crate directory unless [`CompileOptions::keeps_build_dir`]
-    /// holds; a kept directory persists as the recompile cache (see
-    /// [`CompileOptions::build_dir`]).
+    /// Removes the generated project unless
+    /// [`crate::CompileOptions::keeps_build_dir`] holds.
     fn cleanup_build_dir(&self, build_dir: &Path) -> io::Result<()> {
         if !self.options.keeps_build_dir() {
             fs::remove_dir_all(build_dir).map_err(|e| {
@@ -128,23 +121,52 @@ impl Compiler {
     }
 }
 
-/// Invoke `cargo <args>` in `build_dir` and propagate any failure.
-///
-/// Surfaces a friendly "install Rust via rustup" hint if `cargo` isn't on
-/// `PATH`, and otherwise forwards cargo's stderr so users can see the
-/// underlying compiler error.
-fn run_cargo(build_dir: &Path, args: &[&str]) -> io::Result<()> {
-    let output = process::Command::new("cargo")
-        .args(args)
-        .current_dir(build_dir)
-        .output()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => io::Error::new(
-                io::ErrorKind::NotFound,
-                "cargo not found — install Rust via https://rustup.rs",
-            ),
-            kind => io::Error::new(kind, format!("failed to run cargo: {e}")),
+/// Finds the named binary in Cargo artifact messages, including cached
+/// builds. Ignores non-JSON stdout from procedural macros.
+fn find_executable(messages: &[u8], crate_name: &str) -> Option<PathBuf> {
+    for line in messages.split(|byte| *byte == b'\n') {
+        let Ok(message) = serde_json::from_slice::<serde_json::Value>(line) else {
+            continue;
+        };
+        if message["reason"] == "compiler-artifact"
+            && message["target"]["name"] == crate_name
+            && message["target"]["kind"]
+                .as_array()
+                .is_some_and(|kinds| kinds.iter().any(|kind| kind == "bin"))
+            && let Some(path) = message["executable"].as_str()
+        {
+            return Some(PathBuf::from(path));
+        }
+    }
+    None
+}
+
+/// Runs Cargo in the generated project and returns its stdout on success.
+/// Target paths follow [`crate::CompileOptions::target_dir`]. Cargo failures
+/// include its stderr.
+fn run_cargo(build_dir: &Path, target_dir: Option<&Path>, args: &[&str]) -> io::Result<Vec<u8>> {
+    let mut command = process::Command::new("cargo");
+    command.args(args).current_dir(build_dir);
+    if let Some(dir) = target_dir {
+        // Resolve before Cargo changes directory so -T follows other CLI paths.
+        let absolute = std::path::absolute(dir).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!(
+                    "failed to resolve Cargo target directory '{}': {error}",
+                    dir.display()
+                ),
+            )
         })?;
+        command.arg("--target-dir").arg(absolute);
+    }
+    let output = command.output().map_err(|e| match e.kind() {
+        io::ErrorKind::NotFound => io::Error::new(
+            io::ErrorKind::NotFound,
+            "cargo not found; install Rust via https://rustup.rs",
+        ),
+        kind => io::Error::new(kind, format!("failed to run cargo: {e}")),
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -154,19 +176,18 @@ fn run_cargo(build_dir: &Path, args: &[&str]) -> io::Result<()> {
             build_dir.display()
         )));
     }
-    Ok(())
+    Ok(output.stdout)
 }
 
-/// Copy a built binary into place and make it executable on Unix.
+/// Copies a built binary into place and makes it executable on Unix.
 fn install_binary(src: &Path, dest: &Path) -> io::Result<()> {
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)?;
     }
     fs::copy(src, dest)?;
 
-    // On Unix, `fs::copy` preserves the source's permission bits which may
-    // not include the executable flag if the cargo target dir was created
-    // with an unusual umask — set it explicitly.
+    // Copying preserves source permissions, which may lack executable bits
+    // under a restrictive umask.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -176,9 +197,7 @@ fn install_binary(src: &Path, dest: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Ensure the destination path carries the platform-specific executable
-/// extension (`.exe` on Windows). No-op on Unix or when the user already
-/// provided the suffix.
+/// Appends the host platform's executable suffix when it is absent.
 fn exe_with_platform_suffix(path: &Path) -> PathBuf {
     let suffix = env::consts::EXE_SUFFIX;
     if suffix.is_empty() {

--- a/flowlog-compiler/src/cli.rs
+++ b/flowlog-compiler/src/cli.rs
@@ -1,9 +1,5 @@
-//! Command-line interface for the FlowLog compiler binary.
-//!
-//! `Cli` is the clap front-end. It owns every CLI/driver concern (output
-//! paths, build directory, fact directory, `--save-temps`) and projects the
-//! pipeline-relevant subset onto a shared [`flowlog_common::Config`] via
-//! [`Cli::to_config`].
+//! Command-line parsing and conversion into pipeline [`Config`] and build
+//! [`CompileOptions`].
 
 use clap::Parser;
 use flowlog_common::Config;
@@ -65,13 +61,16 @@ pub struct Cli {
     #[arg(long, value_name = "PATH")]
     pub udf_file: Option<String>,
 
-    /// Build the generated Rust crate in DIR and keep it afterwards.
-    /// Reusing the same DIR skips dependency rebuilds, reuses incremental
-    /// artifacts across recompiles, and leaves the generated sources
-    /// readable. Without it, the crate is built in a hidden scratch
-    /// directory that is removed after a successful build.
+    /// Keep the generated Rust project in DIR after compilation.
+    /// Without this option, a hidden scratch project is removed on success.
     #[arg(short = 'B', long, value_name = "DIR")]
     pub build_dir: Option<String>,
+
+    /// Store Cargo artifacts in DIR, shared across generated projects.
+    /// Relative paths start at the compiler's working directory. Overrides
+    /// CARGO_TARGET_DIR; when omitted, Cargo uses its environment and config.
+    #[arg(short = 'T', long, value_name = "DIR")]
+    pub target_dir: Option<String>,
 
     /// Type-check the generated crate with `cargo check` instead of building
     /// an executable. Faster; conflicts with `-o`.
@@ -102,7 +101,7 @@ impl Cli {
         }
     }
 
-    /// Project the CLI onto the compiler options.
+    /// Extracts build settings and applies the default executable path.
     pub fn to_compile_options(&self) -> CompileOptions {
         CompileOptions::new(
             &self.program,
@@ -110,6 +109,7 @@ impl Cli {
             self.output_dir.clone(),
             self.fact_dir.clone(),
             self.build_dir.clone(),
+            self.target_dir.clone(),
             self.check,
         )
     }

--- a/flowlog-compiler/src/options.rs
+++ b/flowlog-compiler/src/options.rs
@@ -8,31 +8,26 @@ use flowlog_common::program_stem;
 /// Compile options, independent of how they were parsed.
 #[derive(Debug, Clone)]
 pub struct CompileOptions {
-    /// Resolved path for the generated executable (CLI default already applied).
     executable_path: PathBuf,
-    /// Directory for writing output relations, if any.
+    /// Directory for writing output relations.
     output_dir: Option<String>,
-    /// Directory containing input fact files, if any.
+    /// Directory containing input fact files.
     fact_dir: Option<String>,
-    /// User-named build directory for the generated crate. Naming one opts
-    /// into persistence: the directory survives the build and doubles as a
-    /// recompile cache (an unchanged program rebuilds as a cargo no-op, an
-    /// edited one incrementally). `None` builds in a hidden scratch
-    /// directory that is removed after a successful build.
     build_dir: Option<PathBuf>,
+    target_dir: Option<PathBuf>,
     /// Type-check the emitted crate with `cargo check`.
     check_only: bool,
 }
 
 impl CompileOptions {
-    /// Build options for `program`. `executable_path` is the user's `-o`
-    /// override; when absent it defaults to the program's file stem.
+    /// Uses the program's file stem when `executable_path` is absent.
     pub fn new(
         program: &str,
         executable_path: Option<String>,
         output_dir: Option<String>,
         fact_dir: Option<String>,
         build_dir: Option<String>,
+        target_dir: Option<String>,
         check_only: bool,
     ) -> Self {
         let executable_path = executable_path
@@ -43,6 +38,7 @@ impl CompileOptions {
             output_dir,
             fact_dir,
             build_dir: build_dir.map(PathBuf::from),
+            target_dir: target_dir.map(PathBuf::from),
             check_only,
         }
     }
@@ -58,10 +54,8 @@ impl CompileOptions {
             .unwrap_or("out")
     }
 
-    /// Build directory for the generated Rust crate: the user-named one
-    /// when given, otherwise a scratch sibling of the executable. The
-    /// scratch default uses a hidden dotfile name so it won't collide
-    /// with the final executable or any user files.
+    /// Returns the named project directory, or a hidden scratch directory
+    /// beside the executable. See [`Self::keeps_build_dir`] for retention.
     pub fn build_dir(&self) -> PathBuf {
         self.build_dir.clone().unwrap_or_else(|| {
             self.executable_path
@@ -73,6 +67,12 @@ impl CompileOptions {
     /// persists after the build.
     pub fn keeps_build_dir(&self) -> bool {
         self.build_dir.is_some()
+    }
+
+    /// Relative paths start at the compiler's working directory. `None`
+    /// leaves directory selection to Cargo's environment and configuration.
+    pub fn target_dir(&self) -> Option<&Path> {
+        self.target_dir.as_deref()
     }
 
     /// Sanitized name suitable for use as a Cargo package/binary name.
@@ -117,32 +117,32 @@ impl CompileOptions {
 mod tests {
     use super::*;
 
-    fn options(executable: Option<&str>, build_dir: Option<&str>) -> CompileOptions {
-        CompileOptions::new(
-            "analysis.dl",
-            executable.map(String::from),
-            None,
-            None,
-            build_dir.map(String::from),
-            false,
-        )
-    }
-
-    /// Scratch builds must not collide with the executable or user files,
-    /// so the default is a hidden dot-directory beside the binary, and it
-    /// is not kept.
     #[test]
     fn build_dir_defaults_to_hidden_sibling_of_executable() {
-        let opts = options(Some("out/bin"), None);
+        let opts = CompileOptions::new(
+            "analysis.dl",
+            Some("out/bin".into()),
+            None,
+            None,
+            None,
+            None,
+            false,
+        );
         assert_eq!(opts.build_dir(), PathBuf::from("out/.bin.build"));
         assert!(!opts.keeps_build_dir());
     }
 
-    /// Naming a directory replaces the scratch default and opts into
-    /// keeping it.
     #[test]
     fn named_build_dir_wins_and_is_kept() {
-        let opts = options(Some("out/bin"), Some("cache/dir"));
+        let opts = CompileOptions::new(
+            "analysis.dl",
+            Some("out/bin".into()),
+            None,
+            None,
+            Some("cache/dir".into()),
+            None,
+            false,
+        );
         assert_eq!(opts.build_dir(), PathBuf::from("cache/dir"));
         assert!(opts.keeps_build_dir());
     }


### PR DESCRIPTION
Setting `CARGO_TARGET_DIR` or Cargo's `build.target-dir` moves build artifacts, but FlowLog still looks for the executable under `<build-dir>/target/release`. This makes installation fail and prevents sharing a Cargo cache across separate generated projects.

Add `-T / --target-dir` to select a shared artifact directory while `-B` selects the generated Rust project directory. Explicit `-T` paths are relative to the compiler's working directory and override Cargo's environment and configuration. The option applies to both builds and `--check`.

Read the executable path from Cargo's JSON artifact messages to handle custom directories, cached builds, and target-platform subdirectories. Cargo still renders Rust diagnostics for users; missing executable information produces an error naming the project and binary.

```bash
flowlog-compiler analysis.dl -B run-a/build -T /shared/cargo-target -o run-a/analysis
flowlog-compiler analysis.dl -B run-b/build -T /shared/cargo-target -o run-b/analysis
```