### PR TITLE
refactor(runtime): move relation declarations to shared I/O

### DIFF
--- a/docs/design/ingest-pipeline.md
+++ b/docs/design/ingest-pipeline.md
@@ -42,15 +42,17 @@ relation's arity; it does not receive the relation declaration.
 
 ## Where each piece lives
 
+Paths below are relative to `flowlog-runtime/src/io/`.
+
 | file            | holds                                                          |
 |-----------------|----------------------------------------------------------------|
 | `relation.rs`   | `Relation` (`NAME`, `ARITY`, `Tuple`, `facts`) |
-| `loader.rs`     | `Loader<R, T, D>`: worker settings, loading sources, and managing the session |
-| `reader/put.rs` | The single-text-row reader |
-| `reader.rs`     | `Reader<T>`: the shared row-reading contract, and the `ingest` loop |
-| `reader/`       | Source-specific readers and their constructors |
-| `decode.rs`     | `Decode<Src>`: the shared row-decoding contract |
-| `decode/`       | Text and typed implementations, with `DecodeCell` and `DecodeField` |
+| `input/loader.rs`     | `Loader<R, T, D>`: worker settings, loading sources, and managing the session |
+| `input/reader.rs`     | `Reader<T>`: the shared row-reading contract, and the `ingest` loop |
+| `input/reader/put.rs` | The single-text-row reader |
+| `input/reader/`       | Source-specific readers and their constructors |
+| `input/decode.rs`     | `Decode<Src>`: the shared row-decoding contract |
+| `input/decode/`       | Text and typed implementations, with `DecodeCell` and `DecodeField` |
 
 Two facts the rustdoc cannot carry on any one item:
 
@@ -58,8 +60,9 @@ Two facts the rustdoc cannot carry on any one item:
   `load_put`), not on `Relation`. A host program's relation never proves it
   can parse a line. Every decoder is an impl that already exists in the
   runtime, selected by the pair of slot tuple and record type; no relation
-  generates one, and a mispaired one does not compile. Only `Relation` and
-  `Loader` are exposed from `io::input`; readers and decoding are internal.
+  generates one, and a mispaired one does not compile. `Relation` is exposed
+  from `io`; `io::input` exposes only `Loader`. Readers and decoding are
+  internal.
 - Readers yield finished tuples rather than records because a lending
   `Record<'_>` would need a generic associated type; decode running inside
   `next` is that constraint, not a preference.
@@ -79,7 +82,7 @@ Both generators share the relation declarations and loader container:
 
 ```rust
 pub struct RelEdge;
-impl ::flowlog_runtime::io::input::Relation for RelEdge {
+impl ::flowlog_runtime::io::Relation for RelEdge {
     const NAME: &'static str = "Edge";
     const ARITY: usize = 2;
     type Tuple = (i32, Spur);

--- a/flowlog-build/src/codegen/relation.rs
+++ b/flowlog-build/src/codegen/relation.rs
@@ -63,7 +63,7 @@ pub fn gen_relations(program: &Program, string_intern: bool) -> Result<TokenStre
             #[allow(non_camel_case_types)]
             pub(crate) struct #marker;
 
-            impl ::flowlog_runtime::io::input::Relation for #marker {
+            impl ::flowlog_runtime::io::Relation for #marker {
                 const NAME: &'static str = #name;
                 const ARITY: usize = #arity;
                 type Tuple = #tuple;

--- a/flowlog-runtime/src/io.rs
+++ b/flowlog-runtime/src/io.rs
@@ -1,15 +1,18 @@
-//! Atomic file writing for generated engine output.
+//! Relation declarations, input loading, and atomic file writing.
 //!
-//! [`input`] owns relation loading; [`write_atomic`] replaces completed
-//! output files without exposing a partial write.
+//! [`Relation`] declares relations independently of their I/O. [`input`]
+//! owns loading; [`write_atomic`] replaces completed output files without
+//! exposing a partial write.
 
 pub mod input;
+mod relation;
 
 use std::io;
 use std::io::BufWriter;
 use std::io::Write;
 use std::path::Path;
 
+pub use relation::Relation;
 use tempfile::NamedTempFile;
 
 // =========================================================================

--- a/flowlog-runtime/src/io/input/loader.rs
+++ b/flowlog-runtime/src/io/input/loader.rs
@@ -12,6 +12,7 @@ use differential_dataflow::input::InputSession;
 use timely::progress::Timestamp;
 
 use crate::error::RuntimeError;
+use crate::io::Relation;
 use crate::io::input::decode::Decode;
 use crate::io::input::decode::text::TextRow;
 use crate::io::input::reader::Reader;
@@ -19,7 +20,6 @@ use crate::io::input::reader::file::FileReader;
 use crate::io::input::reader::host::HostReader;
 use crate::io::input::reader::ingest;
 use crate::io::input::reader::put::PutReader;
-use crate::io::input::relation::Relation;
 
 // =============================================================================
 // Loader

--- a/flowlog-runtime/src/io/input/mod.rs
+++ b/flowlog-runtime/src/io/input/mod.rs
@@ -1,6 +1,5 @@
 //! Reading a relation's rows into the engine.
 //!
-//! [`Relation`] declares the tuple type, metadata, and inline facts.
 //! [`Loader`] owns the session, applies update weights, and manages progress.
 //! Internally, `reader` selects each worker's share of a source and yields
 //! decoded rows. `decode` parses text cells or converts typed host fields
@@ -9,7 +8,5 @@
 pub(crate) mod decode;
 pub(crate) mod loader;
 pub(crate) mod reader;
-pub(crate) mod relation;
 
 pub use loader::Loader;
-pub use relation::Relation;

--- a/flowlog-runtime/src/io/relation.rs
+++ b/flowlog-runtime/src/io/relation.rs
@@ -1,17 +1,13 @@
-//! Relation declarations for runtime input loading.
+//! Relation declarations for runtime I/O.
 //!
-//! [`Relation`] supplies the declaration shared across input sources;
-//! [`Loader`](super::loader::Loader) owns the loading state.
+//! [`Relation`] supplies the name, tuple type, and inline facts independently
+//! of the state used to read or write rows.
 
 use std::iter;
 
 use differential_dataflow::Data;
 
-// =============================================================================
-// Relation
-// =============================================================================
-
-/// Declares one relation independently of its input sources.
+/// Declares one relation independently of how its rows are read or written.
 pub trait Relation {
     /// The name as the `.decl` spells it, for diagnostics.
     const NAME: &'static str;
@@ -19,7 +15,7 @@ pub trait Relation {
     /// The declared number of columns; zero denotes a nullary fact.
     const ARITY: usize;
 
-    /// The row representation stored in the dataflow, after input decoding.
+    /// The row representation stored in the dataflow.
     type Tuple: Data;
 
     /// The `.fact` rows written in the program itself, or none.


### PR DESCRIPTION
Relation declarations currently live under input loading, although the same declaration describes rows for both input and output. Move `Relation` to `flowlog_runtime::io` and update the loader, generated implementations, and ingest documentation to use that shared entry point.

`io::input` now exposes only `Loader`; callers implementing `io::input::Relation` must switch to `io::Relation`. The trait members and inline-fact behavior are unchanged.